### PR TITLE
Disable broken ppc builds

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -27,5 +27,6 @@ crossbuild:
         - linux/arm
         - linux/arm64
         - netbsd/arm
-        - linux/ppc64
-        - linux/ppc64le
+        # Temporarily deactivated as this does not currently build with promu.
+        #- linux/mips64
+        #- linux/mips64le


### PR DESCRIPTION
Disable linux/{ppc64,ppc64le} until we figure out what is wrong with the
automated build pipeline.

CC @sdurrheimer @EdSchouten This will fix the build.