### PR TITLE
Add flag to ignore certain filesystem types

### DIFF
--- a/collector/filesystem_bsd.go
+++ b/collector/filesystem_bsd.go
@@ -33,6 +33,7 @@ import "C"
 
 const (
 	defIgnoredMountPoints = "^/(dev)($|/)"
+	defIgnoredFsTypes     = "^devfs$"
 	MNT_RDONLY            = 0x1
 )
 
@@ -55,6 +56,10 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 
 		device := C.GoString(&mnt[i].f_mntfromname[0])
 		fstype := C.GoString(&mnt[i].f_fstypename[0])
+		if c.ignoredFsTypesPattern.MatchString(fstype) {
+			log.Debugf("Ignoring fs type: %s", fstype)
+			continue
+		}
 
 		var ro float64
 		if (mnt[i].f_flags & MNT_RDONLY) != 0 {

--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -25,6 +25,7 @@ import (
 
 // Arch-dependent implementation must define:
 // * defIgnoredMountPoints
+// * defIgnoredFsTypes
 // * filesystemLabelNames
 // * filesystemCollector.GetStats
 
@@ -34,11 +35,17 @@ var (
 		defIgnoredMountPoints,
 		"Regexp of mount points to ignore for filesystem collector.")
 
+	ignoredFsTypes = flag.String(
+		"collector.filesystem.ignored-fs-types",
+		defIgnoredFsTypes,
+		"Regexp of filesystem types to ignore for filesystem collector.")
+
 	filesystemLabelNames = []string{"device", "mountpoint", "fstype"}
 )
 
 type filesystemCollector struct {
 	ignoredMountPointsPattern *regexp.Regexp
+	ignoredFsTypesPattern     *regexp.Regexp
 	sizeDesc, freeDesc, availDesc,
 	filesDesc, filesFreeDesc, roDesc *prometheus.Desc
 }
@@ -56,7 +63,8 @@ func init() {
 // Filesystems stats.
 func NewFilesystemCollector() (Collector, error) {
 	subsystem := "filesystem"
-	pattern := regexp.MustCompile(*ignoredMountPoints)
+	mountPointPattern := regexp.MustCompile(*ignoredMountPoints)
+	fsTypePatter := regexp.MustCompile(*ignoredFsTypes)
 
 	sizeDesc := prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, subsystem, "size"),
@@ -95,7 +103,8 @@ func NewFilesystemCollector() (Collector, error) {
 	)
 
 	return &filesystemCollector{
-		ignoredMountPointsPattern: pattern,
+		ignoredMountPointsPattern: mountPointPattern,
+		ignoredFsTypesPattern:     fsTypesPattern,
 		sizeDesc:                  sizeDesc,
 		freeDesc:                  freeDesc,
 		availDesc:                 availDesc,

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	defIgnoredMountPoints = "^/(sys|proc|dev)($|/)"
+	defIgnoredFsTypes     = "^(sys|proc)fs$"
 	ST_RDONLY             = 0x1
 )
 
@@ -45,6 +46,10 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 	for _, mpd := range mpds {
 		if c.ignoredMountPointsPattern.MatchString(mpd.mountPoint) {
 			log.Debugf("Ignoring mount point: %s", mpd.mountPoint)
+			continue
+		}
+		if c.ignoredFsTypesPatter.MatchString(mpd.fsType) {
+			log.Debugf("Ignoring fs type: %s", mpd.fsType)
 			continue
 		}
 		buf := new(syscall.Statfs_t)


### PR DESCRIPTION
This PR introduces a flag to ignore certain filesystem types. In our setup there are a lot of useless timeseries exported which all share a few filesystem types. This would add a way to ignore all those and save some precious space.

Please let me know if you have any objections in general against this kind of feature.