### PR TITLE
Add support for stats from /proc/net/snmp as well.

### DIFF
--- a/collector/netstat_linux_test.go
+++ b/collector/netstat_linux_test.go
@@ -5,14 +5,16 @@ import (
 	"testing"
 )
 
+var fileName = "fixtures/netstat"
+
 func TestNetStats(t *testing.T) {
-	file, err := os.Open("fixtures/netstat")
+	file, err := os.Open(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer file.Close()
 
-	netStats, err := parseNetStats(file)
+	netStats, err := parseNetStats(file, fileName)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is the naive implementation for #59. I thought of a few other approaches, mainly looping over a list of files and doing the merge of maps in getStats(). Any other approach would be longer though and I'm not sure of its benefit given the limited and well defined set of inputs (/proc/net/netstat, /proc/net/snmp). I'm happy to hear other opinions if you think this can be refactored a bit more. @matthiasr 