### PR TITLE
Do not use flag before flag.Parse() was called

### DIFF
--- a/collector/ntp.go
+++ b/collector/ntp.go
@@ -35,7 +35,6 @@ type ntpCollector struct {
 }
 
 func init() {
-	ntp.Version = byte(*ntpProtocolVersion)
 	Factories["ntp"] = NewNtpCollector
 }
 
@@ -45,6 +44,7 @@ func NewNtpCollector() (Collector, error) {
 	if *ntpServer == "" {
 		return nil, fmt.Errorf("no NTP server specifies, see --ntpServer")
 	}
+	ntp.Version = byte(*ntpProtocolVersion)
 
 	return &ntpCollector{
 		drift: prometheus.NewGauge(prometheus.GaugeOpts{


### PR DESCRIPTION
@grobie @juliusv Hi! I've made a huge mistake in my previous PR #146 . Using flag in `init()` function of `ntp` collector definitely is not a good idea.