### PR TITLE
Fixed minor compile time error

### DIFF
--- a/collector/filesystem_freebsd.go
+++ b/collector/filesystem_freebsd.go
@@ -17,7 +17,6 @@ package collector
 
 import (
 	"errors"
-	"regexp"
 	"unsafe"
 
 	"github.com/prometheus/log"


### PR DESCRIPTION

Good day.  I deleted a line -- that appears to allow this code to compile cleanly.

````
$ $ uname -a
FreeBSD prod.example.org 10.1-RELEASE FreeBSD 10.1-RELEASE #0 r274401: Tue Nov 11 21:02:49 UTC 2014     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/sys/GENERIC  amd64
$ gmake GO_VERSION=1.5
GOPATH=/usr/home/prodbin/gocode/src/github.com/prometheus/node_exporter/.build/gopath /usr/local/bin/go get -d
touch dependencies-stamp
GOPATH=/usr/home/prodbin/gocode/src/github.com/prometheus/node_exporter/.build/gopath /usr/local/bin/go build -ldflags "-X main.Version=0.11.0" -o node_exporter
# github.com/prometheus/node_exporter/collector
cc: warning: argument unused during compilation: '-pthread'
# github.com/prometheus/node_exporter/collector
/usr/home/prodbin/gocode/src/github.com/prometheus/node_exporter/.build/gopath/src/github.com/prometheus/node_exporter/collector/filesystem_freebsd.go:20: imported and not used: "regexp"
Makefile.COMMON:98: recipe for target 'node_exporter' failed
gmake: *** [node_exporter] Error 2
````