### PR TITLE
Add FreeBSD 'cpu' exporter to default collectors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Which collectors are used is controlled by the `--collectors.enabled` flag.
 Name     | Description | OS
 ---------|-------------|----
 conntrack | Shows conntrack statistics (does nothing if no `/proc/sys/net/netfilter/` present). | Linux
+cpu | Exposes CPU statistics | FreeBSD
 diskstats | Exposes disk I/O statistics from `/proc/diskstats`. | Linux
 entropy | Exposes available entropy. | Linux
 filefd | Exposes file descriptor statistics. | Linux
@@ -37,7 +38,6 @@ version | Exposes node\_exporter version. | _any_
 
 Name     | Description | OS
 ---------|-------------|----
-cpu | Exposes CPU statistics | FreeBSD
 bonding | Exposes the number of configured and active slaves of Linux bonding interfaces. | Linux
 devstat | Exposes device statistics | FreeBSD
 gmond | Exposes statistics from Ganglia. | _any_

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	defaultCollectors = "conntrack,diskstats,entropy,filefd,filesystem,loadavg,mdadm,meminfo,netdev,netstat,sockstat,stat,textfile,time,uname,version,vmstat"
+	defaultCollectors = "conntrack,cpu,diskstats,entropy,filefd,filesystem,loadavg,mdadm,meminfo,netdev,netstat,sockstat,stat,textfile,time,uname,version,vmstat"
 )
 
 var (


### PR DESCRIPTION
As of 1fc84e2fb69ee3d1f063399b00a6284fc8e27cb8 it does not require root anymore.

The CPU collector has been tested for a day on FreeBSD with frequent polling (30s) and does not show memory leaks, reliability or performance issues.