### PR TITLE
Fix compilation on FreeBSD. Refs #139

### DIFF
--- a/collector/interrupts_common.go
+++ b/collector/interrupts_common.go
@@ -13,6 +13,7 @@
 
 // +build !nointerrupts
 // +build !darwin
+// +build !freebsd
 
 package collector
 


### PR DESCRIPTION
There is no interrupts_freebsd.go implementation yet.

Compilation fails currently:

```
collector/interrupts_common.go:39: undefined: interruptLabelNames
```