### PR TITLE
Fixed sockstat test wording

### DIFF
--- a/collector/sockstat_linux_test.go
+++ b/collector/sockstat_linux_test.go
@@ -24,11 +24,11 @@ func TestSockStats(t *testing.T) {
 	}
 
 	if want, got := "4", sockStats["TCP"]["tw"]; want != got {
-		t.Errorf("want sockstat sockets used %s, got %s", want, got)
+		t.Errorf("want sockstat TCP tw %s, got %s", want, got)
 	}
 
 	if want, got := "17", sockStats["TCP"]["alloc"]; want != got {
-		t.Errorf("want sockstat sockets used %s, got %s", want, got)
+		t.Errorf("want sockstat TCP alloc %s, got %s", want, got)
 	}
 
 	// The test file has 1 for TCP mem, which is one page.  So we should get the
@@ -36,6 +36,6 @@ func TestSockStats(t *testing.T) {
 	// os here because this value can change from system to system.  The value is
 	// 4096 by default from linux 2.4 onward.
 	if want, got := strconv.Itoa(os.Getpagesize()), sockStats["TCP"]["mem_bytes"]; want != got {
-		t.Errorf("want sockstat sockets used %s, got %s", want, got)
+		t.Errorf("want sockstat TCP mem_bytes %s, got %s", want, got)
 	}
 }


### PR DESCRIPTION
Updated the sockstat test case wording to report what was actually tested, and not "sockets used" for all test cases.