### PR TITLE
Stop installing golang.org/x/tools/cmd/vet during Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ go:
 env:
 - GO15VENDOREXPERIMENT=1
 
-install:
-- go get golang.org/x/tools/cmd/vet
-
 script:
 - "! gofmt -l $(find . -path ./vendor -prune -o -name '*.go' -print) | read nothing"
 - go vet


### PR DESCRIPTION
This is
[deprecated](https://groups.google.com/forum/#!topic/golang-announce/qu_rAphYdxY)
and no longer necessary as we don't try to build with Go 1.4 anyway.