### PR TITLE
Re-implement CPU metrics collection through sysctls.

### DIFF
--- a/collector/filesystem_bsd.go
+++ b/collector/filesystem_bsd.go
@@ -57,7 +57,7 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 		fstype := C.GoString(&mnt[i].f_fstypename[0])
 
 		var ro float64
-		if mnt[i].f_flags & MNT_RDONLY {
+		if (mnt[i].f_flags & MNT_RDONLY) != 0 {
 			ro = 1
 		}
 


### PR DESCRIPTION
This removes the requirement to run node_exporter as root / with read
access to /dev/kmem in order to get cpu usage statistics.