### PR TITLE
add scripts to generate binary executable for docker

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -6,10 +6,11 @@ ENV GOPATH /go
 ENV CGO_ENABLED=0
 
 ARG ldflags=""
+ARG tags=""
 
 ADD . /go/src/github.com/prometheus/node_exporter
 RUN go get -d github.com/prometheus/node_exporter
-RUN go build -ldflags "${ldflags}" -o /bin/node_exporter github.com/prometheus/node_exporter
+RUN go build -ldflags "${ldflags}" -tags "${tags}" -o /bin/node_exporter github.com/prometheus/node_exporter
 
 
 CMD /bin/cat

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,16 @@
+FROM golang:alpine
+
+RUN apk add --update git
+
+ENV GOPATH /go
+ENV CGO_ENABLED=0
+
+ARG ldflags=""
+
+ADD . /go/src/github.com/prometheus/node_exporter
+RUN go get -d github.com/prometheus/node_exporter
+RUN go build -ldflags "${ldflags}" -o /bin/node_exporter github.com/prometheus/node_exporter
+
+
+CMD /bin/cat
+

--- a/build_docker_executable.sh
+++ b/build_docker_executable.sh
@@ -36,6 +36,11 @@ export GO_LD_FLAGS
 
 echo "Building static binary executable as docker image build..."
 docker build -t ${DOCKER_TAG} --build-arg ldflags="${LDFLAGS}" -f Dockerfile.build .
+if [ $? != 0 ]
+then
+	echo "Failed to build docker image with binary executable" >&2
+	exit 1
+fi
 
 echo "Running idle build image container in order to access its contents..."
 CONTAINER_ID=`docker run -d -t ${DOCKER_TAG}`

--- a/build_docker_executable.sh
+++ b/build_docker_executable.sh
@@ -4,14 +4,20 @@
 #
 # Needed for generating docker images in non-linux environments (osx, windows, etc.)
 #
-# Usage: ./build_docker_executable.sh [options]
+# Usage: ./build_docker_executable.sh [options] ...
 #
 # Options:
 #
-#   stripped
-#     produces a smaller binary, stripped of debug info
+#   ldflags=<value>
+#     values to pass with -ldflags for "go build"
 #
-
+#   tags=<value>
+#     values to pass with -tags for "go build" (-s for stripped binary executable)
+#
+# Example:
+#
+#   ./build_docker_executable.sh ldflags="-s" tags="noloadavg notime"
+#
 
 GITHUB_USER="prometheus"
 GITHUB_REPO="node_exporter"
@@ -22,20 +28,44 @@ GITHUB_PATH="${GITHUB_USER}/${GITHUB_REPO}"
 EXE_PATH="/bin/${GITHUB_REPO}"
 
 LDFLAGS=""
+TAGS=""
 for arg in "${@}"
 do
-	case $arg in
-		stripped)
-			LDFLAGS="${LDFLAGS} -s"
+	echo "$arg" | grep = > /dev/null
+	if [ $? != 0 ]
+	then
+		echo "Invalid argument passed: $arg"
+		exit 1
+	fi
+	key=`echo "$arg" | awk -F= '{ print $1 }'`
+	value=`echo "$arg" | awk -F= '{ $1=""; print substr($0,1) }'`
+	if [ "$key" = "" ]
+	then
+		echo "Empty key passed.  Expected key=value."
+		exit 1
+	fi
+	if [ "$value" = "" ]
+	then
+		echo "Empty value passed for $key.  Expected key=value."
+		exit 1
+	fi
+	case $key in
+		ldflags)
+			LDFLAGS="$value"
+			;;
+		tags)
+			TAGS="$value"
+			;;
+		*)
+			echo "Invalid option: $key"
+			exit 1
 			;;
 	esac
 	
 done
 
-export GO_LD_FLAGS
-
 echo "Building static binary executable as docker image build..."
-docker build -t ${DOCKER_TAG} --build-arg ldflags="${LDFLAGS}" -f Dockerfile.build .
+docker build -t ${DOCKER_TAG} --build-arg ldflags="${LDFLAGS}" --build-arg tags="${TAGS}" -f Dockerfile.build .
 if [ $? != 0 ]
 then
 	echo "Failed to build docker image with binary executable" >&2

--- a/build_docker_executable.sh
+++ b/build_docker_executable.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+#
+# Attempts to generate static binary executable suitable for use in docker images.
+#
+# Needed for generating docker images in non-linux environments (osx, windows, etc.)
+#
+# Usage: ./build_docker_executable.sh [options]
+#
+# Options:
+#
+#   stripped
+#     produces a smaller binary, stripped of debug info
+#
+
+
+GITHUB_USER="prometheus"
+GITHUB_REPO="node_exporter"
+LOCAL_TARGET="./node_exporter"
+
+DOCKER_TAG="${GITHUB_REPO}_build"
+GITHUB_PATH="${GITHUB_USER}/${GITHUB_REPO}"
+EXE_PATH="/bin/${GITHUB_REPO}"
+
+LDFLAGS=""
+for arg in "${@}"
+do
+	case $arg in
+		stripped)
+			LDFLAGS="${LDFLAGS} -s"
+			;;
+	esac
+	
+done
+
+export GO_LD_FLAGS
+
+echo "Building static binary executable as docker image build..."
+docker build -t ${DOCKER_TAG} --build-arg ldflags="${LDFLAGS}" -f Dockerfile.build .
+
+echo "Running idle build image container in order to access its contents..."
+CONTAINER_ID=`docker run -d -t ${DOCKER_TAG}`
+if [ -z "${CONTAINER_ID}" ]
+then
+	echo "Failed to get static build container id" >&2
+	exit 1
+fi
+
+echo "Copying static binary executable out of build image container..."
+docker cp ${CONTAINER_ID}:${EXE_PATH} ${LOCAL_TARGET}
+if [ $? != 0 ]
+then
+	echo "Failed to cp ${EXE_PATH} out of static build container" >&2
+	exit 1
+fi
+
+echo "Stopping build image container..."
+docker stop ${CONTAINER_ID}
+if [ $? != 0 ]
+then
+	echo "Failed to stop static build container" >&2
+	exit 1
+fi
+
+echo "Destroying build image container..."
+docker rm ${CONTAINER_ID}
+if [ $? != 0 ]
+then
+	echo "Failed to remove static build container" >&2
+	exit 1
+fi
+
+echo "Getting build image id..."
+IMAGE_ID=`docker images -q ${DOCKER_TAG}`
+if [ -z "${IMAGE_ID}" ]
+then
+	echo "Failed to determine static build image id" >&2
+	exit 1
+fi
+
+echo "Destroying build image..."
+docker rmi ${IMAGE_ID}
+if [ $? != 0 ]
+then
+	echo "Failed to remove static build image" >&2
+	exit 1
+fi
+
+echo "Finished build of ${LOCAL_TARGET}"

--- a/build_docker_executable.sh
+++ b/build_docker_executable.sh
@@ -12,11 +12,32 @@
 #     values to pass with -ldflags for "go build"
 #
 #   tags=<value>
-#     values to pass with -tags for "go build" (-s for stripped binary executable)
+#     values to pass with -tags for "go build"
 #
 # Example:
 #
 #   ./build_docker_executable.sh ldflags="-s" tags="noloadavg notime"
+#
+# NOTE that if a part of this process, like the docker/go build, fails, the script
+# will abort, and, depending on where the failure occurred, you may have to clean
+# up one or more of the following:
+#
+#   * a docker container with node_exporter_build image, to stop
+#     check: docker ps
+#     fix: docker stop <containerID>
+#
+#   * a docker container with node_exporter_build image, to delete
+#     check: docker ps -a
+#     fix: docker rm <containerID>
+#
+#   * a docker image node_exporter_build, to delete (docker rmi)
+#     check: docker images node_exporter_build
+#     fix: docker rmi <imageID>
+#
+# Tips:
+#
+# * including "-s" in ldflags will produce a binary stripped of debug information,
+#   which can reduce size of a ~12mb executable to ~7mb.
 #
 
 GITHUB_USER="prometheus"


### PR DESCRIPTION
Scripted build of node_exporter binary executable for use with docker:

- OS-independent ("go build" is performed in a container)
- Optionally produces smaller binaries by stripping debug information