### PR TITLE
meminfo_numa: fix crash on CentOS 6 kernel

### DIFF
--- a/collector/fixtures/sys/devices/system/node/node0/meminfo
+++ b/collector/fixtures/sys/devices/system/node/node0/meminfo
@@ -1,3 +1,4 @@
+
 Node 0 MemTotal:       134182340 kB
 Node 0 MemFree:        53030372 kB
 Node 0 MemUsed:        81151968 kB

--- a/collector/fixtures/sys/devices/system/node/node1/meminfo
+++ b/collector/fixtures/sys/devices/system/node/node1/meminfo
@@ -1,3 +1,4 @@
+
 Node 1 MemTotal:       134217728 kB
 Node 1 MemFree:        39634788 kB
 Node 1 MemUsed:        94582940 kB

--- a/collector/meminfo_numa_linux.go
+++ b/collector/meminfo_numa_linux.go
@@ -106,7 +106,10 @@ func parseMemInfoNuma(r io.Reader) (map[meminfoKey]float64, error) {
 	)
 
 	for scanner.Scan() {
-		line := scanner.Text()
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
 		parts := strings.Fields(string(line))
 
 		fv, err := strconv.ParseFloat(parts[3], 64)


### PR DESCRIPTION
It turns out, on some kernels (notably - CentOS6) there is an empty line
inserted at the beginning of /sys/devices/system/node/node*/meminfo
files.  The leads to node_exporter crash on such kernels.

Fix this by checking for empty string first.

Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>