### PR TITLE
mips64 build fix

### DIFF
--- a/collector/uname_linux_int8.go
+++ b/collector/uname_linux_int8.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !nouname,linux,386 !nouname,linux,amd64 !nouname,linux,arm64
+// +build !nouname,linux,386 !nouname,linux,amd64 !nouname,linux,arm64 !nouname,linux,mips64 !nouname,linux,mips64le
 
 package collector
 


### PR DESCRIPTION
Just a quick drive-by fix for the linux/mips64 builds so I can export metrics from my EdgeRouter :smile: