### PR TITLE
hwmon: Provide annotation metric to link chip sysfs paths to human-readable chip types

### DIFF
--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -477,6 +477,11 @@ node_filefd_maximum 1.631329e+06
 # HELP node_forks Total number of forks.
 # TYPE node_forks counter
 node_forks 26442
+# HELP node_hwmon_chip_names Annotation metric for human-readable chip names
+# TYPE node_hwmon_chip_names gauge
+node_hwmon_chip_names{chip="nct6779",chip_name="nct6779"} 1
+node_hwmon_chip_names{chip="platform_coretemp_0",chip_name="coretemp"} 1
+node_hwmon_chip_names{chip="platform_coretemp_1",chip_name="coretemp"} 1
 # HELP node_hwmon_fan_alarm Hardware sensor alarm status (fan)
 # TYPE node_hwmon_fan_alarm gauge
 node_hwmon_fan_alarm{chip="nct6779",sensor="fan2"} 0

--- a/collector/hwmon_linux.go
+++ b/collector/hwmon_linux.go
@@ -36,6 +36,7 @@ var (
 	hwmonInvalidMetricChars = regexp.MustCompile("[^a-z0-9:_]")
 	hwmonFilenameFormat     = regexp.MustCompile(`^(?P<type>[^0-9]+)(?P<id>[0-9]*)?(_(?P<property>.+))?$`)
 	hwmonLabelDesc          = []string{"chip", "sensor"}
+	hwmonChipNameLabelDesc  = []string{"chip", "chip_name"}
 	hwmonSensorTypes        = []string{
 		"vrm", "beep_enable", "update_interval", "in", "cpu", "fan",
 		"pwm", "temp", "curr", "power", "energy", "humidity",
@@ -141,6 +142,26 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) (e
 		if err != nil {
 			return err
 		}
+	}
+
+	hwmonChipName, err := c.hwmonHumanReadableChipName(dir)
+
+	if err == nil {
+		// sensor chip metadata
+		desc := prometheus.NewDesc(
+			"node_hwmon_chip_names",
+			"Annotation metric for human-readable chip names",
+			hwmonChipNameLabelDesc,
+			nil,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			desc,
+			prometheus.GaugeValue,
+			1.0,
+			hwmonName,
+			hwmonChipName,
+		)
 	}
 
 	// format all sensors
@@ -349,6 +370,27 @@ func (c *hwMonCollector) hwmonName(dir string) (string, error) {
 		return cleanName, nil
 	}
 	return "", errors.New("Could not derive a monitoring name for " + dir)
+}
+
+func (c *hwMonCollector) hwmonHumanReadableChipName(dir string) (string, error) {
+	// this is similar to the methods in hwmonName, but with different
+	// precedences -- we can allow duplicates here.
+
+	// preference 1: is there a name file
+
+	sysnameRaw, nameErr := ioutil.ReadFile(path.Join(dir, "name"))
+	if nameErr != nil {
+		return "", nameErr
+	}
+
+	if string(sysnameRaw) != "" {
+		cleanName := cleanMetricName(string(sysnameRaw))
+		if cleanName != "" {
+			return cleanName, nil
+		}
+	}
+
+	return "", errors.New("Could not derive a human-readable chip type for " + dir)
 }
 
 func (c *hwMonCollector) Update(ch chan<- prometheus.Metric) (err error) {


### PR DESCRIPTION
The chip label generation has been changed in #334 to prefer the unique device path (e.g. the location on the PCI bus) due to #333.

After discussion in #355, we learnt that the way forward is to provide an annotation metric (instead of a new label on the existing metrics). The annotation metric allows to link the unique chip sysfs path to a human-readable chip type which may not be unique among chip sysfs paths (for example, dual-slot systems have multiple chipType="coretemp" sensors).

This allows to mitigate the downsides of the solution to #333 (namely that the device path may not be stable across kernels and reboots) for cases where it does not matter that multiple devices may have the same human-readable type (e.g. aggregation or where at most one device of a type is present).

For cases where no human-readable type can be derived, the annotation metric is not emitted.

(**Note:** The below examples have been modified to match the most recent commits in this pull request.)

The annotation metric can be used in queries like this:

1. Find the voltages of a nouveau-driven GPU:

        node_hwmon_in_volts and on (chip) node_hwmon_chip_names{chip_name="nouveau"}

2. Find the temperatures of a GPU using the amdgpu driver:

        node_hwmon_temp_celsius and on (chip) node_hwmon_chip_names{chip_name="amdgpu"}

3. Find all CPU temperatures:

        node_hwmon_temp_celsius and on (chip) node_hwmon_chip_names{chip_name="coretemp"}