### PR TITLE
Collect at every scrape, rather than at regular intervals.

### DIFF
--- a/collector/attributes.go
+++ b/collector/attributes.go
@@ -29,7 +29,7 @@ func NewAttributesCollector(config Config) (Collector, error) {
 	for l := range c.config.Attributes {
 		labelNames = append(labelNames, l)
 	}
-	gv := prometheus.NewGaugeVec(
+	attributes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Name:      "attributes",
@@ -37,17 +37,13 @@ func NewAttributesCollector(config Config) (Collector, error) {
 		},
 		labelNames,
 	)
-	collector, err := prometheus.RegisterOrGet(gv)
-	if err != nil {
-		return nil, err
-	}
-	attributes = collector.(*prometheus.GaugeVec)
 	return &c, nil
 }
 
-func (c *attributesCollector) Update() (updates int, err error) {
+func (c *attributesCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	glog.V(1).Info("Set node_attributes{%v}: 1", c.config.Attributes)
 	attributes.Reset()
 	attributes.With(c.config.Attributes).Set(1)
-	return updates, err
+	attributes.Collect(ch)
+	return err
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -1,6 +1,10 @@
 // Exporter is a prometheus exporter using multiple Factories to collect and export system metrics.
 package collector
 
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
 const Namespace = "node"
 
 var Factories = make(map[string]func(Config) (Collector, error))
@@ -8,7 +12,7 @@ var Factories = make(map[string]func(Config) (Collector, error))
 // Interface a collector has to implement.
 type Collector interface {
 	// Get new metrics and expose them via prometheus registry.
-	Update() (n int, err error)
+	Update(ch chan<- prometheus.Metric) (err error)
 }
 
 // TODO: Instead of periodically call Update, a Collector could be implemented

--- a/collector/lastlogin.go
+++ b/collector/lastlogin.go
@@ -39,21 +39,18 @@ func NewLastLoginCollector(config Config) (Collector, error) {
 	c := lastLoginCollector{
 		config: config,
 	}
-	if _, err := prometheus.RegisterOrGet(lastSeen); err != nil {
-		return nil, err
-	}
 	return &c, nil
 }
 
-func (c *lastLoginCollector) Update() (updates int, err error) {
+func (c *lastLoginCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	last, err := getLastLoginTime()
 	if err != nil {
-		return updates, fmt.Errorf("Couldn't get last seen: %s", err)
+		return fmt.Errorf("Couldn't get last seen: %s", err)
 	}
-	updates++
 	glog.V(1).Infof("Set node_last_login_time: %f", last)
 	lastSeen.Set(last)
-	return updates, err
+	lastSeen.Collect(ch)
+	return err
 }
 
 func getLastLoginTime() (float64, error) {

--- a/collector/loadavg.go
+++ b/collector/loadavg.go
@@ -38,23 +38,18 @@ func NewLoadavgCollector(config Config) (Collector, error) {
 	c := loadavgCollector{
 		config: config,
 	}
-
-	if _, err := prometheus.RegisterOrGet(load1); err != nil {
-		return nil, err
-	}
 	return &c, nil
 }
 
-func (c *loadavgCollector) Update() (updates int, err error) {
+func (c *loadavgCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	load, err := getLoad1()
 	if err != nil {
-		return updates, fmt.Errorf("Couldn't get load: %s", err)
+		return fmt.Errorf("Couldn't get load: %s", err)
 	}
-	updates++
 	glog.V(1).Infof("Set node_load: %f", load)
 	load1.Set(load)
-
-	return updates, err
+	load1.Collect(ch)
+	return err
 }
 
 func getLoad1() (float64, error) {

--- a/collector/time.go
+++ b/collector/time.go
@@ -32,16 +32,13 @@ func NewTimeCollector(config Config) (Collector, error) {
 		config: config,
 	}
 
-	if _, err := prometheus.RegisterOrGet(systemTime); err != nil {
-		return nil, err
-	}
 	return &c, nil
 }
 
-func (c *timeCollector) Update() (updates int, err error) {
-	updates++
+func (c *timeCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	now := time.Now()
 	glog.V(1).Infof("Set time: %f", now.Unix())
 	systemTime.Set(float64(now.Unix()))
-	return updates, err
+	systemTime.Collect(ch)
+	return err
 }


### PR DESCRIPTION
Switch to Update using the Collecter Collect interface, due to not knowing all
metricnames in all modules beforehand we can't use Describe and thus the full
Collecter interface.

Remove 'updates', it's meaning varies by module and doesn't seem to add much.
