### PR TITLE
Fix build w/o conntrack collector

### DIFF
--- a/collector/conntrack_linux.go
+++ b/collector/conntrack_linux.go
@@ -16,10 +16,6 @@
 package collector
 
 import (
-	"io/ioutil"
-	"strconv"
-	"strings"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -66,16 +62,4 @@ func (c *conntrackCollector) Update(ch chan<- prometheus.Metric) (err error) {
 		c.limit, prometheus.GaugeValue, float64(value))
 
 	return nil
-}
-
-func readUintFromFile(path string) (uint64, error) {
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return 0, err
-	}
-	value, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	return value, nil
 }

--- a/collector/helper.go
+++ b/collector/helper.go
@@ -15,6 +15,7 @@ package collector
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strconv"
 	"strings"
 )
@@ -28,4 +29,16 @@ func splitToInts(str string, sep string) (ints []int, err error) {
 		ints = append(ints, i)
 	}
 	return ints, nil
+}
+
+func readUintFromFile(path string) (uint64, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	value, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return value, nil
 }


### PR DESCRIPTION
Entry collector uses readUintFromFile() function which is defined by
conntrack collector. Thus, it is impossible to build node_exporter w/o
contract collector. Fix this by factoring out the function into
helper.go file.

Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>