### PR TITLE
sockstat: add support for RHE4

### DIFF
--- a/collector/fixtures/proc/net/sockstat_rhe4
+++ b/collector/fixtures/proc/net/sockstat_rhe4
@@ -1,0 +1,5 @@
+sockets: used 229
+TCP: inuse 4 orphan 0 tw 4 alloc 17 mem 1
+UDP: inuse 0
+RAW: inuse 0
+FRAG: inuse 0 memory 0

--- a/collector/sockstat_linux.go
+++ b/collector/sockstat_linux.go
@@ -117,11 +117,13 @@ func parseSockStats(r io.Reader, fileName string) (map[string]map[string]string,
 	sockStat["TCP"]["mem_bytes"] = strconv.Itoa(pageCount * pageSize)
 
 	// Update the UDP mem from page count to bytes.
-	pageCount, err = strconv.Atoi(sockStat["UDP"]["mem"])
-	if err != nil {
-		return nil, fmt.Errorf("invalid value %s in sockstats: %s", sockStat["UDP"]["mem"], err)
+	if udpMem := sockStat["UDP"]["mem"]; udpMem != "" {
+		pageCount, err = strconv.Atoi(udpMem)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value %s in sockstats: %s", sockStat["UDP"]["mem"], err)
+		}
+		sockStat["UDP"]["mem_bytes"] = strconv.Itoa(pageCount * pageSize)
 	}
-	sockStat["UDP"]["mem_bytes"] = strconv.Itoa(pageCount * pageSize)
 
 	return sockStat, nil
 }

--- a/collector/sockstat_linux_test.go
+++ b/collector/sockstat_linux_test.go
@@ -20,7 +20,12 @@ import (
 )
 
 func TestSockStats(t *testing.T) {
-	file, err := os.Open("fixtures/proc/net/sockstat")
+	testSockStats(t, "fixtures/proc/net/sockstat")
+	testSockStats(t, "fixtures/proc/net/sockstat_rhe4")
+}
+
+func testSockStats(t *testing.T, fixture string) {
+	file, err := os.Open(fixture)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
sorry for open a pull request for such a vintage OS, but the change is small and node exporter works reliable there after the patch (with go 1.4.2).

The only difference that caused a parsing error is a missing memory field in the UDP section of sockstat, i made the extraction of udp memory from sockstat optional with this patch.

ps.: just in case someone finds this post in need of  a prometheus node-exporter for RHE4, one also needs a patched [go 1.4.2](https://github.com/mgit-at/go/tree/release-branch.go1.4-rhe4)
