### PR TITLE
Change stats to follow name guidelines

### DIFF
--- a/collector/native_collector.go
+++ b/collector/native_collector.go
@@ -35,16 +35,16 @@ var (
 	// Docs from https://www.kernel.org/doc/Documentation/iostats.txt
 	diskStatsMetrics = []diskStat{
 		{"reads_completed", prometheus.NewCounter(), "The total number of reads completed successfully."},
-		{"reads_merged", prometheus.NewCounter(), "The number of reads merged. Reads and writes which are adjacent to each other may be merged for efficiency. Thus two 4K reads may become one 8K read before it is ultimately handed to the disk, and so it will be counted (and queued) as only one I/O. This metric lets you know how often this was done."},
+		{"reads_merged", prometheus.NewCounter(), "The number of reads merged. See https://www.kernel.org/doc/Documentation/iostats.txt"},
 		{"sectors_read", prometheus.NewCounter(), "The total number of sectors read successfully."},
-		{"read_time_ms", prometheus.NewCounter(), "the total number of milliseconds spent by all reads (as measured from __make_request() to end_that_request_last())."},
+		{"read_time_ms", prometheus.NewCounter(), "the total number of milliseconds spent by all reads."},
 		{"writes_completed", prometheus.NewCounter(), "The total number of writes completed successfully."},
-		{"writes_merged", prometheus.NewCounter(), "The number of writes merged. Reads and writes which are adjacent to each other may be merged for efficiency. Thus two 4K reads may become one 8K read before it is ultimately handed to the disk, and so it will be counted (and queued) as only one I/O. This metric lets you know how often this was done."},
+		{"writes_merged", prometheus.NewCounter(), "The number of writes merged. See https://www.kernel.org/doc/Documentation/iostats.txt"},
 		{"sectors_written", prometheus.NewCounter(), "The total number of sectors written successfully."},
-		{"write_time_ms", prometheus.NewCounter(), "This is the total number of milliseconds spent by all writes (as measured from __make_request() to end_that_request_last())."},
-		{"io_now", prometheus.NewGauge(), "The number of I/Os currently in progress. Incremented as requests are given to appropriate struct request_queue and decremented as they finish."},
-		{"io_time_ms", prometheus.NewCounter(), "Milliseconds spent doing I/Os. This metric increases so long as node_disk_io_now is nonzero."},
-		{"io_time_weighted", prometheus.NewCounter(), "The weighted # of milliseconds spent doing I/Os. This metric is incremented at each I/O start, I/O completion, I/O merge, or read of these stats by the number of I/Os in progress (node_disk_io_now) times the number of milliseconds spent doing I/O since the last update of this field.  This can provide an easy measure of both I/O completion time and the backlog that may be accumulating."},
+		{"write_time_ms", prometheus.NewCounter(), "This is the total number of milliseconds spent by all writes."},
+		{"io_now", prometheus.NewGauge(), "The number of I/Os currently in progress."},
+		{"io_time_ms", prometheus.NewCounter(), "Milliseconds spent doing I/Os."},
+		{"io_time_weighted", prometheus.NewCounter(), "The weighted # of milliseconds spent doing I/Os. See https://www.kernel.org/doc/Documentation/iostats.txt"},
 	}
 	lastSeen         = prometheus.NewGauge()
 	load1            = prometheus.NewGauge()


### PR DESCRIPTION
This is a big change to how node_exporter exports to support the guidelines and make it easier to use, and will likely break all current users.

Sample output: http://pastebin.com/jvPt9pUx

Diskstats: Split out metrics, keep 'device' label
Meminfo: Split out metrics, one each. Convert kB to bytes.
Netstats: Split out metrics, keep 'device' label.
Interrupts: Stays the same. Not perfect, but should be rarely used.
Loadavg: Make it clear it's the 1m loadavg
Last seen: Not clear this belongs in the node exporter, as it's more a user
  thing than a machine thing. Changed to absolute time rather than relative.

All stats now have appropriate counter/gauge type, and as useful docs as practical.
