### PR TITLE
Add flag to change the location of the procfs.

### DIFF
--- a/collector/diskstats_linux.go
+++ b/collector/diskstats_linux.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	procDiskStats = "/proc/diskstats"
 	diskSubsystem = "disk"
 )
 
@@ -147,6 +146,7 @@ func NewDiskstatsCollector() (Collector, error) {
 }
 
 func (c *diskstatsCollector) Update(ch chan<- prometheus.Metric) (err error) {
+	procDiskStats := procFilePath("diskstats")
 	diskStats, err := getDiskStats()
 	if err != nil {
 		return fmt.Errorf("couldn't get diskstats: %s", err)
@@ -184,7 +184,7 @@ func (c *diskstatsCollector) Update(ch chan<- prometheus.Metric) (err error) {
 }
 
 func getDiskStats() (map[string]map[int]string, error) {
-	file, err := os.Open(procDiskStats)
+	file, err := os.Open(procFilePath("diskstats"))
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func parseDiskStats(r io.Reader) (map[string]map[int]string, error) {
 	for scanner.Scan() {
 		parts := strings.Fields(string(scanner.Text()))
 		if len(parts) < 4 { // we strip major, minor and dev
-			return nil, fmt.Errorf("invalid line in %s: %s", procDiskStats, scanner.Text())
+			return nil, fmt.Errorf("invalid line in %s: %s", procFilePath("diskstats"), scanner.Text())
 		}
 		dev := parts[2]
 		diskStats[dev] = map[int]string{}

--- a/collector/filefd_linux.go
+++ b/collector/filefd_linux.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	procFileFDStat      = "/proc/sys/fs/file-nr"
 	fileFDStatSubsystem = "filefd"
 )
 
@@ -33,7 +32,7 @@ func NewFileFDStatCollector() (Collector, error) {
 }
 
 func (c *fileFDStatCollector) Update(ch chan<- prometheus.Metric) (err error) {
-	fileFDStat, err := getFileFDStats(procFileFDStat)
+	fileFDStat, err := getFileFDStats(procFilePath("sys/fs/file-nr"))
 	if err != nil {
 		return fmt.Errorf("couldn't get file-nr: %s", err)
 	}
@@ -44,7 +43,7 @@ func (c *fileFDStatCollector) Update(ch chan<- prometheus.Metric) (err error) {
 					Namespace: Namespace,
 					Subsystem: fileFDStatSubsystem,
 					Name:      name,
-					Help:      fmt.Sprintf("filefd %s from %s.", name, procFileFDStat),
+					Help:      fmt.Sprintf("File descriptor statistics: %s.", name),
 				},
 			)
 			v, err := strconv.ParseFloat(value, 64)

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	defIgnoredMountPoints = "^/(sys|proc|dev)($|/)"
-	procMounts            = "/proc/mounts"
 )
 
 var (
@@ -60,7 +59,7 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 }
 
 func mountPointDetails() ([]filesystemDetails, error) {
-	file, err := os.Open(procMounts)
+	file, err := os.Open(procFilePath("mounts"))
 	if err != nil {
 		return nil, err
 	}

--- a/collector/interrupts_linux.go
+++ b/collector/interrupts_linux.go
@@ -4,6 +4,7 @@ package collector
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,10 +12,6 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
-)
-
-const (
-	procInterrupts = "/proc/interrupts"
 )
 
 type interruptsCollector struct {
@@ -33,7 +30,7 @@ func NewInterruptsCollector() (Collector, error) {
 			prometheus.CounterOpts{
 				Namespace: Namespace,
 				Name:      "interrupts",
-				Help:      "Interrupt details from /proc/interrupts.",
+				Help:      "Interrupt details.",
 			},
 			[]string{"CPU", "type", "info", "devices"},
 		),
@@ -71,7 +68,7 @@ type interrupt struct {
 }
 
 func getInterrupts() (map[string]interrupt, error) {
-	file, err := os.Open(procInterrupts)
+	file, err := os.Open(procFilePath("interrupts"))
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +84,7 @@ func parseInterrupts(r io.Reader) (map[string]interrupt, error) {
 	)
 
 	if !scanner.Scan() {
-		return nil, fmt.Errorf("%s empty", procInterrupts)
+		return nil, errors.New("interrupts empty")
 	}
 	cpuNum := len(strings.Fields(string(scanner.Text()))) // one header per cpu
 

--- a/collector/ipvs.go
+++ b/collector/ipvs.go
@@ -3,16 +3,11 @@
 package collector
 
 import (
-	"flag"
 	"fmt"
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs"
-)
-
-var (
-	ipvsProcfsMountPoint = flag.String("collector.ipvs.procfs", procfs.DefaultMountPoint, "procfs mountpoint.")
 )
 
 type ipvsCollector struct {
@@ -46,7 +41,7 @@ func newIPVSCollector() (*ipvsCollector, error) {
 		subsystem = "ipvs"
 	)
 
-	c.fs, err = procfs.NewFS(*ipvsProcfsMountPoint)
+	c.fs, err = procfs.NewFS(*procPath)
 	if err != nil {
 		return nil, err
 	}

--- a/collector/ipvs_test.go
+++ b/collector/ipvs_test.go
@@ -107,7 +107,7 @@ var (
 )
 
 func TestIPVSCollector(t *testing.T) {
-	if err := flag.Set("collector.ipvs.procfs", "fixtures"); err != nil {
+	if err := flag.Set("collector.procfs", "fixtures"); err != nil {
 		t.Fatal(err)
 	}
 	collector, err := newIPVSCollector()
@@ -169,7 +169,7 @@ func (c miniCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func TestIPVSCollectorResponse(t *testing.T) {
-	if err := flag.Set("collector.ipvs.procfs", "fixtures"); err != nil {
+	if err := flag.Set("collector.procfs", "fixtures"); err != nil {
 		t.Fatal(err)
 	}
 	collector, err := NewIPVSCollector()

--- a/collector/loadavg_linux.go
+++ b/collector/loadavg_linux.go
@@ -12,10 +12,6 @@ import (
 	"github.com/prometheus/log"
 )
 
-const (
-	procLoad = "/proc/loadavg"
-)
-
 type loadavgCollector struct {
 	metric prometheus.Gauge
 }
@@ -48,7 +44,7 @@ func (c *loadavgCollector) Update(ch chan<- prometheus.Metric) (err error) {
 }
 
 func getLoad1() (float64, error) {
-	data, err := ioutil.ReadFile(procLoad)
+	data, err := ioutil.ReadFile(procFilePath("loadavg"))
 	if err != nil {
 		return 0, err
 	}

--- a/collector/meminfo_linux.go
+++ b/collector/meminfo_linux.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	procMemInfo      = "/proc/meminfo"
 	memInfoSubsystem = "memory"
 )
 
@@ -48,7 +47,7 @@ func (c *meminfoCollector) Update(ch chan<- prometheus.Metric) (err error) {
 				Namespace: Namespace,
 				Subsystem: memInfoSubsystem,
 				Name:      k,
-				Help:      k + " from /proc/meminfo.",
+				Help:      fmt.Sprintf("Memory information field %s.", k),
 			})
 		}
 		c.metrics[k].Set(v)
@@ -58,7 +57,7 @@ func (c *meminfoCollector) Update(ch chan<- prometheus.Metric) (err error) {
 }
 
 func getMemInfo() (map[string]float64, error) {
-	file, err := os.Open(procMemInfo)
+	file, err := os.Open(procFilePath("meminfo"))
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +85,7 @@ func parseMemInfo(r io.Reader) (map[string]float64, error) {
 		case 3: // has unit, we presume kB
 			fv *= 1024
 		default:
-			return nil, fmt.Errorf("Invalid line in %s: %s", procMemInfo, line)
+			return nil, fmt.Errorf("Invalid line in meminfo: %s", line)
 		}
 		key := parts[0][:len(parts[0])-1] // remove trailing : from key
 		// Active(anon) -> Active_anon

--- a/collector/netstat_linux.go
+++ b/collector/netstat_linux.go
@@ -14,8 +14,6 @@ import (
 )
 
 const (
-	procNetStat       = "/proc/net/netstat"
-	procSNMPStat      = "/proc/net/snmp"
 	netStatsSubsystem = "netstat"
 )
 
@@ -36,11 +34,11 @@ func NewNetStatCollector() (Collector, error) {
 }
 
 func (c *netStatCollector) Update(ch chan<- prometheus.Metric) (err error) {
-	netStats, err := getNetStats(procNetStat)
+	netStats, err := getNetStats(procFilePath("net/netstat"))
 	if err != nil {
 		return fmt.Errorf("couldn't get netstats: %s", err)
 	}
-	snmpStats, err := getNetStats(procSNMPStat)
+	snmpStats, err := getNetStats(procFilePath("net/snmp"))
 	if err != nil {
 		return fmt.Errorf("couldn't get SNMP stats: %s", err)
 	}
@@ -58,7 +56,7 @@ func (c *netStatCollector) Update(ch chan<- prometheus.Metric) (err error) {
 						Namespace: Namespace,
 						Subsystem: netStatsSubsystem,
 						Name:      key,
-						Help:      fmt.Sprintf("%s %s from /proc/net/{netstat,snmp}.", protocol, name),
+						Help:      fmt.Sprintf("Protocol %s statistic %s.", protocol, name),
 					},
 				)
 			}

--- a/collector/procpath.go
+++ b/collector/procpath.go
@@ -1,0 +1,17 @@
+package collector
+
+import (
+	"flag"
+	"path"
+
+	"github.com/prometheus/procfs"
+)
+
+var (
+	// The path of the proc filesystem.
+	procPath = flag.String("collector.procfs", procfs.DefaultMountPoint, "procfs mountpoint.")
+)
+
+func procFilePath(name string) string {
+	return path.Join(*procPath, name)
+}

--- a/collector/sockstat_linux.go
+++ b/collector/sockstat_linux.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	procSockStat      = "/proc/net/sockstat"
 	sockStatSubsystem = "sockstat"
 )
 
@@ -36,7 +35,7 @@ func NewSockStatCollector() (Collector, error) {
 }
 
 func (c *sockStatCollector) Update(ch chan<- prometheus.Metric) (err error) {
-	sockStats, err := getSockStats(procSockStat)
+	sockStats, err := getSockStats(procFilePath("net/sockstat"))
 	if err != nil {
 		return fmt.Errorf("couldn't get sockstats: %s", err)
 	}
@@ -49,7 +48,7 @@ func (c *sockStatCollector) Update(ch chan<- prometheus.Metric) (err error) {
 						Namespace: Namespace,
 						Subsystem: sockStatSubsystem,
 						Name:      key,
-						Help:      fmt.Sprintf("%s %s from /proc/net/sockstat.", protocol, name),
+						Help:      fmt.Sprintf("Number of %s sockets in state %s.", protocol, name),
 					},
 				)
 			}

--- a/collector/stat_linux.go
+++ b/collector/stat_linux.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	procStat = "/proc/stat"
-	userHz   = 100
+	userHz = 100
 )
 
 type statCollector struct {
@@ -75,9 +74,9 @@ func NewStatCollector() (Collector, error) {
 	}, nil
 }
 
-// Expose a variety of stats from /proc/stats.
+// Expose kernel and system statistics.
 func (c *statCollector) Update(ch chan<- prometheus.Metric) (err error) {
-	file, err := os.Open(procStat)
+	file, err := os.Open(procFilePath("stat"))
 	if err != nil {
 		return err
 	}

--- a/collector/tcpstat_linux.go
+++ b/collector/tcpstat_linux.go
@@ -13,11 +13,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const (
-	procTCPStat  = "/proc/net/tcp"
-	procTCP6Stat = "/proc/net/tcp6"
-)
-
 type TCPConnectionState int
 
 const (
@@ -58,14 +53,15 @@ func NewTCPStatCollector() (Collector, error) {
 }
 
 func (c *tcpStatCollector) Update(ch chan<- prometheus.Metric) (err error) {
-	tcpStats, err := getTCPStats(procTCPStat)
+	tcpStats, err := getTCPStats(procFilePath("net/tcp"))
 	if err != nil {
 		return fmt.Errorf("couldn't get tcpstats: %s", err)
 	}
 
 	// if enabled ipv6 system
-	if _, hasIPv6 := os.Stat(procTCP6Stat); hasIPv6 == nil {
-		tcp6Stats, err := getTCPStats(procTCP6Stat)
+	tcp6File := procFilePath("net/tcp6")
+	if _, hasIPv6 := os.Stat(tcp6File); hasIPv6 == nil {
+		tcp6Stats, err := getTCPStats(tcp6File)
 		if err != nil {
 			return fmt.Errorf("couldn't get tcp6stats: %s", err)
 		}


### PR DESCRIPTION
Remove all hardcoded references to `/proc`. For all collectors that do
not use `github.com/prometheus/procfs` yet, provide a wrapper to
generate the full paths.

Reformulate help strings, errors and comments to remove absolute
references to `/proc`.

This is a breaking change: the `-collector.ipvs.procfs` flag is removed
in favor of the general flag. Since it only affected that collector it
was only useful for development, so this should not cause many issues.