### PR TITLE
Add a unit test for the conversion

### DIFF
--- a/collector/netdev_freebsd.go
+++ b/collector/netdev_freebsd.go
@@ -53,19 +53,23 @@ func getNetDevStats(ignore *regexp.Regexp) (map[string]map[string]string, error)
 			devStats := map[string]string{}
 			data := (*C.struct_if_data)(ifa.ifa_data)
 
-			devStats["receive_packets"] = strconv.FormatUint(uint64(data.ifi_ipackets), 10)
-			devStats["transmit_packets"] = strconv.FormatUint(uint64(data.ifi_opackets), 10)
-			devStats["receive_errs"] = strconv.FormatUint(uint64(data.ifi_ierrors), 10)
-			devStats["transmit_errs"] = strconv.FormatUint(uint64(data.ifi_oerrors), 10)
-			devStats["receive_bytes"] = strconv.FormatUint(uint64(data.ifi_ibytes), 10)
-			devStats["transmit_bytes"] = strconv.FormatUint(uint64(data.ifi_obytes), 10)
-			devStats["receive_multicast"] = strconv.FormatUint(uint64(data.ifi_imcasts), 10)
-			devStats["transmit_multicast"] = strconv.FormatUint(uint64(data.ifi_omcasts), 10)
-			devStats["receive_drop"] = strconv.FormatUint(uint64(data.ifi_iqdrops), 10)
-			devStats["transmit_drop"] = strconv.FormatUint(uint64(data.ifi_oqdrops), 10)
+			devStats["receive_packets"] = convertFreeBSDCPUTime(uint64(data.ifi_ipackets))
+			devStats["transmit_packets"] = convertFreeBSDCPUTime(uint64(data.ifi_opackets))
+			devStats["receive_errs"] = convertFreeBSDCPUTime(uint64(data.ifi_ierrors))
+			devStats["transmit_errs"] = convertFreeBSDCPUTime(uint64(data.ifi_oerrors))
+			devStats["receive_bytes"] = convertFreeBSDCPUTime(uint64(data.ifi_ibytes))
+			devStats["transmit_bytes"] = convertFreeBSDCPUTime(uint64(data.ifi_obytes))
+			devStats["receive_multicast"] = convertFreeBSDCPUTime(uint64(data.ifi_imcasts))
+			devStats["transmit_multicast"] = convertFreeBSDCPUTime(uint64(data.ifi_omcasts))
+			devStats["receive_drop"] = convertFreeBSDCPUTime(uint64(data.ifi_iqdrops))
+			devStats["transmit_drop"] = convertFreeBSDCPUTime(uint64(data.ifi_oqdrops))
 			netDev[dev] = devStats
 		}
 	}
 
 	return netDev, nil
+}
+
+func convertFreeBSDCPUTime(counter uint64) string {
+	return strconv.FormatUint(counter, 10)
 }

--- a/collector/netdev_freebsd_test.go
+++ b/collector/netdev_freebsd_test.go
@@ -1,0 +1,50 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import "testing"
+
+type uintToStringTest struct {
+	in  uint64
+	out string
+}
+
+var uinttostringtests = []uintToStringTest{
+	// Copied base10 values from strconv's tests:
+	{0, "0"},
+	{1, "1"},
+	{12345678, "12345678"},
+	{1<<31 - 1, "2147483647"},
+	{1 << 31, "2147483648"},
+	{1<<31 + 1, "2147483649"},
+	{1<<32 - 1, "4294967295"},
+	{1 << 32, "4294967296"},
+	{1<<32 + 1, "4294967297"},
+	{1 << 50, "1125899906842624"},
+	{1<<63 - 1, "9223372036854775807"},
+
+	// Some values that convert correctly on amd64, but not on i386.
+	{0x1bf0c640a, "7500227594"},
+	{0xbee5df75, "3202735989"},
+}
+
+func TestUintToString(t *testing.T) {
+	for _, test := range uinttostringtests {
+		is := convertFreeBSDCPUTime(test.in)
+		if is != test.out {
+			t.Errorf("convertFreeBSDCPUTime(%v) = %v want %v",
+				test.in, is, test.out)
+		}
+	}
+}


### PR DESCRIPTION
As promised, this tests the actual conversion, except the step where we change the type from the ulong to uint64.

Changing the tests to use oldconvert() too makes it fail on freebsd/386 (but I had to reapply this patch to before #207) to get it to compile at all on 386.