### PR TITLE
Also ignore vda1 and friends

### DIFF
--- a/collector/diskstats.go
+++ b/collector/diskstats.go
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	ignoredDevices = flag.String("diskstatsIgnoredDevices", "^(ram|loop|(h|s|xv)d[a-z])\\d+$", "Regexp of devices to ignore for diskstats.")
+	ignoredDevices = flag.String("diskstatsIgnoredDevices", "^(ram|loop|(h|s|v|xv)d[a-z])\\d+$", "Regexp of devices to ignore for diskstats.")
 )
 
 type diskstatsCollector struct {


### PR DESCRIPTION
Whatever virtualization bigv.io use, it exposes block devices as /dev/vda{,1,2}. As we only care about stats for the whole block devices, and not partitions, add vd? partitions to ignore list.

I'm unsure whether we should also ignore /dev/fd? and /dev/sr?. There is a case that the latter might still be useful, but the former is really dubious. Thoughts?

@juliusv @brian-brazil 