### PR TITLE
Expose version and other build information as metric similar to Prometheus itself

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,16 @@
 
 VERSION  := 0.12.0rc1
 TARGET   := node_exporter
-GOFLAGS  := -ldflags "-X main.Version=$(VERSION)"
+
+REVISION := $(shell git rev-parse --short HEAD 2> /dev/null || echo 'unknown')
+BRANCH   := $(shell git rev-parse --abbrev-ref HEAD 2> /dev/null || echo 'unknown')
+
+REPO_PATH := "github.com/prometheus/node_exporter"
+LDFLAGS   := -X main.Version=$(VERSION)
+LDFLAGS   += -X $(REPO_PATH)/collector.Version=$(VERSION)
+LDFLAGS   += -X $(REPO_PATH)/collector.Revision=$(REVISION)
+LDFLAGS   += -X $(REPO_PATH)/collector.Branch=$(BRANCH)
+
+GOFLAGS   := -ldflags "$(LDFLAGS)"
 
 include Makefile.COMMON

--- a/collector/version.go
+++ b/collector/version.go
@@ -1,0 +1,51 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	Version  string
+	Revision string
+	Branch   string
+)
+
+type versionCollector struct {
+	metric *prometheus.GaugeVec
+}
+
+func init() {
+	Factories["version"] = NewVersionCollector
+}
+
+func NewVersionCollector() (Collector, error) {
+	metric := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "node_exporter_build_info",
+			Help: "A metric with a constant '1' value labeled by version, revision, and branch from which the node_exporter was built.",
+		},
+		[]string{"version", "revision", "branch"},
+	)
+	metric.WithLabelValues(Version, Revision, Branch).Set(1)
+	return &versionCollector{
+		metric: metric,
+	}, nil
+}
+
+func (c *versionCollector) Update(ch chan<- prometheus.Metric) (err error) {
+	c.metric.Collect(ch)
+	return err
+}

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -42,7 +42,7 @@ var (
 	listenAddress     = flag.String("web.listen-address", ":9100", "Address on which to expose metrics and web interface.")
 	metricsPath       = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 	enabledCollectors = flag.String("collectors.enabled",
-		filterAvailableCollectors("conntrack,diskstats,filefd,filesystem,loadavg,mdadm,meminfo,netdev,netstat,sockstat,stat,textfile,time,uname"),
+		filterAvailableCollectors("conntrack,diskstats,filefd,filesystem,loadavg,mdadm,meminfo,netdev,netstat,sockstat,stat,textfile,time,uname,version"),
 		"Comma-separated list of collectors to use.")
 	printCollectors = flag.Bool("collectors.print", false, "If true, print available collectors and exit.")
 


### PR DESCRIPTION
When dealing with a larger number of servers, it's easy to lose track what version of the node_exporter is running on which machine. Especially because sometimes metrics or labels get renamed from version to version (e.g. filesystem => mountpoint), it's rather important to have a way to ensure all servers are running the expected version.

Currently the exporter doesn't provide a way to retrieve its version (except from the logs), so I added a new `/version` endpoint, which does simply return the version as plain text.

This would allow deployment scripts to verify that the running version actually matches the expected one and fail otherwise. It would also make it possible to get an overview over all the different node_exporter versions running on my servers and find out which one need to be upgraded.

What do you think?