### PR TITLE
Use POSIX "command" instead of non-standard "which"

### DIFF
--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -100,10 +100,10 @@ EOF
 trap finish EXIT
 
 get() {
-  if which curl > /dev/null 2>&1
+  if command -v curl > /dev/null 2>&1
   then
     curl -s -f "$@"
-  elif which wget > /dev/null 2>&1
+  elif command -v wget > /dev/null 2>&1
   then
     wget -O - "$@"
   else


### PR DESCRIPTION
`which` is not installed by default on a base Arch Linux installation:

```
time="2016-12-21T18:35:36+01:00" level=info msg="Listening on 127.0.0.1:16199" source="node_exporter.go:176"
=========================
make: *** [Makefile:36: test-e2e] Fehler 1
Build step 'Shell ausführen' marked build as failure
```

whereas `command` is part of any POSIX shell