### PR TITLE
filled authors

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,8 +10,24 @@ Maintainers of this repository:
 The following individuals have contributed code to this repository
 (listed in alphabetical order):
 
+* Alexey Palazhchenko <alexey.palazhchenko@gmail.com>
+* Alexis Letessier
+* Benjamin Staffin <benley@gmail.com>
 * Björn Rabenstein <beorn@soundcloud.com>
 * Brian Brazil <brian.brazil@boxever.com>
+* chosenken
+* Daniel Speichert <daniel@speichert.pro>
+* Eric Ripa
+* Fabian Reinartz <fabian@soundcloud.com>
+* Franklin Wise <franklin@krave.io>
+* Ian Hansen
+* Jari Takkala <jtakkala@gmail.com>
 * Johannes 'fish' Ziemke <github@freigeist.org>
+* Jonas Große Sundrup <cherti@letopolis.de>
 * Julius Volz <julius@soundcloud.com>
+* Matthias Rampke <matthias@rampke.de>
+* Siavash Safi <siavash.safi@gmail.com>
+* Stephen Shirley <kormat@gmail.com>
+* Steve Durrheimer <s.durrheimer@gmail.com>
 * Tobias Schmidt <ts@soundcloud.com>
+* Will Rouesnel <w.rouesnel@gmail.com>


### PR DESCRIPTION
filled the author's file with the contributors listed via GitHub.

Mailadresses are, if available, taken from the respective GitHub-profiles, otherwise from the git log. The latter case is marked with a line note.

for names without addresses no address could be found on github or in the git log.