### PR TITLE
MAINT: use more detailed version in archive.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 VERSION  := 0.7.1
 
+NICE_GIT_VERSION	:= $(shell ./gitversion.sh)
+FULL_VERSION := $(VERSION)-$(NICE_GIT_VERSION)
+
 SRC      := $(wildcard *.go)
 TARGET   := node_exporter
 
@@ -30,7 +33,7 @@ GO         := GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
 
 SUFFIX  := $(GOOS)-$(GOARCH)
 BINARY  := $(TARGET)
-ARCHIVE := $(TARGET)-$(VERSION).$(SUFFIX).tar.gz
+ARCHIVE := $(TARGET)-$(FULL_VERSION).$(SUFFIX).tar.gz
 SELFLINK := $(GOPATH)/src/github.com/prometheus/node_exporter
 
 default: $(BINARY)
@@ -56,9 +59,11 @@ $(BINARY): $(GOCC) $(SRC) dependencies
 $(ARCHIVE): $(BINARY)
 	tar -czf $@ $<
 
+archive: $(ARCHIVE)
+
 release: REMOTE     ?= $(error "can't release, REMOTE not set")
 release: REMOTE_DIR ?= $(error "can't release, REMOTE_DIR not set")
-release: $(ARCHIVE)
+release: archive
 	scp $< $(REMOTE):$(REMOTE_DIR)/$(ARCHIVE)
 
 test: $(GOCC) dependencies

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ GO         := GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
 
 SUFFIX  := $(GOOS)-$(GOARCH)
 BINARY  := $(TARGET)
-ARCHIVE := $(TARGET)-$(FULL_VERSION).$(SUFFIX).tar.gz
+ARCHIVE := $(TARGET)-$(VERSION).$(SUFFIX).tar.gz
+FULLY_VERSIONED_ARCHIVE := $(TARGET)-$(FULL_VERSION).$(SUFFIX).tar.gz
 SELFLINK := $(GOPATH)/src/github.com/prometheus/node_exporter
 
 default: $(BINARY)
@@ -59,7 +60,11 @@ $(BINARY): $(GOCC) $(SRC) dependencies
 $(ARCHIVE): $(BINARY)
 	tar -czf $@ $<
 
+$(FULLY_VERSIONED_ARCHIVE): $(BINARY)
+	tar -czf $@ $<
+
 archive: $(ARCHIVE)
+versioned_archive: $(FULLY_VERSIONED_ARCHIVE)
 
 release: REMOTE     ?= $(error "can't release, REMOTE not set")
 release: REMOTE_DIR ?= $(error "can't release, REMOTE_DIR not set")

--- a/gitversion.sh
+++ b/gitversion.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
-_tag=`git describe`
-another_var=`expr index "$_tag" "-"`
-echo ${_tag:$another_var}
+
+# We strip the tag part of git describe and append it to the currently defined
+# version in the makefile
+DESCRIBE=`git describe`
+FROM_TAG_INDEX=`expr index "$DESCRIBE" "-"`
+echo ${DESCRIBE:$FROM_TAG_INDEX}

--- a/gitversion.sh
+++ b/gitversion.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+_tag=`git describe`
+another_var=`expr index "$_tag" "-"`
+echo ${_tag:$another_var}


### PR DESCRIPTION
This tiny PR implements the following:

* add an archive target to build an archive without uploading it anywhere.
* add more detailed version based on `git describe`