### PR TITLE
fix go tarball download for OS X, use redirect from golang.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,30 @@ VERSION  := 0.7.1
 SRC      := $(wildcard *.go)
 TARGET   := node_exporter
 
-OS   := $(subst Darwin,darwin,$(subst Linux,linux,$(shell uname)))
-ARCH := $(subst x86_64,amd64,$(shell uname -m))
+OS         := $(subst Darwin,darwin,$(subst Linux,linux,$(shell uname)))
+ARCH       := $(subst x86_64,amd64,$(shell uname -m))
 
-GOOS   ?= $(OS)
-GOARCH ?= $(ARCH)
-GOPKG  := go1.4.1.$(OS)-$(ARCH).tar.gz
-GOROOT := $(CURDIR)/.deps/go
-GOPATH := $(CURDIR)/.deps/gopath
-GOCC   := $(GOROOT)/bin/go
-GOLIB  := $(GOROOT)/pkg/$(GOOS)_$(GOARCH)
-GO     := GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
+# The release engineers apparently need to key their binary artifacts to the
+# Mac OS X release family.
+MAC_OS_X_VERSION ?= 10.8
+
+GOOS       ?= $(OS)
+GOARCH     ?= $(ARCH)
+
+ifeq ($(GOOS),darwin)
+RELEASE_SUFFIX ?= -osx$(MAC_OS_X_VERSION)
+else
+RELEASE_SUFFIX ?=
+endif
+	
+GO_VERSION ?= 1.4.1
+GOURL      ?= http://golang.org/dl
+GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
+GOROOT     := $(CURDIR)/.deps/go
+GOPATH     := $(CURDIR)/.deps/gopath
+GOCC       := $(GOROOT)/bin/go
+GOLIB      := $(GOROOT)/pkg/$(GOOS)_$(GOARCH)
+GO         := GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
 
 SUFFIX  := $(GOOS)-$(GOARCH)
 BINARY  := $(TARGET)
@@ -24,7 +37,7 @@ default: $(BINARY)
 
 .deps/$(GOPKG):
 	mkdir -p .deps
-	curl -o .deps/$(GOPKG) https://storage.googleapis.com/golang/$(GOPKG)
+	curl -o .deps/$(GOPKG) -L $(GOURL)/$(GOPKG)
 
 $(GOCC): .deps/$(GOPKG)
 	tar -C .deps -xzf .deps/$(GOPKG)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ RELEASE_SUFFIX ?=
 endif
 	
 GO_VERSION ?= 1.4.1
-GOURL      ?= http://golang.org/dl
+GOURL      ?= https://golang.org/dl
 GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
 GOROOT     := $(CURDIR)/.deps/go
 GOPATH     := $(CURDIR)/.deps/gopath


### PR DESCRIPTION
The download link was missing the suffix for OS X. This is taken straight from prometheus' Makefile.
Also using the golang.org instead of directly taking it from the CDN seems cleaner.