### PR TITLE
Add some basic battery statistics the MegaCLI collector.

### DIFF
--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -775,6 +775,27 @@ node_md_is_active{device="md6"} 1
 node_md_is_active{device="md7"} 1
 node_md_is_active{device="md8"} 1
 node_md_is_active{device="md9"} 1
+# HELP node_megacli_adapter_disk_presence megacli: disk presence per adapter
+# TYPE node_megacli_adapter_disk_presence gauge
+node_megacli_adapter_disk_presence{type="Critical Disks"} 0
+node_megacli_adapter_disk_presence{type="Degraded"} 0
+node_megacli_adapter_disk_presence{type="Disks"} 4
+node_megacli_adapter_disk_presence{type="Failed Disks"} 0
+node_megacli_adapter_disk_presence{type="Offline"} 0
+node_megacli_adapter_disk_presence{type="Physical Devices"} 5
+node_megacli_adapter_disk_presence{type="Virtual Drives"} 1
+# HELP node_megacli_battery_current_ampere megacli: backup battery unit current
+# TYPE node_megacli_battery_current_ampere gauge
+node_megacli_battery_current_ampere 0.042
+# HELP node_megacli_battery_periodic_learn_required megacli: backup battery unit periodic learn required
+# TYPE node_megacli_battery_periodic_learn_required gauge
+node_megacli_battery_periodic_learn_required 1
+# HELP node_megacli_battery_temperature_celsius megacli: backup battery unit temperature
+# TYPE node_megacli_battery_temperature_celsius gauge
+node_megacli_battery_temperature_celsius 45
+# HELP node_megacli_battery_voltage_volts megacli: backup battery unit voltage
+# TYPE node_megacli_battery_voltage_volts gauge
+node_megacli_battery_voltage_volts 3.934
 # HELP node_megacli_drive_count megacli: drive error and event counters
 # TYPE node_megacli_drive_count counter
 node_megacli_drive_count{enclosure="32",slot="0",type="Media Error Count"} 0

--- a/collector/fixtures/megacli
+++ b/collector/fixtures/megacli
@@ -1,3 +1,13 @@
 #!/usr/bin/env bash
 
-cat "$(dirname "$0")/megacli_disks.txt"
+case "$1" in
+-AdpAllInfo)
+  cat "$(dirname "$0")/megacli_adapter.txt"
+  ;;
+-AdpBbuCmd)
+  cat "$(dirname "$0")/megacli_battery.txt"
+  ;;
+-PDList)
+  cat "$(dirname "$0")/megacli_disks.txt"
+  ;;
+esac

--- a/collector/fixtures/megacli_battery.txt
+++ b/collector/fixtures/megacli_battery.txt
@@ -1,0 +1,84 @@
+                                     
+BBU status for Adapter: 0
+
+BatteryType: BBU
+Voltage: 3934 mV
+Current: 42 mA
+Temperature: 45 C
+
+BBU Firmware Status:
+
+  Charging Status              : None
+  Voltage                                 : OK
+  Temperature                             : OK
+  Learn Cycle Requested	                  : No
+  Learn Cycle Active                      : No
+  Learn Cycle Status                      : OK
+  Learn Cycle Timeout                     : No
+  I2c Errors Detected                     : No
+  Battery Pack Missing                    : No
+  Battery Replacement required            : No
+  Remaining Capacity Low                  : No
+  Periodic Learn Required                 : Yes
+  Transparent Learn                       : No
+  No space to cache offload               : No
+  Pack is about to fail & should be replaced : No
+  Cache Offload premium feature required  : No
+  Module microcode update required        : No
+
+Battery state: 
+
+GasGuageStatus:
+  Fully Discharged        : No
+  Fully Charged           : Yes
+  Discharging             : No
+  Initialized             : No
+  Remaining Time Alarm    : No
+  Remaining Capacity Alarm: Yes
+  Discharge Terminated    : No
+  Over Temperature        : No
+  Charging Terminated     : No
+  Over Charged            : No
+
+Relative State of Charge: 99 %
+Charger Status: Complete
+Remaining Capacity: 229 mAh
+Full Charge Capacity: 232 mAh
+isSOHGood: Yes
+
+BBU Capacity Info for Adapter: 0
+
+Relative State of Charge: 99 %
+Absolute State of charge: 0 %
+Remaining Capacity: 229 mAh
+Full Charge Capacity: 232 mAh
+Run time to empty: Battery is not being discharged 
+Average time to empty: 18 min 
+Average Time to full: Battery is not being charged 
+Cycle Count: 7
+Max Error = 0 %
+Remaining Capacity Alarm = 0 mAh
+Remining Time Alarm = 0 Min
+
+BBU Design Info for Adapter: 0
+
+Date of Manufacture: 07/18, 2011
+Design Capacity: 90 mAh
+Design Voltage: 0 mV
+Specification Info: 0
+Serial Number: 0
+Pack Stat Configuration: 0x0000
+Manufacture Name: 
+Device Name: 
+Device Chemistry: 
+Battery FRU: N/A
+
+
+BBU Properties for Adapter: 0
+
+Auto Learn Period: 7776000 Sec
+Next Learn time: 540215340 Sec 
+Learn Delay Interval:0 Hours
+Auto-Learn Mode: Enabled
+
+Exit Code: 0x00

--- a/collector/megacli_test.go
+++ b/collector/megacli_test.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	testMegaCliAdapter = "fixtures/megacli_adapter.txt"
+	testMegaCliBattery = "fixtures/megacli_battery.txt"
 	testMegaCliDisks   = "fixtures/megacli_disks.txt"
 
 	physicalDevicesExpected = "5"
@@ -47,6 +48,21 @@ func TestMegaCliAdapter(t *testing.T) {
 
 	if stats["Device Present"]["Degraded"] != virtualDevicesDegraded {
 		t.Fatalf("Unexpected degraded device count: %s != %s", stats["Device Present"]["Degraded"], virtualDevicesDegraded)
+	}
+}
+
+func TestMegaCliBattery(t *testing.T) {
+	data, err := os.Open(testMegaCliBattery)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats := parseMegaCliBattery(data)
+
+	if stats[""]["Voltage"] != "3934 mV" {
+		t.Fatalf("Unexpected voltage: %s != %s", stats[""]["Voltage"], "3934 mV")
+	}
+	if stats["BBU Firmware Status"]["Voltage"] != "OK" {
+		t.Fatalf("Unexpected voltage: %s != %s", stats["BBU Firmware Status"]["Voltage"], "OK")
 	}
 }
 


### PR DESCRIPTION
While replacing some of our existing Icinga-based alerts with ones based
on Prometheus, we noticed that the MegaCLI exporter doesn't provide
insight in battery-related metrics.

This change adds metrics for some of the basic battery parameters
(voltage, current, temperature). Here at work we're also interested in
having a metric for whether periodic learning is required, as we'd
like to perform that manually, rather than letting the card do that
during office hours.

Also hook up the existing adapter statistics to the end-to-end test.