### PR TITLE
Make collector-specific flags consistent with others.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ collectors.
 By default the build will include the native collectors that expose information
 from /proc.
 
-Which collectors are used is controlled by the `--enabledCollectors` flag.
+Which collectors are used is controlled by the `--collectors.enabled` flag.
 
 ### Enabled by default
 
@@ -31,7 +31,7 @@ meminfo | Exposes memory statistics from /proc/meminfo.
 netdev | Exposes network interface statistics from /proc/netstat, such as bytes transferred.
 netstat | Exposes network statistics from /proc/net/netstat. This is the same information as `netstat -s`.
 stat | Exposes various statistics from /proc/stat. This includes CPU usage, boot time, forks and interrupts.
-textfile | Exposes statistics read from local disk. The `--textfile.directory` flag must be set.
+textfile | Exposes statistics read from local disk. The `--collector.textfile.directory` flag must be set.
 time | Exposes the current system time.
 
 
@@ -55,9 +55,10 @@ to export static metrics, such as what role a machine has. The Pushgateway
 should be used for service-level metrics. The textfile module is for metrics
 that are tied to a machine.
 
-To use set the `--textfile.directory` flag on the Node exporter. The collector
-will parse all files in that directory matching the glob `*.prom` using the
-[text format](http://prometheus.io/docs/instrumenting/exposition_formats/).
+To use set the `--collector.textfile.directory` flag on the Node exporter. The
+collector will parse all files in that directory matching the glob `*.prom`
+using the [text
+format](http://prometheus.io/docs/instrumenting/exposition_formats/).
 
 To atomically push completion time for a cron job:
 ```

--- a/collector/diskstats.go
+++ b/collector/diskstats.go
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	ignoredDevices = flag.String("diskstatsIgnoredDevices", "^(ram|loop|fd|(h|s|v|xv)d[a-z])\\d+$", "Regexp of devices to ignore for diskstats.")
+	ignoredDevices = flag.String("collector.diskstats.ignored-devices", "^(ram|loop|fd|(h|s|v|xv)d[a-z])\\d+$", "Regexp of devices to ignore for diskstats.")
 )
 
 type diskstatsCollector struct {

--- a/collector/filesystem.go
+++ b/collector/filesystem.go
@@ -21,7 +21,7 @@ const (
 )
 
 var (
-	ignoredMountPoints = flag.String("filesystemIgnoredMountPoints", "^/(sys|proc|dev)($|/)", "Regexp of mount points to ignore for filesystem collector.")
+	ignoredMountPoints = flag.String("collector.filesystem.ignored-mount-points", "^/(sys|proc|dev)($|/)", "Regexp of mount points to ignore for filesystem collector.")
 )
 
 type filesystemCollector struct {

--- a/collector/ntp.go
+++ b/collector/ntp.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	ntpServer = flag.String("ntpServer", "", "NTP server to use for ntp collector.")
+	ntpServer = flag.String("collector.ntp.server", "", "NTP server to use for ntp collector.")
 )
 
 type ntpCollector struct {

--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	textFileDirectory = flag.String("textfile.directory", "", "Directory to read text files with metrics from.")
+	textFileDirectory = flag.String("collector.textfile.directory", "", "Directory to read text files with metrics from.")
 )
 
 type textFileCollector struct {


### PR DESCRIPTION
This puts all collector-specific flags into their own namespace under
"collector.<collector-name>", and moves from camel case to dashes, which
is the standard in Prometheus land now.