### PR TITLE
Added loadavg collector for Solaris

### DIFF
--- a/collector/loadavg_solaris.go
+++ b/collector/loadavg_solaris.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin dragonfly netbsd openbsd
+// +build solaris
 // +build !noloadavg
 
 package collector
@@ -20,7 +20,13 @@ import (
 	"errors"
 )
 
-// #include <stdlib.h>
+/*
+// Define "__stack_chk_fail" and "__stack_chk_guard" symbols.
+#cgo LDFLAGS: -fno-stack-protector -lssp
+// Ensure "hrtime_t" is defined for sys/loadavg.h
+#include <sys/time.h>
+#include <sys/loadavg.h>
+*/
 import "C"
 
 func getLoad() ([]float64, error) {


### PR DESCRIPTION
It seems Solaris prefers `sys/loadavg.h` over `stdlib.h` when fetching the load average.

Using `stdlib.h`

```
$GOOS=solaris GOARCH=amd64 go build node_exporter.go
# github.com/prometheus/node_exporter/collector
could not determine kind of name for C.getloadavg
```

Related PR comments: https://github.com/prometheus/node_exporter/pull/155#issuecomment-152975331

For Illumos based OSes it was required to include `sys/time.h` to ensure that `hrtime_t` was defined.

https://www.illumos.org/issues/6002

It also required setting the ldflags `-fno-stack-protector -lssp` to avoid undefined symbols when linking with gcc.

```
/opt/local/go/pkg/tool/solaris_amd64/link: running gcc failed: exit status 1
Undefined                       first referenced
 symbol                             in file
 __stack_chk_fail                    /tmp/go-link-138622936/000002.o
 __stack_chk_guard                   /tmp/go-link-138622936/000002.o
```

It should be noted that I have only tested these changes on SmartOS x86_64 (`joyent_20150820T062742Z`). 

```
./node_exporter               INFO[0000] Starting node_exporter (version=, branch=, revision=)  source=node_exporter.go:135
INFO[0000] Build context (go=go1.6.3, user=, date=)      source=node_exporter.go:136
INFO[0000] No directory specified, see --collector.textfile.directory  source=textfile.go:57
INFO[0000] Enabled collectors:                           source=node_exporter.go:155
INFO[0000]  - textfile                                   source=node_exporter.go:157
INFO[0000]  - time                                       source=node_exporter.go:157
INFO[0000]  - loadavg                                    source=node_exporter.go:157
INFO[0000] Listening on :9100                            source=node_exporter.go:176
```

```
curl -s 127.0.0.1:9100/metrics|grep loadavg
node_exporter_scrape_duration_seconds{collector="loadavg",result="success",quantile="0.5"} 0.00018160500000000002
node_exporter_scrape_duration_seconds{collector="loadavg",result="success",quantile="0.9"} 0.00029454700000000004
node_exporter_scrape_duration_seconds{collector="loadavg",result="success",quantile="0.99"} 0.00029454700000000004
node_exporter_scrape_duration_seconds_sum{collector="loadavg",result="success"} 0.0013667870000000002
node_exporter_scrape_duration_seconds_count{collector="loadavg",result="success"} 6
```

Let me know if I can rework anything on the PR! Would love to start helping with Illumos based OS support!
