### PR TITLE
Add filesystem read-only metric.

### DIFF
--- a/collector/filesystem_bsd.go
+++ b/collector/filesystem_bsd.go
@@ -33,6 +33,7 @@ import "C"
 
 const (
 	defIgnoredMountPoints = "^/(dev)($|/)"
+	MNT_RDONLY            = 0x1
 )
 
 // Expose filesystem fullness.
@@ -55,6 +56,11 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 		device := C.GoString(&mnt[i].f_mntfromname[0])
 		fstype := C.GoString(&mnt[i].f_fstypename[0])
 
+		var ro float64
+		if mnt[i].f_flags & MNT_RDONLY {
+			ro = 1
+		}
+
 		labelValues := []string{device, mountpoint, fstype}
 		stats = append(stats, filesystemStats{
 			labelValues: labelValues,
@@ -63,6 +69,7 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 			avail:       float64(mnt[i].f_bavail) * float64(mnt[i].f_bsize),
 			files:       float64(mnt[i].f_files),
 			filesFree:   float64(mnt[i].f_ffree),
+			ro:          ro,
 		})
 	}
 	return stats, nil

--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -40,12 +40,12 @@ var (
 type filesystemCollector struct {
 	ignoredMountPointsPattern *regexp.Regexp
 	sizeDesc, freeDesc, availDesc,
-	filesDesc, filesFreeDesc *prometheus.Desc
+	filesDesc, filesFreeDesc, roDesc *prometheus.Desc
 }
 
 type filesystemStats struct {
-	labelValues                         []string
-	size, free, avail, files, filesFree float64
+	labelValues                             []string
+	size, free, avail, files, filesFree, ro float64
 }
 
 func init() {
@@ -88,6 +88,12 @@ func NewFilesystemCollector() (Collector, error) {
 		filesystemLabelNames, nil,
 	)
 
+	roDesc := prometheus.NewDesc(
+		prometheus.BuildFQName(Namespace, subsystem, "readonly"),
+		"Filesystem read-only status.",
+		filesystemLabelNames, nil,
+	)
+
 	return &filesystemCollector{
 		ignoredMountPointsPattern: pattern,
 		sizeDesc:                  sizeDesc,
@@ -95,6 +101,7 @@ func NewFilesystemCollector() (Collector, error) {
 		availDesc:                 availDesc,
 		filesDesc:                 filesDesc,
 		filesFreeDesc:             filesFreeDesc,
+		roDesc:                    roDesc,
 	}, nil
 }
 
@@ -123,6 +130,10 @@ func (c *filesystemCollector) Update(ch chan<- prometheus.Metric) (err error) {
 		ch <- prometheus.MustNewConstMetric(
 			c.filesFreeDesc, prometheus.GaugeValue,
 			s.filesFree, s.labelValues...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.roDesc, prometheus.GaugeValue,
+			s.ro, s.labelValues...,
 		)
 	}
 	return nil

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	defIgnoredMountPoints = "^/(sys|proc|dev)($|/)"
+	ST_RDONLY             = 0x1
 )
 
 type filesystemDetails struct {
@@ -54,6 +55,11 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 			continue
 		}
 
+		var ro float64
+		if buf.Flags & ST_RDONLY != 0 {
+			ro = 1
+		}
+
 		labelValues := []string{mpd.device, mpd.mountPoint, mpd.fsType}
 		stats = append(stats, filesystemStats{
 			labelValues: labelValues,
@@ -62,6 +68,7 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 			avail:       float64(buf.Bavail) * float64(buf.Bsize),
 			files:       float64(buf.Files),
 			filesFree:   float64(buf.Ffree),
+			ro:          ro,
 		})
 	}
 	return stats, nil


### PR DESCRIPTION
Adds a metric for indicating filesystem read-only status.

node_filesystem_readonly_bool is 1 when the filesystem is read-only, 0 when it is read-write.

Closes #147 

Implemented but not tested for BSD as well.