### PR TITLE
Close file handler in textfile

### DIFF
--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -91,6 +91,7 @@ func (c *textFileCollector) parseTextFiles() []*dto.MetricFamily {
 		}
 		var parser expfmt.TextParser
 		parsedFamilies, err := parser.TextToMetricFamilies(file)
+		file.Close()
 		if err != nil {
 			log.Errorf("Error parsing %s: %v", path, err)
 			error = 1.0


### PR DESCRIPTION
Current the file handler not closed. Only closed by gc. May be has some hidden trouble.

@beorn7 