### PR TITLE
Cut release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.9.0 / unreleased
+
+* [BUGFIX] Fix `/proc/net/dev` parsing.
+* [CLEANUP] Remove the `attributes` collector, use `textfile` instead.
+* [CLEANUP] Replace last uses of the configuration file with flags.
+* [IMPROVEMENT] Remove cgo dependency.
+* [IMPROVEMENT] Sort collector names when printing.
+* [FEATURE] IPVS stats collector.
+
+## 0.8.1 / 2015-05-17
+
+* [MAINTENANCE] Use the common Prometheus build infrastructure.
+* [MAINTENANCE] Update former Google Code imports.
+* [IMPROVEMENT] Log the version at startup.
+* [FEATURE] TCP stats collector
+
 ## 0.8.0 / 2015-03-09
 * [CLEANUP] Introduced semantic versioning and changelog. From now on,
   changes will be reported in this file.

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION  := 0.8.1
+VERSION  := 0.9.0
 TARGET   := node_exporter
 GOFLAGS  := -ldflags "-X main.Version $(VERSION)"
 


### PR DESCRIPTION
This release adds the IPVS collector and removes the deprecated
attributes collector.

@juliusv @discordianfish not sure if I'm doing this right?