### PR TITLE
Add vmstat collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ stat | Exposes various statistics from `/proc/stat`. This includes CPU usage, bo
 textfile | Exposes statistics read from local disk. The `--collector.textfile.directory` flag must be set.
 time | Exposes the current system time.
 mdadm | Exposes statistics about devices in `/proc/mdstat` (does nothing if no /proc/mdstat present).
+vmstat | Exposes statistics from`/proc/vmstat`.
 
 
 ### Disabled by default

--- a/collector/vmstat.go
+++ b/collector/vmstat.go
@@ -1,0 +1,69 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !novmstat
+
+package collector
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	vmStatSubsystem = "vmstat"
+)
+
+type vmStatCollector struct{}
+
+func init() {
+	Factories["vmstat"] = NewvmStatCollector
+}
+
+// Takes a prometheus registry and returns a new Collector exposing
+// vmstat stats.
+func NewvmStatCollector() (Collector, error) {
+	return &vmStatCollector{}, nil
+}
+
+func (c *vmStatCollector) Update(ch chan<- prometheus.Metric) (err error) {
+	file, err := os.Open(procFilePath("vmstat"))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		parts := strings.Fields(scanner.Text())
+		value, err := strconv.ParseFloat(parts[1], 64)
+		if err != nil {
+			return err
+		}
+
+		metric := prometheus.NewUntyped(prometheus.UntypedOpts{
+			Namespace: Namespace,
+			Subsystem: vmStatSubsystem,
+			Name:      parts[0],
+			Help:      fmt.Sprintf("/proc/vmstat information field %s.", parts[0]),
+		})
+		metric.Set(value)
+		metric.Collect(ch)
+	}
+	return err
+}

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -39,7 +39,7 @@ var (
 	listenAddress     = flag.String("web.listen-address", ":9100", "Address on which to expose metrics and web interface.")
 	metricsPath       = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 	enabledCollectors = flag.String("collectors.enabled",
-		filterAvailableCollectors("conntrack,diskstats,filefd,filesystem,loadavg,mdadm,meminfo,netdev,netstat,sockstat,stat,textfile,time,uname,version"),
+		filterAvailableCollectors("conntrack,diskstats,filefd,filesystem,loadavg,mdadm,meminfo,netdev,netstat,sockstat,stat,textfile,time,uname,version,vmstat"),
 		"Comma-separated list of collectors to use.")
 	printCollectors = flag.Bool("collectors.print", false, "If true, print available collectors and exit.")
 


### PR DESCRIPTION
this adds a vmstat collector to node_exporter  #185 

in /proc/vmstat the most values are simple counters[1], however some are not, i blacklisted these values unitl i found a good way to deal with.
```
counterBlacklist := []string{"nr_dirty", "nr_writeback", "nr_unstable", "nr_page_table_pages","nr_mapped ,nr_slab"}
```

please review

[1] http://www.linuxinsight.com/proc_vmstat.html