### PR TITLE
Fix uname collector for ppc64 architectures

### DIFF
--- a/collector/uname_linux.go
+++ b/collector/uname_linux.go
@@ -46,31 +46,19 @@ func newUnameCollector() (Collector, error) {
 	return &unameCollector{}, nil
 }
 
-func intArrayToString(array [65]int8) string {
-	var str string
-	for _, a := range array {
-		if a == 0 {
-			break
-		}
-		str += string(a)
-	}
-	return str
-}
-
 func (c unameCollector) Update(ch chan<- prometheus.Metric) error {
 	var uname syscall.Utsname
 	if err := syscall.Uname(&uname); err != nil {
 		return err
 	}
 
-	labelValues := []string{
-		intArrayToString(uname.Sysname),
-		intArrayToString(uname.Release),
-		intArrayToString(uname.Version),
-		intArrayToString(uname.Machine),
-		intArrayToString(uname.Nodename),
-		intArrayToString(uname.Domainname),
-	}
-	ch <- prometheus.MustNewConstMetric(unameDesc, prometheus.GaugeValue, 1, labelValues...)
+	ch <- prometheus.MustNewConstMetric(unameDesc, prometheus.GaugeValue, 1,
+		unameToString(uname.Sysname),
+		unameToString(uname.Release),
+		unameToString(uname.Version),
+		unameToString(uname.Machine),
+		unameToString(uname.Nodename),
+		unameToString(uname.Domainname),
+	)
 	return nil
 }

--- a/collector/uname_linux_int8.go
+++ b/collector/uname_linux_int8.go
@@ -1,0 +1,27 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !nouname,linux,386 !nouname,linux,amd64
+
+package collector
+
+func unameToString(input [65]int8) string {
+	var str string
+	for _, a := range input {
+		if a == 0 {
+			break
+		}
+		str += string(a)
+	}
+	return str
+}

--- a/collector/uname_linux_uint8.go
+++ b/collector/uname_linux_uint8.go
@@ -1,0 +1,27 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !nouname,linux,arm !nouname,linux,ppc64 !nouname,linux,ppc64le
+
+package collector
+
+func unameToString(input [65]uint8) string {
+	var str string
+	for _, a := range input {
+		if a == 0 {
+			break
+		}
+		str += string(a)
+	}
+	return str
+}


### PR DESCRIPTION
The syscall.Utsname struct under ppc64/ppc64le uses uint8 type instead
of int8.

I was able to cross-compile node_exporter for ppc64 that way. Not tested due to lack of hardware. `GOARCH=ppc64 make`.

@SuperQ @fabxc 