### PR TITLE
fix TestParseTextFiles() on Windows

### DIFF
--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
+	"path"
 	"sort"
 	"strings"
 	"time"
@@ -82,7 +82,7 @@ func (c *textFileCollector) parseTextFiles() []*dto.MetricFamily {
 		if !strings.HasSuffix(f.Name(), ".prom") {
 			continue
 		}
-		path := filepath.Join(c.path, f.Name())
+		path := path.Join(c.path, f.Name())
 		file, err := os.Open(path)
 		if err != nil {
 			log.Errorf("Error opening %s: %v", path, err)


### PR DESCRIPTION
By using filepath.Join(), the path created on Windows uses `\\` slashes, resulting in `"Metric read from fixtures\\textfile\\two_metric_files\\metrics1.prom\\"`

With the following patch, the TestParseTextFiles() test now pass, and tests looks like this:

```
node_exporter windows-fixes = $ go test -v .\collector                      
=== RUN   TestMegaCliAdapter                                                
--- PASS: TestMegaCliAdapter (0.00s)                                        
=== RUN   TestMegaCliDisks                                                  
--- PASS: TestMegaCliDisks (0.00s)                                          
=== RUN   TestMegaCliCollectorDoesntCrash                                   
--- FAIL: TestMegaCliCollectorDoesntCrash (0.00s)                           
        megacli_test.go:93: exec: "./fixtures/megacli": file does not exist 
=== RUN   TestDefaultProcPath                                               
--- PASS: TestDefaultProcPath (0.00s)                                       
=== RUN   TestCustomProcPath                                                
--- PASS: TestCustomProcPath (0.00s)                                        
=== RUN   TestDefaultSysPath                                                
--- PASS: TestDefaultSysPath (0.00s)                                        
=== RUN   TestCustomSysPath                                                 
--- PASS: TestCustomSysPath (0.00s)                                         
=== RUN   TestParseTextFiles                                                
--- PASS: TestParseTextFiles (0.01s)                                        
FAIL                                                                        
exit status 1                                                               
FAIL    github.com/prometheus/node_exporter/collector   0.443s              
```

looking at the megacli failure next.

PS, I am interested in extending Windows support for node_exporter