### PR TITLE
fix (mdstat): resync=DELAYED if md arrays in checking and allocated on same physiclal units.

### DIFF
--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -426,6 +426,7 @@ node_md_blocks{device="md4"} 4.883648e+06
 node_md_blocks{device="md6"} 1.95310144e+08
 node_md_blocks{device="md7"} 7.813735424e+09
 node_md_blocks{device="md8"} 1.95310144e+08
+node_md_blocks{device="md9"} 523968
 # HELP node_md_blocks_synced Number of blocks synced on device.
 # TYPE node_md_blocks_synced gauge
 node_md_blocks_synced{device="md0"} 248896
@@ -435,6 +436,7 @@ node_md_blocks_synced{device="md4"} 4.883648e+06
 node_md_blocks_synced{device="md6"} 1.6775552e+07
 node_md_blocks_synced{device="md7"} 7.813735424e+09
 node_md_blocks_synced{device="md8"} 1.6775552e+07
+node_md_blocks_synced{device="md9"} 523968
 # HELP node_md_disks Total number of disks of device.
 # TYPE node_md_disks gauge
 node_md_disks{device="md0"} 2
@@ -444,6 +446,7 @@ node_md_disks{device="md4"} 2
 node_md_disks{device="md6"} 2
 node_md_disks{device="md7"} 4
 node_md_disks{device="md8"} 2
+node_md_disks{device="md9"} 4
 # HELP node_md_disks_active Number of active disks of device.
 # TYPE node_md_disks_active gauge
 node_md_disks_active{device="md0"} 2
@@ -453,6 +456,7 @@ node_md_disks_active{device="md4"} 2
 node_md_disks_active{device="md6"} 1
 node_md_disks_active{device="md7"} 3
 node_md_disks_active{device="md8"} 2
+node_md_disks_active{device="md9"} 4
 # HELP node_md_is_active Indicator whether the md-device is active or not.
 # TYPE node_md_is_active gauge
 node_md_is_active{device="md0"} 1
@@ -462,6 +466,7 @@ node_md_is_active{device="md4"} 0
 node_md_is_active{device="md6"} 1
 node_md_is_active{device="md7"} 1
 node_md_is_active{device="md8"} 1
+node_md_is_active{device="md9"} 1
 # HELP node_megacli_drive_count megacli: drive error and event counters
 # TYPE node_megacli_drive_count counter
 node_megacli_drive_count{enclosure="32",slot="0",type="Media Error Count"} 0

--- a/collector/fixtures/proc/mdstat
+++ b/collector/fixtures/proc/mdstat
@@ -23,4 +23,9 @@ md7 : active raid6 sdb1[0] sde1[3] sdd1[2] sdc1[1]
       7813735424 blocks super 1.2 level 6, 512k chunk, algorithm 2 [4/3] [U_UU]
       bitmap: 0/30 pages [0KB], 65536KB chunk
 
+md9 : active raid1 sdc2[2] sdd2[3] sdb2[1] sda2[0]
+      523968 blocks super 1.2 [4/4] [UUUU]
+            resync=DELAYED
+
+
 unused devices: <none>

--- a/collector/mdadm.go
+++ b/collector/mdadm.go
@@ -162,7 +162,7 @@ func parseMdstat(mdStatusFilePath string) ([]mdStatus, error) {
 
 		// If device is syncing at the moment, get the number of currently synced bytes,
 		// otherwise that number equals the size of the device.
-		if strings.Contains(lines[j], "recovery") || strings.Contains(lines[j], "resync") {
+		if strings.Contains(lines[j], "recovery") || strings.Contains(lines[j], "resync") && ! strings.Contains(lines[j], "resync=DELAYED") {
 			syncedBlocks, err = evalBuildline(lines[j])
 			if err != nil {
 				return mdStates, fmt.Errorf("error parsing mdstat: %s", err)

--- a/collector/mdadm_test.go
+++ b/collector/mdadm_test.go
@@ -32,6 +32,7 @@ func TestMdadm(t *testing.T) {
 		"md6":   mdStatus{"md6", true, 1, 2, 195310144, 16775552},
 		"md8":   mdStatus{"md8", true, 2, 2, 195310144, 16775552},
 		"md7":   mdStatus{"md7", true, 3, 4, 7813735424, 7813735424},
+		"md9":   mdStatus{"md9", true, 4, 4, 523968, 523968},
 	}
 
 	for _, md := range mdStates {

--- a/collector/ntp.go
+++ b/collector/ntp.go
@@ -45,7 +45,7 @@ func NewNtpCollector() (Collector, error) {
 		return nil, fmt.Errorf("no NTP server specifies, see --ntpServer")
 	}
 	if *ntpProtocolVersion < 2 || *ntpProtocolVersion > 4 {
-		return nil, fmt.Errorf("invalid NTP protocol version %d; must be 2, 3, or 4")
+		return nil, fmt.Errorf("invalid NTP protocol version %d; must be 2, 3, or 4", *ntpProtocolVersion)
 	}
 
 	return &ntpCollector{


### PR DESCRIPTION
mdstat collector fails on my RAID6 array I have few md arrays in checking state sitting on same physical units.