### PR TITLE
replace collector/fixtures/megacli bash script with a go program

### DIFF
--- a/collector/fixtures/megacli
+++ b/collector/fixtures/megacli
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-cat "$(dirname "$0")/megacli_disks.txt"

--- a/collector/fixtures/megacli_fixture/main.go
+++ b/collector/fixtures/megacli_fixture/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+)
+
+func main() {
+	s, _ := ioutil.ReadFile("./collector/fixtures/megacli_disks.txt")
+	fmt.Println(string(s))
+}

--- a/collector/megacli_test.go
+++ b/collector/megacli_test.go
@@ -18,6 +18,7 @@ package collector
 import (
 	"flag"
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -74,7 +75,11 @@ func TestMegaCliDisks(t *testing.T) {
 }
 
 func TestMegaCliCollectorDoesntCrash(t *testing.T) {
-	if err := flag.Set("collector.megacli.command", "./fixtures/megacli"); err != nil {
+	if err := exec.Command("go", "build", "./fixtures/megacli_fixture").Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := flag.Set("collector.megacli.command", "./megacli_fixture"); err != nil {
 		t.Fatal(err)
 	}
 	collector, err := NewMegaCliCollector()


### PR DESCRIPTION
fixes test TestMegaCliCollectorDoesntCrash() on Windows where we dont have a bash shell