### PR TITLE
fix a small typo in an error message

### DIFF
--- a/collector/diskstats_linux.go
+++ b/collector/diskstats_linux.go
@@ -258,7 +258,7 @@ func parseDiskStats(r io.Reader) (map[string]map[int]string, error) {
 
 		bytesWritten, err := convertDiskSectorsToBytes(diskStats[dev][6])
 		if err != nil {
-			return nil, fmt.Errorf("invalid value for sectors read in %s: %s", procFilePath("diskstats"), scanner.Text())
+			return nil, fmt.Errorf("invalid value for sectors written in %s: %s", procFilePath("diskstats"), scanner.Text())
 		}
 		diskStats[dev][12] = bytesWritten
 	}


### PR DESCRIPTION
-Fix a small typo in the error message for sectors written.