### PR TITLE
update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
+sudo: false
+
 language: go
+go:
+  - 1.4.3
+  - 1.5.1
+  - tip
+
+install:
+  - go get -d
 
 script:
- - make test
+  - go test -v ./...


### PR DESCRIPTION
* use new Travis infrastructure
* specify Go versions (1.4, 1.5, tip)
* don't use the Makefile, Travis installs Go for us and `go test` is all
  we need