### PR TITLE
Fix compilation on OS X

### DIFF
--- a/collector/interrupts_common.go
+++ b/collector/interrupts_common.go
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 // +build !nointerrupts
+// +build !darwin
 
 package collector
 


### PR DESCRIPTION
As OS X doesn't have it's own interrupts provider, don't build
interrupts_common on OS X as well. Otherwise build fails, because
interrupts_common depends on variables provided by platform-specific
files.

Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>