### PR TITLE
Allows netdev devices to be ignored

### DIFF
--- a/collector/netdev_test.go
+++ b/collector/netdev_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"os"
+	"regexp"
 	"testing"
 )
 
@@ -12,7 +13,7 @@ func TestNetDevStats(t *testing.T) {
 	}
 	defer file.Close()
 
-	netStats, err := parseNetDevStats(file)
+	netStats, err := parseNetDevStats(file, regexp.MustCompile("^veth"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,5 +28,13 @@ func TestNetDevStats(t *testing.T) {
 
 	if want, got := "934", netStats["transmit"]["tun0"]["packets"]; want != got {
 		t.Errorf("want netstat tun0 packets %s, got %s", want, got)
+	}
+
+	if want, got := 6, len(netStats["transmit"]); want != got {
+		t.Errorf("want count of devices to be %d, got %d", want, got)
+	}
+
+	if _, ok := netStats["transmit"]["veth4B09XN"]; ok != false {
+		t.Error("want fixture interface veth4B09XN to not exist, but it does")
 	}
 }


### PR DESCRIPTION
At DigitalOcean we want to be able to ignore some network devices. We have machines that can have hundreds of virtual network devices from our guest virtual machines that get exposed on the host. This can explode the number of metrics we gather out of node_exporter. The metrics we really want from node_exporter are for the host machine, not the guests.

I followed similar naming guide as the filesystem exporter and diskstats. The default regexp provided to flags matches the "" (empty-string) device, so nobody should be affected by this change.

I pass the compiled `*regexp.Regexp` into the parser for easier testability.

It seems somebody brought up wanting this ability before:

https://github.com/prometheus/node_exporter/issues/60