### PR TITLE
Enable *bsd collector on darwin

### DIFF
--- a/collector/filesystem_bsd.go
+++ b/collector/filesystem_bsd.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build freebsd openbsd
+// +build freebsd openbsd darwin,amd64
 // +build !nofilesystem
 
 package collector

--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // +build !nofilesystem
-// +build linux freebsd openbsd
+// +build linux freebsd openbsd darwin,amd64
 
 package collector
 


### PR DESCRIPTION
Well that was easy :)

The cgo based bsd variant just works on darwin:

```
$ curl -s 192.168.1.104:9100/metrics|grep '/dev/disk1'
node_filesystem_avail{device="/dev/disk1",fstype="hfs",mountpoint="/"} 7.5835293696e+10
node_filesystem_files{device="/dev/disk1",fstype="hfs",mountpoint="/"} 5.8315941e+07
node_filesystem_files_free{device="/dev/disk1",fstype="hfs",mountpoint="/"} 1.8514476e+07
node_filesystem_free{device="/dev/disk1",fstype="hfs",mountpoint="/"} 7.6097437696e+10
node_filesystem_readonly{device="/dev/disk1",fstype="hfs",mountpoint="/"} 0
node_filesystem_size{device="/dev/disk1",fstype="hfs",mountpoint="/"} 2.38862102528e+11
```