### PR TITLE
export DragonFlyBSD CPU time

### DIFF
--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -26,21 +26,14 @@ import (
 
 /*
 #cgo LDFLAGS:
-#include <fcntl.h>
-#include <stdlib.h>
-#include <sys/param.h>
-#include <sys/resource.h>
-#include <sys/time.h>
 #include <sys/sysctl.h>
 #include <kinfo.h>
+#include <stdlib.h>
 
 static int mibs_set_up = 0;
 
 static int mib_kern_cp_times[2];
 static size_t mib_kern_cp_times_len = 2;
-
-static const int mib_hw_ncpu[] = {CTL_HW, HW_NCPU};
-static const size_t mib_hw_ncpu_len = 2;
 
 static const int mib_kern_clockrate[] = {CTL_KERN, KERN_CLOCKRATE};
 static size_t mib_kern_clockrate_len = 2;
@@ -145,18 +138,12 @@ func NewStatCollector() (Collector, error) {
 	}, nil
 }
 
-type exportedCPUTime struct {
-	cp_user, cp_nice, cp_sys, cp_intr, cp_idle uint64
-}
-
 // Expose CPU stats using sysctl.
 func (c *statCollector) Update(ch chan<- prometheus.Metric) (err error) {
 
 	// We want time spent per-cpu per CPUSTATE.
 	// CPUSTATES (number of CPUSTATES) is defined as 5U.
-	// Order: CP_USER | CP_NICE | CP_SYS | CP_IDLE | CP_INTR
-	// sysctl kern.cp_times provides hw.ncpu * CPUSTATES long integers:
-	//   hw.ncpu * (space-separated list of the above variables)
+	// States: CP_USER | CP_NICE | CP_SYS | CP_IDLE | CP_INTR
 	//
 	// Each value is a counter incremented at frequency
 	//   kern.clockrate.(stathz | hz)

--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -97,16 +97,9 @@ int getCPUTimes(int *ncpu, struct exported_cputime **cputime) {
 
 	*cputime = &xp_t[0];
 
-	// free(&cp_t);
-
 	return 0;
 
 }
-
-void freeCPUTimes(double *cpu_times) {
-	free(cpu_times);
-}
-
 */
 import "C"
 
@@ -156,8 +149,6 @@ func (c *statCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	if C.getCPUTimes(&ncpu, &cpuTimesC) == -1 {
 		return errors.New("could not retrieve CPU times")
 	}
-	// TODO: Remember to free variables
-	// defer C.freeCPUTimes(cpuTimesC)
 
 	cpuTimes := (*[1 << 30]C.struct_exported_cputime)(unsafe.Pointer(cpuTimesC))[:ncpu:ncpu]
 

--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -32,23 +32,6 @@ import (
 #include <stdlib.h>
 #include <stdio.h>
 
-static int mibs_set_up = 0;
-
-static int mib_kern_cp_times[2];
-static size_t mib_kern_cp_times_len = 2;
-
-static const int mib_kern_clockrate[] = {CTL_KERN, KERN_CLOCKRATE};
-static size_t mib_kern_clockrate_len = 2;
-
-// Setup method for MIBs not available as constants.
-// Calls to this method must be synchronized externally.
-int
-setupSysctlMIBs() {
-	int ret = sysctlnametomib("kern.cputime", mib_kern_cp_times, &mib_kern_cp_times_len);
-	if (ret == 0) mibs_set_up = 1;
-	return ret;
-}
-
 int
 getCPUTimes(char **cputime) {
 	size_t len;
@@ -117,9 +100,6 @@ func init() {
 // Takes a prometheus registry and returns a new Collector exposing
 // CPU stats.
 func NewStatCollector() (Collector, error) {
-	if C.setupSysctlMIBs() == -1 {
-		return nil, errors.New("could not initialize sysctl MIBs")
-	}
 	return &statCollector{
 		cpu: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, "", "cpu"),

--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -18,6 +18,7 @@ package collector
 import (
 	"errors"
 	"fmt"
+	"unsafe"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -175,9 +176,11 @@ func (c *statCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	if C.getCPUTimes(&ncpu, &cpuTimesC, &cpuTimesLength) == -1 {
 		return errors.New("could not retrieve CPU times")
 	}
+	// TODO: Remember to free variables
 	// defer C.freeCPUTimes(cpuTimesC)
-	fmt.Println(cpuTimesC)
-	fmt.Println(uint64(cpuTimesLength))
+
+	cpuTimes := (*[1 << 30]C.struct_kinfo_cputime)(unsafe.Pointer(&cpuTimesC))[:ncpu:ncpu]
+	fmt.Println(cpuTimes)
 	return errors.New("early kill")
 	if cpuTimesLength > maxCPUTimesLen {
 		return errors.New("more CPU's than MAXCPU?")

--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -117,7 +117,7 @@ func (c *statCollector) Update(ch chan<- prometheus.Metric) error {
 	// States: CP_USER | CP_NICE | CP_SYS | CP_IDLE | CP_INTR
 	//
 	// Each value is a counter incremented at frequency
-	//   kern.clockrate.(stathz | hz)
+	//   kern.cputimer.freq
 	//
 	// Look into sys/kern/kern_clock.c for details.
 

--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -1,0 +1,128 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !nocpu
+
+package collector
+
+import (
+	"errors"
+	"strconv"
+	"unsafe"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+/*
+#cgo LDFLAGS:
+#include <stdio.h>
+#include <kinfo.h>
+#include <sys/sysctl.h>
+
+int
+getCPUTimes(int *ncpu, double **cpu_times, size_t *cp_times_length)
+{
+	int cpu, mib[2];
+	struct kinfo_cputime cp_t[ncpu];
+	uint64_t user, nice, sys, intr, idle;
+
+	size_t len;
+
+	mib[0] = CTL_HW;
+	mib[1] = HW_NCPU;
+	len = sizeof(*ncpu);
+	if (-1 == sysctl(mib, 2, &ncpu, &len, NULL, 0))
+		return -1;
+
+	bzero(cp_t, sizeof(struct kinfo_cputime)*(*ncpu));
+
+	len = sizeof(cp_t[0])*(*ncpu);
+	if (sysctlbyname("kern.cputime", &cp_t, &len, NULL, 0))
+		return -1;
+
+	// Retrieve clockrate
+	struct clockinfo clockrate;
+	int mib_kern_clockrate[] = {CTL_KERN, KERN_CLOCKRATE};
+	size_t mib_kern_clockrate_len = 2;
+	size_t clockrate_size = sizeof(clockrate);
+
+	if (sysctl(mib_kern_clockrate, mib_kern_clockrate_len, &clockrate, &clockrate_size, NULL, 0) == -1)
+		return -1;
+
+	long cpufreq = clockrate.stathz > 0 ? clockrate.stathz : clockrate.hz;
+	cpu_times = (double *) malloc(sizeof(double)*(*cp_times_length));
+	for (int i = 0; i < (*cp_times_length); i++) {
+		(*cpu_times)[i] = ((double) cp_times[i]) / cpufreq;
+	}
+
+	return 0;
+}
+
+void freeCPUTimes(double *cpu_times) {
+	free(cpu_times);
+}
+*/
+
+import "C"
+
+type statCollector struct {
+	cpu *prometheus.CounterVec
+}
+
+func init() {
+	Factories["cpu"] = NewStatCollector
+}
+
+// Takes a prometheus registry and returns a new Collector exposing
+// CPU stats.
+func NewStatCollector() (Collector, error) {
+	return &statCollector{
+		cpu: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: Namespace,
+				Name:      "cpu_seconds_total",
+				Help:      "Seconds the CPU spent in each mode.",
+			},
+			[]string{"cpu", "mode"},
+		),
+	}, nil
+}
+
+// Expose CPU stats using sysctl.
+func (c *statCollector) Update(ch chan<- prometheus.Metric) (err error) {
+	// Adapted from
+	// https://www.dragonflybsd.org/mailarchive/users/2010-04/msg00056.html
+
+	var ncpu C.int
+	var cpuTimesC *C.double
+	var cpuTimesLength C.size_t
+	if C.getCPUTimes(&ncpu, &cpuTimesC, &cpuTimesLength) == -1 {
+		return errors.New("could not retrieve CPU times")
+	}
+	defer C.freeCPUTimes(cpuTimesC)
+
+	// Convert C.double array to Go array (https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices).
+	cpuTimes := (*[maxCPUTimesLen]C.double)(unsafe.Pointer(cpuTimesC))[:cpuTimesLength:cpuTimesLength]
+
+	for cpu := 0; cpu < int(ncpu); cpu++ {
+		base_idx := C.CPUSTATES * cpu
+		c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "user"}).Set(float64(cpuTimes[base_idx+C.CP_USER]))
+		c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "nice"}).Set(float64(cpuTimes[base_idx+C.CP_NICE]))
+		c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "system"}).Set(float64(cpuTimes[base_idx+C.CP_SYS]))
+		c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "interrupt"}).Set(float64(cpuTimes[base_idx+C.CP_INTR]))
+		c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "idle"}).Set(float64(cpuTimes[base_idx+C.CP_IDLE]))
+	}
+
+	c.cpu.Collect(ch)
+	return err
+}

--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -17,63 +17,112 @@ package collector
 
 import (
 	"errors"
-	"strconv"
-	"unsafe"
+	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 /*
 #cgo LDFLAGS:
-#include <stdio.h>
-#include <kinfo.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/param.h>
+#include <sys/resource.h>
+#include <sys/time.h>
 #include <sys/sysctl.h>
+#include <kinfo.h>
 
-int
-getCPUTimes(int *ncpu, double **cpu_times, size_t *cp_times_length)
-{
-	int cpu, mib[2];
-	struct kinfo_cputime cp_t[ncpu];
-	uint64_t user, nice, sys, intr, idle;
+static int mibs_set_up = 0;
+
+static int mib_kern_cp_times[2];
+static size_t mib_kern_cp_times_len = 2;
+
+static const int mib_hw_ncpu[] = {CTL_HW, HW_NCPU};
+static const size_t mib_hw_ncpu_len = 2;
+
+static const int mib_kern_clockrate[] = {CTL_KERN, KERN_CLOCKRATE};
+static size_t mib_kern_clockrate_len = 2;
+
+// Setup method for MIBs not available as constants.
+// Calls to this method must be synchronized externally.
+int setupSysctlMIBs() {
+	int ret = sysctlnametomib("kern.cputime", mib_kern_cp_times, &mib_kern_cp_times_len);
+	if (ret == 0) mibs_set_up = 1;
+	return ret;
+}
+
+int getCPUTimes(int *ncpu, struct kinfo_cputime *cputime, uint64_t *cpu_user) {
+	// // Assert that mibs are set up through setupSysctlMIBs
+	// if (!mibs_set_up) {
+	// 	return -1;
+	// }
+
+	// // Retrieve number of cpu cores
+	// size_t ncpu_size = sizeof(*ncpu);
+	// if (sysctl(mib_hw_ncpu, mib_hw_ncpu_len, ncpu, &ncpu_size, NULL, 0) == -1 ||
+	//     sizeof(*ncpu) != ncpu_size) {
+	// 	return -1;
+	// }
 
 	size_t len;
 
+	// Get number of cpu cores.
+	int mib[2];
 	mib[0] = CTL_HW;
 	mib[1] = HW_NCPU;
 	len = sizeof(*ncpu);
-	if (-1 == sysctl(mib, 2, &ncpu, &len, NULL, 0))
+	if (sysctl(mib, 2, ncpu, &len, NULL, 0)) {
 		return -1;
-
-	bzero(cp_t, sizeof(struct kinfo_cputime)*(*ncpu));
-
-	len = sizeof(cp_t[0])*(*ncpu);
-	if (sysctlbyname("kern.cputime", &cp_t, &len, NULL, 0))
-		return -1;
+	}
 
 	// Retrieve clockrate
 	struct clockinfo clockrate;
-	int mib_kern_clockrate[] = {CTL_KERN, KERN_CLOCKRATE};
-	size_t mib_kern_clockrate_len = 2;
 	size_t clockrate_size = sizeof(clockrate);
-
-	if (sysctl(mib_kern_clockrate, mib_kern_clockrate_len, &clockrate, &clockrate_size, NULL, 0) == -1)
+	if (sysctl(mib_kern_clockrate, mib_kern_clockrate_len, &clockrate, &clockrate_size, NULL, 0) == -1 ||
+	    sizeof(clockrate) != clockrate_size) {
 		return -1;
-
-	long cpufreq = clockrate.stathz > 0 ? clockrate.stathz : clockrate.hz;
-	cpu_times = (double *) malloc(sizeof(double)*(*cp_times_length));
-	for (int i = 0; i < (*cp_times_length); i++) {
-		(*cpu_times)[i] = ((double) cp_times[i]) / cpufreq;
 	}
 
+	// // Retrieve cp_times values
+	// *cp_times_length = (*ncpu) * CPUSTATES;
+        //
+	// long cp_times[*cp_times_length];
+	// size_t cp_times_size = sizeof(cp_times);
+
+	// Get the cpu times.
+	struct kinfo_cputime cp_t[*ncpu];
+	bzero(cp_t, sizeof(struct kinfo_cputime)*(*ncpu));
+	len = sizeof(cp_t[0])*(*ncpu);
+	if (sysctlbyname("kern.cputime", &cp_t, &len, NULL, 0)) {
+		return -1;
+	}
+
+	*cpu_user = cp_t[0].cp_user;
+	*cputime = cp_t[0];
+	// This results in outputting:
+	// {1362514572 273421 845667973 12986861 17529717536 0 0 0 0 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]}
+	// So, we have the first 5 numbers from the first cpu.
+	// Need to figure out how to get the second cpu, i.e. cputime needs to be created with [2]
+
+	// Compute absolute time for different CPU states
+	// long cpufreq = clockrate.stathz > 0 ? clockrate.stathz : clockrate.hz;
+	// *cpu_times = (double *) malloc(sizeof(double)*(len));
+	// for (int i = 0; i < (len); i++) {
+	// 	(*cpu_times)[i] = ((double) cp_t[i]) / cpufreq;
+	// }
+
 	return 0;
+
 }
 
 void freeCPUTimes(double *cpu_times) {
 	free(cpu_times);
 }
-*/
 
+*/
 import "C"
+
+const maxCPUTimesLen = C.MAXCPU * C.CPUSTATES
 
 type statCollector struct {
 	cpu *prometheus.CounterVec
@@ -86,6 +135,9 @@ func init() {
 // Takes a prometheus registry and returns a new Collector exposing
 // CPU stats.
 func NewStatCollector() (Collector, error) {
+	if C.setupSysctlMIBs() == -1 {
+		return nil, errors.New("could not initialize sysctl MIBs")
+	}
 	return &statCollector{
 		cpu: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -98,30 +150,50 @@ func NewStatCollector() (Collector, error) {
 	}, nil
 }
 
+type kinfoCPUTime struct {
+	cp_user, cp_nice, cp_sys, cp_intr, cp_idle uint64
+}
+
 // Expose CPU stats using sysctl.
 func (c *statCollector) Update(ch chan<- prometheus.Metric) (err error) {
-	// Adapted from
-	// https://www.dragonflybsd.org/mailarchive/users/2010-04/msg00056.html
+
+	// We want time spent per-cpu per CPUSTATE.
+	// CPUSTATES (number of CPUSTATES) is defined as 5U.
+	// Order: CP_USER | CP_NICE | CP_SYS | CP_IDLE | CP_INTR
+	// sysctl kern.cp_times provides hw.ncpu * CPUSTATES long integers:
+	//   hw.ncpu * (space-separated list of the above variables)
+	//
+	// Each value is a counter incremented at frequency
+	//   kern.clockrate.(stathz | hz)
+	//
+	// Look into sys/kern/kern_clock.c for details.
 
 	var ncpu C.int
-	var cpuTimesC *C.double
-	var cpuTimesLength C.size_t
+	var cpuTimesC C.struct_kinfo_cputime
+	var cpuTimesLength C.uint64_t
+
 	if C.getCPUTimes(&ncpu, &cpuTimesC, &cpuTimesLength) == -1 {
 		return errors.New("could not retrieve CPU times")
 	}
-	defer C.freeCPUTimes(cpuTimesC)
+	// defer C.freeCPUTimes(cpuTimesC)
+	fmt.Println(cpuTimesC)
+	fmt.Println(uint64(cpuTimesLength))
+	return errors.New("early kill")
+	if cpuTimesLength > maxCPUTimesLen {
+		return errors.New("more CPU's than MAXCPU?")
+	}
 
 	// Convert C.double array to Go array (https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices).
-	cpuTimes := (*[maxCPUTimesLen]C.double)(unsafe.Pointer(cpuTimesC))[:cpuTimesLength:cpuTimesLength]
-
-	for cpu := 0; cpu < int(ncpu); cpu++ {
-		base_idx := C.CPUSTATES * cpu
-		c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "user"}).Set(float64(cpuTimes[base_idx+C.CP_USER]))
-		c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "nice"}).Set(float64(cpuTimes[base_idx+C.CP_NICE]))
-		c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "system"}).Set(float64(cpuTimes[base_idx+C.CP_SYS]))
-		c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "interrupt"}).Set(float64(cpuTimes[base_idx+C.CP_INTR]))
-		c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "idle"}).Set(float64(cpuTimes[base_idx+C.CP_IDLE]))
-	}
+	// cpuTimes := (*[maxCPUTimesLen]C.double)(unsafe.Pointer(cpuTimesC))[:cpuTimesLength:cpuTimesLength]
+	//
+	// for cpu := 0; cpu < int(ncpu); cpu++ {
+	// 	base_idx := C.CPUSTATES * cpu
+	// 	c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "user"}).Set(float64(cpuTimes[base_idx+C.CP_USER]))
+	// 	c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "nice"}).Set(float64(cpuTimes[base_idx+C.CP_NICE]))
+	// 	c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "system"}).Set(float64(cpuTimes[base_idx+C.CP_SYS]))
+	// 	c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "interrupt"}).Set(float64(cpuTimes[base_idx+C.CP_INTR]))
+	// 	c.cpu.With(prometheus.Labels{"cpu": strconv.Itoa(cpu), "mode": "idle"}).Set(float64(cpuTimes[base_idx+C.CP_IDLE]))
+	// }
 
 	c.cpu.Collect(ch)
 	return err

--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -82,7 +82,9 @@ getCPUTimes(int *ncpu, char **cputime) {
 
 	// string needs to hold (5*ncpu)(uint64_t + char)
 	// The char is the space between values.
-	*cputime = (char *) malloc((sizeof(uint64_t)+sizeof(char))*(5*(*ncpu)));
+	int cputime_size = (sizeof(uint64_t)+sizeof(char))*(5*(*ncpu));
+	*cputime = (char *) malloc(cputime_size);
+	bzero(*cputime, cputime_size);
 
 	uint64_t user, nice, sys, intr, idle;
 	user = nice = sys = intr = idle = 0;

--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -63,15 +63,15 @@ getCPUTimes(char **cputime) {
 		return -1;
 	}
 
-	// Retrieve clockrate
-	struct clockinfo clockrate;
-	size_t clockrate_size = sizeof(clockrate);
-	if (sysctl(mib_kern_clockrate, mib_kern_clockrate_len, &clockrate, &clockrate_size, NULL, 0) == -1 ||
-	    sizeof(clockrate) != clockrate_size) {
+	// The bump on each statclock is
+	// ((cur_systimer - prev_systimer) * systimer_freq) >> 32
+	// where
+	// systimer_freq = sysctl kern.cputimer.freq
+	long freq;
+	len = sizeof(freq);
+	if (sysctlbyname("kern.cputimer.freq", &freq, &len, NULL, 0)) {
 		return -1;
 	}
-
-	long freq = clockrate.stathz > 0 ? clockrate.stathz : clockrate.hz;
 
 	// Get the cpu times.
 	struct kinfo_cputime cp_t[ncpu];

--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -146,7 +146,6 @@ func (c *statCollector) Update(ch chan<- prometheus.Metric) error {
 		return errors.New("could not retrieve CPU times")
 	}
 
-	// TODO: Find better way to remove trailing white space.
 	cpuTimes := strings.Split(strings.TrimSpace(C.GoString(cpuTimesC)), " ")
 	C.free(unsafe.Pointer(cpuTimesC))
 	// TODO: Figure out why the string is always growing

--- a/collector/cpu_dragonfly_test.go
+++ b/collector/cpu_dragonfly_test.go
@@ -1,0 +1,41 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !nocpu
+
+package collector
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestCPU(t *testing.T) {
+	var (
+		fieldsCount = 5
+		times, err  = getDragonFlyCPUTimes()
+	)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(times) == 0 {
+		t.Fatalf("no cputimes found")
+	}
+
+	want := runtime.NumCPU() * fieldsCount
+	if len(times) != want {
+		t.Fatalf("should have %d cpuTimes: got %d", want, len(times))
+	}
+}


### PR DESCRIPTION
Hey,

This reports the node cpu time for machines running DragonFlyBSD. It is analogous to `cpu_freebsd.go`, but unfortunately DragonFly required a different implementation.

The code here is heavily influenced by the FreeBSD implementation, as well as this:

https://www.dragonflybsd.org/mailarchive/users/2010-04/msg00056.html

I have a separate implementation that uses creates a go slice from a C array of the double values, instead of how this implementation uses a string, if that is preferred: https://github.com/stuartnelson3/node_exporter/blob/dfly-cpu-doubles/collector/cpu_dragonfly.go

Note:

The units seem to be off by perhaps 3 orders of magnitude. I'm waiting for a response from the DragonFly community as to what the units for the various cpu modes.

**FIXED:** It seems I was using the incorrect value to find cpu time. The value I should use is the systimer_freq. The pr has been updated to use that.
