### PR TITLE
Make filesystem collector more robust.

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -17,7 +17,6 @@ package collector
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"strings"
 	"syscall"
@@ -54,8 +53,9 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 		buf := new(syscall.Statfs_t)
 		err := syscall.Statfs(mpd.mountPoint, buf)
 		if err != nil {
-			return nil, fmt.Errorf("Statfs on %s returned %s",
+			log.Debugf("Statfs on %s returned %s",
 				mpd.mountPoint, err)
+			continue
 		}
 
 		labelValues := []string{mpd.device, mpd.mountPoint, mpd.fsType}


### PR DESCRIPTION
Current behaviour throws away all stats on any Statfs error. In practice
this is not useful. This turns such errors into debug log messages -
though silently ignoring them seems even more valid to me.

(note this is a suggested partial fix for issue #81 )