### PR TITLE
Calculate Linux disk bytes read/written based on sector size

### DIFF
--- a/collector/diskstats_linux_test.go
+++ b/collector/diskstats_linux_test.go
@@ -37,4 +37,12 @@ func TestDiskStats(t *testing.T) {
 	if want, got := "68", diskStats["mmcblk0p2"][10]; want != got {
 		t.Errorf("want diskstats mmcblk0p2 %s, got %s", want, got)
 	}
+
+	if want, got := "513713216512", diskStats["sda"][11]; want != got {
+		t.Errorf("want diskstats sda read bytes %s, got %s", want, got)
+	}
+
+	if want, got := "258916880384", diskStats["sda"][12]; want != got {
+		t.Errorf("want diskstats sda write bytes %s, got %s", want, got)
+	}
 }

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -9,16 +9,16 @@ go_gc_duration_seconds_sum 0
 go_gc_duration_seconds_count 0
 # HELP go_goroutines Number of goroutines that currently exist.
 # TYPE go_goroutines gauge
-go_goroutines 23
+go_goroutines 13
 # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
 # TYPE go_memstats_alloc_bytes gauge
-go_memstats_alloc_bytes 1.4502e+06
+go_memstats_alloc_bytes 1.077136e+06
 # HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
 # TYPE go_memstats_alloc_bytes_total counter
-go_memstats_alloc_bytes_total 1.4502e+06
+go_memstats_alloc_bytes_total 1.077136e+06
 # HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
 # TYPE go_memstats_buck_hash_sys_bytes gauge
-go_memstats_buck_hash_sys_bytes 1.443627e+06
+go_memstats_buck_hash_sys_bytes 1.443406e+06
 # HELP go_memstats_frees_total Total number of frees.
 # TYPE go_memstats_frees_total counter
 go_memstats_frees_total 0
@@ -27,31 +27,31 @@ go_memstats_frees_total 0
 go_memstats_gc_sys_bytes 98304
 # HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
 # TYPE go_memstats_heap_alloc_bytes gauge
-go_memstats_heap_alloc_bytes 1.4502e+06
+go_memstats_heap_alloc_bytes 1.077136e+06
 # HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
 # TYPE go_memstats_heap_idle_bytes gauge
-go_memstats_heap_idle_bytes 172032
+go_memstats_heap_idle_bytes 737280
 # HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
 # TYPE go_memstats_heap_inuse_bytes gauge
-go_memstats_heap_inuse_bytes 2.351104e+06
+go_memstats_heap_inuse_bytes 1.916928e+06
 # HELP go_memstats_heap_objects Number of allocated objects.
 # TYPE go_memstats_heap_objects gauge
-go_memstats_heap_objects 5482
+go_memstats_heap_objects 4245
 # HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
 # TYPE go_memstats_heap_released_bytes_total counter
 go_memstats_heap_released_bytes_total 0
 # HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
 # TYPE go_memstats_heap_sys_bytes gauge
-go_memstats_heap_sys_bytes 2.523136e+06
+go_memstats_heap_sys_bytes 2.654208e+06
 # HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
 # TYPE go_memstats_last_gc_time_seconds gauge
 go_memstats_last_gc_time_seconds 9
 # HELP go_memstats_lookups_total Total number of pointer lookups.
 # TYPE go_memstats_lookups_total counter
-go_memstats_lookups_total 26
+go_memstats_lookups_total 16
 # HELP go_memstats_mallocs_total Total number of mallocs.
 # TYPE go_memstats_mallocs_total counter
-go_memstats_mallocs_total 5482
+go_memstats_mallocs_total 4245
 # HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
 # TYPE go_memstats_mcache_inuse_bytes gauge
 go_memstats_mcache_inuse_bytes 9664
@@ -60,7 +60,7 @@ go_memstats_mcache_inuse_bytes 9664
 go_memstats_mcache_sys_bytes 16384
 # HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
 # TYPE go_memstats_mspan_inuse_bytes gauge
-go_memstats_mspan_inuse_bytes 22400
+go_memstats_mspan_inuse_bytes 18144
 # HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
 # TYPE go_memstats_mspan_sys_bytes gauge
 go_memstats_mspan_sys_bytes 32768
@@ -69,13 +69,13 @@ go_memstats_mspan_sys_bytes 32768
 go_memstats_next_gc_bytes 4.194304e+06
 # HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
 # TYPE go_memstats_other_sys_bytes gauge
-go_memstats_other_sys_bytes 1.065421e+06
+go_memstats_other_sys_bytes 1.065642e+06
 # HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
 # TYPE go_memstats_stack_inuse_bytes gauge
-go_memstats_stack_inuse_bytes 622592
+go_memstats_stack_inuse_bytes 491520
 # HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
 # TYPE go_memstats_stack_sys_bytes gauge
-go_memstats_stack_sys_bytes 622592
+go_memstats_stack_sys_bytes 491520
 # HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
 # TYPE go_memstats_sys_bytes gauge
 go_memstats_sys_bytes 5.802232e+06
@@ -180,6 +180,34 @@ node_cpu{cpu="cpu7",mode="softirq"} 0.31
 node_cpu{cpu="cpu7",mode="steal"} 0
 node_cpu{cpu="cpu7",mode="system"} 101.64
 node_cpu{cpu="cpu7",mode="user"} 290.98
+# HELP node_disk_bytes_read The total number of bytes read successfully.
+# TYPE node_disk_bytes_read counter
+node_disk_bytes_read{device="dm-0"} 5.13708655616e+11
+node_disk_bytes_read{device="dm-1"} 1.589248e+06
+node_disk_bytes_read{device="dm-2"} 1.578752e+08
+node_disk_bytes_read{device="dm-3"} 1.98144e+06
+node_disk_bytes_read{device="dm-4"} 529408
+node_disk_bytes_read{device="dm-5"} 4.3150848e+07
+node_disk_bytes_read{device="mmcblk0"} 798720
+node_disk_bytes_read{device="mmcblk0p1"} 81920
+node_disk_bytes_read{device="mmcblk0p2"} 389120
+node_disk_bytes_read{device="sda"} 5.13713216512e+11
+node_disk_bytes_read{device="sr0"} 0
+node_disk_bytes_read{device="vda"} 1.6727491584e+10
+# HELP node_disk_bytes_written The total number of bytes written successfully.
+# TYPE node_disk_bytes_written counter
+node_disk_bytes_written{device="dm-0"} 2.5891680256e+11
+node_disk_bytes_written{device="dm-1"} 303104
+node_disk_bytes_written{device="dm-2"} 2.607828992e+09
+node_disk_bytes_written{device="dm-3"} 0
+node_disk_bytes_written{device="dm-4"} 70144
+node_disk_bytes_written{device="dm-5"} 5.89664256e+08
+node_disk_bytes_written{device="mmcblk0"} 0
+node_disk_bytes_written{device="mmcblk0p1"} 0
+node_disk_bytes_written{device="mmcblk0p2"} 0
+node_disk_bytes_written{device="sda"} 2.58916880384e+11
+node_disk_bytes_written{device="sr0"} 0
+node_disk_bytes_written{device="vda"} 1.0938236928e+11
 # HELP node_disk_io_now The number of I/Os currently in progress.
 # TYPE node_disk_io_now gauge
 node_disk_io_now{device="dm-0"} 0
@@ -336,65 +364,70 @@ node_disk_writes_merged{device="sr0"} 0
 node_disk_writes_merged{device="vda"} 2.0711856e+07
 # HELP node_exporter_scrape_duration_seconds node_exporter: Duration of a scrape job.
 # TYPE node_exporter_scrape_duration_seconds summary
-node_exporter_scrape_duration_seconds{collector="bonding",result="success",quantile="0.5"} 0.000887339
-node_exporter_scrape_duration_seconds{collector="bonding",result="success",quantile="0.9"} 0.000887339
-node_exporter_scrape_duration_seconds{collector="bonding",result="success",quantile="0.99"} 0.000887339
-node_exporter_scrape_duration_seconds_sum{collector="bonding",result="success"} 0.000887339
+node_exporter_scrape_duration_seconds{collector="bonding",result="success",quantile="0.5"} 7.481600000000001e-05
+node_exporter_scrape_duration_seconds{collector="bonding",result="success",quantile="0.9"} 7.481600000000001e-05
+node_exporter_scrape_duration_seconds{collector="bonding",result="success",quantile="0.99"} 7.481600000000001e-05
+node_exporter_scrape_duration_seconds_sum{collector="bonding",result="success"} 7.481600000000001e-05
 node_exporter_scrape_duration_seconds_count{collector="bonding",result="success"} 1
-node_exporter_scrape_duration_seconds{collector="diskstats",result="success",quantile="0.5"} 0.002223042
-node_exporter_scrape_duration_seconds{collector="diskstats",result="success",quantile="0.9"} 0.002223042
-node_exporter_scrape_duration_seconds{collector="diskstats",result="success",quantile="0.99"} 0.002223042
-node_exporter_scrape_duration_seconds_sum{collector="diskstats",result="success"} 0.002223042
+node_exporter_scrape_duration_seconds{collector="conntrack",result="success",quantile="0.5"} 0.00027974200000000003
+node_exporter_scrape_duration_seconds{collector="conntrack",result="success",quantile="0.9"} 0.00027974200000000003
+node_exporter_scrape_duration_seconds{collector="conntrack",result="success",quantile="0.99"} 0.00027974200000000003
+node_exporter_scrape_duration_seconds_sum{collector="conntrack",result="success"} 0.00027974200000000003
+node_exporter_scrape_duration_seconds_count{collector="conntrack",result="success"} 1
+node_exporter_scrape_duration_seconds{collector="diskstats",result="success",quantile="0.5"} 0.001661895
+node_exporter_scrape_duration_seconds{collector="diskstats",result="success",quantile="0.9"} 0.001661895
+node_exporter_scrape_duration_seconds{collector="diskstats",result="success",quantile="0.99"} 0.001661895
+node_exporter_scrape_duration_seconds_sum{collector="diskstats",result="success"} 0.001661895
 node_exporter_scrape_duration_seconds_count{collector="diskstats",result="success"} 1
-node_exporter_scrape_duration_seconds{collector="filefd",result="success",quantile="0.5"} 9.285100000000001e-05
-node_exporter_scrape_duration_seconds{collector="filefd",result="success",quantile="0.9"} 9.285100000000001e-05
-node_exporter_scrape_duration_seconds{collector="filefd",result="success",quantile="0.99"} 9.285100000000001e-05
-node_exporter_scrape_duration_seconds_sum{collector="filefd",result="success"} 9.285100000000001e-05
+node_exporter_scrape_duration_seconds{collector="filefd",result="success",quantile="0.5"} 0.000146396
+node_exporter_scrape_duration_seconds{collector="filefd",result="success",quantile="0.9"} 0.000146396
+node_exporter_scrape_duration_seconds{collector="filefd",result="success",quantile="0.99"} 0.000146396
+node_exporter_scrape_duration_seconds_sum{collector="filefd",result="success"} 0.000146396
 node_exporter_scrape_duration_seconds_count{collector="filefd",result="success"} 1
-node_exporter_scrape_duration_seconds{collector="loadavg",result="success",quantile="0.5"} 0.00034298300000000005
-node_exporter_scrape_duration_seconds{collector="loadavg",result="success",quantile="0.9"} 0.00034298300000000005
-node_exporter_scrape_duration_seconds{collector="loadavg",result="success",quantile="0.99"} 0.00034298300000000005
-node_exporter_scrape_duration_seconds_sum{collector="loadavg",result="success"} 0.00034298300000000005
+node_exporter_scrape_duration_seconds{collector="loadavg",result="success",quantile="0.5"} 6.1362e-05
+node_exporter_scrape_duration_seconds{collector="loadavg",result="success",quantile="0.9"} 6.1362e-05
+node_exporter_scrape_duration_seconds{collector="loadavg",result="success",quantile="0.99"} 6.1362e-05
+node_exporter_scrape_duration_seconds_sum{collector="loadavg",result="success"} 6.1362e-05
 node_exporter_scrape_duration_seconds_count{collector="loadavg",result="success"} 1
-node_exporter_scrape_duration_seconds{collector="mdadm",result="success",quantile="0.5"} 0.002383572
-node_exporter_scrape_duration_seconds{collector="mdadm",result="success",quantile="0.9"} 0.002383572
-node_exporter_scrape_duration_seconds{collector="mdadm",result="success",quantile="0.99"} 0.002383572
-node_exporter_scrape_duration_seconds_sum{collector="mdadm",result="success"} 0.002383572
+node_exporter_scrape_duration_seconds{collector="mdadm",result="success",quantile="0.5"} 0.000199423
+node_exporter_scrape_duration_seconds{collector="mdadm",result="success",quantile="0.9"} 0.000199423
+node_exporter_scrape_duration_seconds{collector="mdadm",result="success",quantile="0.99"} 0.000199423
+node_exporter_scrape_duration_seconds_sum{collector="mdadm",result="success"} 0.000199423
 node_exporter_scrape_duration_seconds_count{collector="mdadm",result="success"} 1
-node_exporter_scrape_duration_seconds{collector="megacli",result="success",quantile="0.5"} 0.050494332
-node_exporter_scrape_duration_seconds{collector="megacli",result="success",quantile="0.9"} 0.050494332
-node_exporter_scrape_duration_seconds{collector="megacli",result="success",quantile="0.99"} 0.050494332
-node_exporter_scrape_duration_seconds_sum{collector="megacli",result="success"} 0.050494332
+node_exporter_scrape_duration_seconds{collector="megacli",result="success",quantile="0.5"} 0.005821468000000001
+node_exporter_scrape_duration_seconds{collector="megacli",result="success",quantile="0.9"} 0.005821468000000001
+node_exporter_scrape_duration_seconds{collector="megacli",result="success",quantile="0.99"} 0.005821468000000001
+node_exporter_scrape_duration_seconds_sum{collector="megacli",result="success"} 0.005821468000000001
 node_exporter_scrape_duration_seconds_count{collector="megacli",result="success"} 1
-node_exporter_scrape_duration_seconds{collector="meminfo",result="success",quantile="0.5"} 0.0021957210000000003
-node_exporter_scrape_duration_seconds{collector="meminfo",result="success",quantile="0.9"} 0.0021957210000000003
-node_exporter_scrape_duration_seconds{collector="meminfo",result="success",quantile="0.99"} 0.0021957210000000003
-node_exporter_scrape_duration_seconds_sum{collector="meminfo",result="success"} 0.0021957210000000003
+node_exporter_scrape_duration_seconds{collector="meminfo",result="success",quantile="0.5"} 0.001771465
+node_exporter_scrape_duration_seconds{collector="meminfo",result="success",quantile="0.9"} 0.001771465
+node_exporter_scrape_duration_seconds{collector="meminfo",result="success",quantile="0.99"} 0.001771465
+node_exporter_scrape_duration_seconds_sum{collector="meminfo",result="success"} 0.001771465
 node_exporter_scrape_duration_seconds_count{collector="meminfo",result="success"} 1
-node_exporter_scrape_duration_seconds{collector="netdev",result="success",quantile="0.5"} 0.001722343
-node_exporter_scrape_duration_seconds{collector="netdev",result="success",quantile="0.9"} 0.001722343
-node_exporter_scrape_duration_seconds{collector="netdev",result="success",quantile="0.99"} 0.001722343
-node_exporter_scrape_duration_seconds_sum{collector="netdev",result="success"} 0.001722343
+node_exporter_scrape_duration_seconds{collector="netdev",result="success",quantile="0.5"} 0.000959257
+node_exporter_scrape_duration_seconds{collector="netdev",result="success",quantile="0.9"} 0.000959257
+node_exporter_scrape_duration_seconds{collector="netdev",result="success",quantile="0.99"} 0.000959257
+node_exporter_scrape_duration_seconds_sum{collector="netdev",result="success"} 0.000959257
 node_exporter_scrape_duration_seconds_count{collector="netdev",result="success"} 1
-node_exporter_scrape_duration_seconds{collector="netstat",result="success",quantile="0.5"} 0.0030769110000000003
-node_exporter_scrape_duration_seconds{collector="netstat",result="success",quantile="0.9"} 0.0030769110000000003
-node_exporter_scrape_duration_seconds{collector="netstat",result="success",quantile="0.99"} 0.0030769110000000003
-node_exporter_scrape_duration_seconds_sum{collector="netstat",result="success"} 0.0030769110000000003
+node_exporter_scrape_duration_seconds{collector="netstat",result="success",quantile="0.5"} 0.0017044130000000001
+node_exporter_scrape_duration_seconds{collector="netstat",result="success",quantile="0.9"} 0.0017044130000000001
+node_exporter_scrape_duration_seconds{collector="netstat",result="success",quantile="0.99"} 0.0017044130000000001
+node_exporter_scrape_duration_seconds_sum{collector="netstat",result="success"} 0.0017044130000000001
 node_exporter_scrape_duration_seconds_count{collector="netstat",result="success"} 1
-node_exporter_scrape_duration_seconds{collector="sockstat",result="success",quantile="0.5"} 0.000420661
-node_exporter_scrape_duration_seconds{collector="sockstat",result="success",quantile="0.9"} 0.000420661
-node_exporter_scrape_duration_seconds{collector="sockstat",result="success",quantile="0.99"} 0.000420661
-node_exporter_scrape_duration_seconds_sum{collector="sockstat",result="success"} 0.000420661
+node_exporter_scrape_duration_seconds{collector="sockstat",result="success",quantile="0.5"} 0.000153337
+node_exporter_scrape_duration_seconds{collector="sockstat",result="success",quantile="0.9"} 0.000153337
+node_exporter_scrape_duration_seconds{collector="sockstat",result="success",quantile="0.99"} 0.000153337
+node_exporter_scrape_duration_seconds_sum{collector="sockstat",result="success"} 0.000153337
 node_exporter_scrape_duration_seconds_count{collector="sockstat",result="success"} 1
-node_exporter_scrape_duration_seconds{collector="stat",result="success",quantile="0.5"} 0.001113649
-node_exporter_scrape_duration_seconds{collector="stat",result="success",quantile="0.9"} 0.001113649
-node_exporter_scrape_duration_seconds{collector="stat",result="success",quantile="0.99"} 0.001113649
-node_exporter_scrape_duration_seconds_sum{collector="stat",result="success"} 0.001113649
+node_exporter_scrape_duration_seconds{collector="stat",result="success",quantile="0.5"} 0.00011309800000000001
+node_exporter_scrape_duration_seconds{collector="stat",result="success",quantile="0.9"} 0.00011309800000000001
+node_exporter_scrape_duration_seconds{collector="stat",result="success",quantile="0.99"} 0.00011309800000000001
+node_exporter_scrape_duration_seconds_sum{collector="stat",result="success"} 0.00011309800000000001
 node_exporter_scrape_duration_seconds_count{collector="stat",result="success"} 1
-node_exporter_scrape_duration_seconds{collector="textfile",result="success",quantile="0.5"} 3.9e-07
-node_exporter_scrape_duration_seconds{collector="textfile",result="success",quantile="0.9"} 3.9e-07
-node_exporter_scrape_duration_seconds{collector="textfile",result="success",quantile="0.99"} 3.9e-07
-node_exporter_scrape_duration_seconds_sum{collector="textfile",result="success"} 3.9e-07
+node_exporter_scrape_duration_seconds{collector="textfile",result="success",quantile="0.5"} 3.29e-07
+node_exporter_scrape_duration_seconds{collector="textfile",result="success",quantile="0.9"} 3.29e-07
+node_exporter_scrape_duration_seconds{collector="textfile",result="success",quantile="0.99"} 3.29e-07
+node_exporter_scrape_duration_seconds_sum{collector="textfile",result="success"} 3.29e-07
 node_exporter_scrape_duration_seconds_count{collector="textfile",result="success"} 1
 # HELP node_filefd_allocated File descriptor statistics: allocated.
 # TYPE node_filefd_allocated gauge
@@ -1330,8 +1363,8 @@ node_sockstat_UDP_mem_bytes 0
 node_sockstat_sockets_used 229
 # HELP node_textfile_mtime Unixtime mtime of textfiles successfully read.
 # TYPE node_textfile_mtime gauge
-node_textfile_mtime{file="metrics1.prom"} 1.4450870579790444e+09
-node_textfile_mtime{file="metrics2.prom"} 1.4450870579790444e+09
+node_textfile_mtime{file="metrics1.prom"} 1.451167666820433e+09
+node_textfile_mtime{file="metrics2.prom"} 1.451167666820433e+09
 # HELP node_textfile_scrape_error 1 if there was an error opening or reading a file, 0 otherwise
 # TYPE node_textfile_scrape_error gauge
 node_textfile_scrape_error 0
@@ -1340,19 +1373,19 @@ node_textfile_scrape_error 0
 process_cpu_seconds_total 0
 # HELP process_max_fds Maximum number of open file descriptors.
 # TYPE process_max_fds gauge
-process_max_fds 65536
+process_max_fds 1024
 # HELP process_open_fds Number of open file descriptors.
 # TYPE process_open_fds gauge
 process_open_fds 7
 # HELP process_resident_memory_bytes Resident memory size in bytes.
 # TYPE process_resident_memory_bytes gauge
-process_resident_memory_bytes 9.129984e+06
+process_resident_memory_bytes 1.23904e+07
 # HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
 # TYPE process_start_time_seconds gauge
-process_start_time_seconds 1.44528171118e+09
+process_start_time_seconds 1.45121398864e+09
 # HELP process_virtual_memory_bytes Virtual memory size in bytes.
 # TYPE process_virtual_memory_bytes gauge
-process_virtual_memory_bytes 1.28520192e+08
+process_virtual_memory_bytes 1.30809856e+08
 # HELP testmetric1_1 Metric read from collector/fixtures/textfile/two_metric_files/metrics1.prom
 # TYPE testmetric1_1 untyped
 testmetric1_1{foo="bar"} 10


### PR DESCRIPTION
This is only calculated for raw devices, since determinining the parent
device for partitions would require additional work, and partitions are
excluded from collection by default.