### PR TITLE
Add Linux uname collector.

### DIFF
--- a/collector/uname_linux.go
+++ b/collector/uname_linux.go
@@ -1,0 +1,63 @@
+// +build !nouname
+
+package collector
+
+import (
+	"syscall"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var unameDesc = prometheus.NewDesc(
+	prometheus.BuildFQName(Namespace, "uname", "info"),
+	"Labeled system information as provided by the uname system call.",
+	[]string{
+		"sysname",
+		"release",
+		"version",
+		"machine",
+		"nodename",
+		"domainname",
+	},
+	nil,
+)
+
+type unameCollector struct{}
+
+func init() {
+	Factories["uname"] = newUnameCollector
+}
+
+// NewUnameCollector returns new unameCollector.
+func newUnameCollector() (Collector, error) {
+	return &unameCollector{}, nil
+}
+
+func intArrayToString(array [65]int8) string {
+	var str string
+	for _, a := range array {
+		if a == 0 {
+			break
+		}
+		str += string(a)
+	}
+	return str
+}
+
+func (c unameCollector) Update(ch chan<- prometheus.Metric) error {
+	var uname syscall.Utsname
+	if err := syscall.Uname(&uname); err != nil {
+		return err
+	}
+
+	labelValues := []string{
+		intArrayToString(uname.Sysname),
+		intArrayToString(uname.Release),
+		intArrayToString(uname.Version),
+		intArrayToString(uname.Machine),
+		intArrayToString(uname.Nodename),
+		intArrayToString(uname.Domainname),
+	}
+	ch <- prometheus.MustNewConstMetric(unameDesc, prometheus.GaugeValue, 1, labelValues...)
+	return nil
+}

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -28,7 +28,7 @@ var (
 	memProfile        = flag.String("debug.memprofile-file", "", "Write memory profile to this file upon receipt of SIGUSR1.")
 	listenAddress     = flag.String("web.listen-address", ":9100", "Address on which to expose metrics and web interface.")
 	metricsPath       = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
-	enabledCollectors = flag.String("collectors.enabled", "diskstats,filesystem,loadavg,meminfo,stat,textfile,time,netdev,netstat,sockstat,filefd", "Comma-separated list of collectors to use.")
+	enabledCollectors = flag.String("collectors.enabled", "diskstats,filefd,filesystem,loadavg,meminfo,netdev,netstat,sockstat,stat,textfile,time,uname", "Comma-separated list of collectors to use.")
 	printCollectors   = flag.Bool("collectors.print", false, "If true, print available collectors and exit.")
 	authUser          = flag.String("auth.user", "", "Username for basic auth.")
 	authPass          = flag.String("auth.pass", "", "Password for basic auth.")


### PR DESCRIPTION
This creates a single metric like:

```
node_uname_info{domainname="(none)",machine="x86_64",nodename="desktop",release="3.16.0-48-generic",sysname="Linux",version="#64~14.04.1-Ubuntu SMP Thu Aug 20 23:03:57 UTC 2015"} 1
```