### PR TITLE
Build cleanly under windows.

### DIFF
--- a/collector/interrupts_common.go
+++ b/collector/interrupts_common.go
@@ -14,6 +14,7 @@
 // +build !nointerrupts
 // +build !darwin
 // +build !freebsd
+// +build !windows
 
 package collector
 

--- a/collector/loadavg.go
+++ b/collector/loadavg.go
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 // +build !noloadavg
+// +build !windows
 
 package collector
 

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -18,12 +18,9 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
-	"os"
-	"os/signal"
 	"sort"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -153,9 +150,6 @@ func main() {
 
 	nodeCollector := NodeCollector{collectors: collectors}
 	prometheus.MustRegister(nodeCollector)
-
-	sigUsr1 := make(chan os.Signal)
-	signal.Notify(sigUsr1, syscall.SIGUSR1)
 
 	handler := prometheus.Handler()
 


### PR DESCRIPTION
Removes unused signal handlers left over from signal based collection
and block the non windows-relevant collectors loadavg and interrupts.

Signal based collection removed in 1c17481a4289a81b70e482fcf1d4a432da87c5de over a year ago.

@brian-brazil @discordianfish @grobie 