### PR TITLE
Compile fs stats for dfly

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cpu | Exposes CPU statistics | FreeBSD
 diskstats | Exposes disk I/O statistics from `/proc/diskstats`. | Linux
 entropy | Exposes available entropy. | Linux
 filefd | Exposes file descriptor statistics from `/proc/sys/fs/file-nr`. | Linux
-filesystem | Exposes filesystem statistics, such as disk space used. | FreeBSD, Linux, OpenBSD
+filesystem | Exposes filesystem statistics, such as disk space used. | FreeBSD, Dragonfly, Linux, OpenBSD
 loadavg | Exposes load average. | Darwin, Dragonfly, FreeBSD, Linux, NetBSD, OpenBSD, Solaris
 mdadm | Exposes statistics about devices in `/proc/mdstat` (does nothing if no `/proc/mdstat` present). | Linux
 meminfo | Exposes memory statistics. | FreeBSD, Linux

--- a/collector/filesystem_bsd.go
+++ b/collector/filesystem_bsd.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build freebsd openbsd darwin dragonfly,amd64
+// +build freebsd openbsd darwin,amd64 dragonfly
 // +build !nofilesystem
 
 package collector

--- a/collector/filesystem_bsd.go
+++ b/collector/filesystem_bsd.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build freebsd openbsd darwin,amd64
+// +build freebsd openbsd darwin dragonfly,amd64
 // +build !nofilesystem
 
 package collector

--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // +build !nofilesystem
-// +build linux freebsd openbsd darwin,amd64
+// +build linux freebsd openbsd darwin dragonfly,amd64
 
 package collector
 

--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // +build !nofilesystem
-// +build linux freebsd openbsd darwin dragonfly,amd64
+// +build linux freebsd openbsd darwin,amd64 dragonfly
 
 package collector
 


### PR DESCRIPTION
Add dragonfly as a compile target.

Sample output from my machine:

```
# HELP node_filesystem_avail Filesystem space available to non-root users in bytes.
# TYPE node_filesystem_avail gauge
node_filesystem_avail{device="/dev/serno/6VY96M9D.s1a",fstype="ufs",mountpoint="/boot"} 5.43205376e+08
node_filesystem_avail{device="/pfs/@@-1:00001",fstype="null",mountpoint="/var"} 2.08283615232e+11
node_filesystem_avail{device="/pfs/@@-1:00002",fstype="null",mountpoint="/tmp"} 2.08283615232e+11
node_filesystem_avail{device="/pfs/@@-1:00003",fstype="null",mountpoint="/home"} 2.08283582464e+11
node_filesystem_avail{device="/pfs/@@-1:00004",fstype="null",mountpoint="/usr/obj"} 2.08283615232e+11
node_filesystem_avail{device="/pfs/@@-1:00005",fstype="null",mountpoint="/var/crash"} 2.08283615232e+11
node_filesystem_avail{device="/pfs/@@-1:00006",fstype="null",mountpoint="/var/tmp"} 2.08283615232e+11
node_filesystem_avail{device="ROOT",fstype="hammer",mountpoint="/"} 2.08283582464e+11
node_filesystem_avail{device="procfs",fstype="procfs",mountpoint="/proc"} 0
# HELP node_filesystem_files Filesystem total file nodes.
# TYPE node_filesystem_files gauge
node_filesystem_files{device="/dev/serno/6VY96M9D.s1a",fstype="ufs",mountpoint="/boot"} 129790
node_filesystem_files{device="/pfs/@@-1:00001",fstype="null",mountpoint="/var"} 431860
node_filesystem_files{device="/pfs/@@-1:00002",fstype="null",mountpoint="/tmp"} 431860
node_filesystem_files{device="/pfs/@@-1:00003",fstype="null",mountpoint="/home"} 431860
node_filesystem_files{device="/pfs/@@-1:00004",fstype="null",mountpoint="/usr/obj"} 431860
node_filesystem_files{device="/pfs/@@-1:00005",fstype="null",mountpoint="/var/crash"} 431860
node_filesystem_files{device="/pfs/@@-1:00006",fstype="null",mountpoint="/var/tmp"} 431860
node_filesystem_files{device="ROOT",fstype="hammer",mountpoint="/"} 431860
node_filesystem_files{device="procfs",fstype="procfs",mountpoint="/proc"} 7924
# HELP node_filesystem_files_free Filesystem total free file nodes.
# TYPE node_filesystem_files_free gauge
node_filesystem_files_free{device="/dev/serno/6VY96M9D.s1a",fstype="ufs",mountpoint="/boot"} 128428
node_filesystem_files_free{device="/pfs/@@-1:00001",fstype="null",mountpoint="/var"} 0
node_filesystem_files_free{device="/pfs/@@-1:00002",fstype="null",mountpoint="/tmp"} 0
node_filesystem_files_free{device="/pfs/@@-1:00003",fstype="null",mountpoint="/home"} 0
node_filesystem_files_free{device="/pfs/@@-1:00004",fstype="null",mountpoint="/usr/obj"} 0
node_filesystem_files_free{device="/pfs/@@-1:00005",fstype="null",mountpoint="/var/crash"} 0
node_filesystem_files_free{device="/pfs/@@-1:00006",fstype="null",mountpoint="/var/tmp"} 0
node_filesystem_files_free{device="ROOT",fstype="hammer",mountpoint="/"} 0
node_filesystem_files_free{device="procfs",fstype="procfs",mountpoint="/proc"} 7918
# HELP node_filesystem_free Filesystem free space in bytes.
# TYPE node_filesystem_free gauge
node_filesystem_free{device="/dev/serno/6VY96M9D.s1a",fstype="ufs",mountpoint="/boot"} 6.27757056e+08
node_filesystem_free{device="/pfs/@@-1:00001",fstype="null",mountpoint="/var"} 2.08283615232e+11
node_filesystem_free{device="/pfs/@@-1:00002",fstype="null",mountpoint="/tmp"} 2.08283615232e+11
node_filesystem_free{device="/pfs/@@-1:00003",fstype="null",mountpoint="/home"} 2.08283582464e+11
node_filesystem_free{device="/pfs/@@-1:00004",fstype="null",mountpoint="/usr/obj"} 2.08283615232e+11
node_filesystem_free{device="/pfs/@@-1:00005",fstype="null",mountpoint="/var/crash"} 2.08283615232e+11
node_filesystem_free{device="/pfs/@@-1:00006",fstype="null",mountpoint="/var/tmp"} 2.08283615232e+11
node_filesystem_free{device="ROOT",fstype="hammer",mountpoint="/"} 2.08283582464e+11
node_filesystem_free{device="procfs",fstype="procfs",mountpoint="/proc"} 0
# HELP node_filesystem_readonly Filesystem read-only status.
# TYPE node_filesystem_readonly gauge
node_filesystem_readonly{device="/dev/serno/6VY96M9D.s1a",fstype="ufs",mountpoint="/boot"} 0
node_filesystem_readonly{device="/pfs/@@-1:00001",fstype="null",mountpoint="/var"} 0
node_filesystem_readonly{device="/pfs/@@-1:00002",fstype="null",mountpoint="/tmp"} 0
node_filesystem_readonly{device="/pfs/@@-1:00003",fstype="null",mountpoint="/home"} 0
node_filesystem_readonly{device="/pfs/@@-1:00004",fstype="null",mountpoint="/usr/obj"} 0
node_filesystem_readonly{device="/pfs/@@-1:00005",fstype="null",mountpoint="/var/crash"} 0
node_filesystem_readonly{device="/pfs/@@-1:00006",fstype="null",mountpoint="/var/tmp"} 0
node_filesystem_readonly{device="ROOT",fstype="hammer",mountpoint="/"} 0
node_filesystem_readonly{device="procfs",fstype="procfs",mountpoint="/proc"} 0
# HELP node_filesystem_size Filesystem size in bytes.
# TYPE node_filesystem_size gauge
node_filesystem_size{device="/dev/serno/6VY96M9D.s1a",fstype="ufs",mountpoint="/boot"} 1.056913408e+09
node_filesystem_size{device="/pfs/@@-1:00001",fstype="null",mountpoint="/var"} 2.39175991296e+11
node_filesystem_size{device="/pfs/@@-1:00002",fstype="null",mountpoint="/tmp"} 2.39175991296e+11
node_filesystem_size{device="/pfs/@@-1:00003",fstype="null",mountpoint="/home"} 2.39175991296e+11
node_filesystem_size{device="/pfs/@@-1:00004",fstype="null",mountpoint="/usr/obj"} 2.39175991296e+11
node_filesystem_size{device="/pfs/@@-1:00005",fstype="null",mountpoint="/var/crash"} 2.39175991296e+11
node_filesystem_size{device="/pfs/@@-1:00006",fstype="null",mountpoint="/var/tmp"} 2.39175991296e+11
node_filesystem_size{device="ROOT",fstype="hammer",mountpoint="/"} 2.39175991296e+11
node_filesystem_size{device="procfs",fstype="procfs",mountpoint="/proc"} 4096
```