### PR TITLE
Document logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,6 @@
 
 VERSION  := 0.8.0
 TARGET   := node_exporter
+GOFLAGS  := -ldflags "-X main.Version $(VERSION)"
 
 include Makefile.COMMON

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ collectors.
     make
     ./node_exporter <flags>
 
+The node_exporter uses the [glog][glog] library for logging. With the default
+parameters, nothing will be logged. Use `-logtostderr` to enable logging to
+stderr and `--help` to see more options about logging.
+
+[glog]: https://godoc.org/github.com/golang/glog
+
 ## Running tests
 
     make test

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -22,6 +22,9 @@ import (
 const subsystem = "exporter"
 
 var (
+	// set at build time
+	Version = "0.0.0.dev"
+
 	configFile        = flag.String("config.file", "", "Path to config file.")
 	memProfile        = flag.String("debug.memprofile-file", "", "Write memory profile to this file upon receipt of SIGUSR1.")
 	listenAddress     = flag.String("web.listen-address", ":9100", "Address on which to expose metrics and web interface.")
@@ -137,6 +140,7 @@ func loadCollectors(file string) (map[string]collector.Collector, error) {
 
 func main() {
 	flag.Parse()
+
 	if *printCollectors {
 		fmt.Printf("Available collectors:\n")
 		for n, _ := range collector.Factories {
@@ -182,6 +186,8 @@ func main() {
 			</body>
 			</html>`))
 	})
+
+	glog.Infof("Starting node_exporter v%s at %s", Version, *listenAddress)
 	err = http.ListenAndServe(*listenAddress, nil)
 	if err != nil {
 		glog.Fatal(err)


### PR DESCRIPTION
The glog flag interface is neither intuitive nor consistent with the rest of our flags unfortunately. We also seem to use both the fmt and glog library for logging. What do people prefer?

@brian-brazil @discordianfish