### PR TITLE
Add runit service dir flag

### DIFF
--- a/collector/runit.go
+++ b/collector/runit.go
@@ -16,10 +16,17 @@
 package collector
 
 import (
+	"flag"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"github.com/soundcloud/go-runit/runit"
 )
+
+var runitServiceDir = flag.String(
+	"collector.runit.servicecdir",
+	"/etc/service",
+	"Path to runit service directory.")
 
 type runitCollector struct {
 	state, stateDesired, stateNormal, stateTimestamp *prometheus.GaugeVec
@@ -81,7 +88,7 @@ func NewRunitCollector() (Collector, error) {
 }
 
 func (c *runitCollector) Update(ch chan<- prometheus.Metric) error {
-	services, err := runit.GetServices("/etc/service")
+	services, err := runit.GetServices(*runitServiceDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This closes #362

While the runit collect probably will get deprecated soon, this should have had a flag from day 1 so I think it's fair to add this for now.