### PR TITLE
Ignore autofs filesystems on linux

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	defIgnoredMountPoints = "^/(sys|proc|dev)($|/)"
-	defIgnoredFSTypes     = "^(sys|proc)fs$"
+	defIgnoredFSTypes     = "^(sys|proc|auto)fs$"
 	ST_RDONLY             = 0x1
 )
 


### PR DESCRIPTION
node_exporter currently triggers autofs to mount the underlying
filesystem on every scrape. This is undesirable. Better ignore autofs.

The underlying filesystem that autofs mounts will be monitored though,
when the (real) filesystem is mounted.