### PR TITLE
Fix compile error on FreeBSD

### DIFF
--- a/collector/filesystem_bsd.go
+++ b/collector/filesystem_bsd.go
@@ -57,7 +57,7 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 		fstype := C.GoString(&mnt[i].f_fstypename[0])
 
 		var ro float64
-		if mnt[i].f_flags & MNT_RDONLY {
+		if (mnt[i].f_flags & MNT_RDONLY) != 0 {
 			ro = 1
 		}
 


### PR DESCRIPTION
When compiling `20ecedd0b4c983bd7b88f97cd7a21461988a6c12` with GNU make (`gmake`) on FreeBSD 10.2-RELEASE, I get the following error:

```
collector/filesystem_bsd.go:60: non-bool mnt[i].f_flags & MNT_RDONLY (type C.uint64_t) used as if condition
Makefile.COMMON:85: recipe for target 'node_exporter' failed
gmake: *** [node_exporter] Error 2
```

This problem is fixed by this patch.