### PR TITLE
Replace some FreeBSD collectors with pure Go versions

### DIFF
--- a/collector/loadavg_freebsd.go
+++ b/collector/loadavg_freebsd.go
@@ -1,0 +1,27 @@
+// +build !noloadavg
+
+package collector
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func getLoad() ([]float64, error) {
+	type loadavg struct {
+		load  [3]uint32
+		scale int
+	}
+	b, err := unix.SysctlRaw("vm.loadavg")
+	if err != nil {
+		return nil, err
+	}
+	load := *(*loadavg)(unsafe.Pointer((&b[0])))
+	scale := float64(load.scale)
+	return []float64{
+		float64(load.load[0]) / scale,
+		float64(load.load[1]) / scale,
+		float64(load.load[2]) / scale,
+	}, nil
+}

--- a/collector/loadavg_unix.go
+++ b/collector/loadavg_unix.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin dragonfly freebsd netbsd openbsd solaris
+// +build darwin dragonfly netbsd openbsd solaris
 // +build !noloadavg
 
 package collector

--- a/collector/meminfo_bsd.go
+++ b/collector/meminfo_bsd.go
@@ -17,29 +17,11 @@
 package collector
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sys/unix"
 )
-
-/*
-#include <stddef.h>
-#include <sys/sysctl.h>
-
-int _sysctl(const char* name) {
-        int val;
-        size_t size = sizeof(val);
-        int res = sysctlbyname(name, &val, &size, NULL, 0);
-        if (res == -1) {
-                return -1;
-        }
-        if (size != sizeof(val)) {
-                return -2;
-        }
-        return val;
-}
-*/
-import "C"
 
 const (
 	memInfoSubsystem = "memory"
@@ -58,34 +40,20 @@ func NewMeminfoCollector() (Collector, error) {
 }
 
 func (c *meminfoCollector) Update(ch chan<- prometheus.Metric) (err error) {
-	var pages map[string]C.int
-	pages = make(map[string]C.int)
+	pages := make(map[string]uint32)
 
-	size := C._sysctl(C.CString("vm.stats.vm.v_page_size"))
-	if size == -1 {
-		return errors.New("sysctl(vm.stats.vm.v_page_size) failed")
+	size, err := unix.SysctlUint32("vm.stats.vm.v_page_size")
+	if err != nil {
+		return fmt.Errorf("sysctl(vm.stats.vm.v_page_size) failed: %s", err)
 	}
-	if size == -2 {
-		return errors.New("sysctl(vm.stats.vm.v_page_size) failed, wrong buffer size")
-	}
-
-	pages["active"] = C._sysctl(C.CString("vm.stats.vm.v_active_count"))
-	pages["inactive"] = C._sysctl(C.CString("vm.stats.vm.v_inactive_count"))
-	pages["wire"] = C._sysctl(C.CString("vm.stats.vm.v_wire_count"))
-	pages["cache"] = C._sysctl(C.CString("vm.stats.vm.v_cache_count"))
-	pages["free"] = C._sysctl(C.CString("vm.stats.vm.v_free_count"))
-	pages["swappgsin"] = C._sysctl(C.CString("vm.stats.vm.v_swappgsin"))
-	pages["swappgsout"] = C._sysctl(C.CString("vm.stats.vm.v_swappgsout"))
-	pages["total"] = C._sysctl(C.CString("vm.stats.vm.v_page_count"))
-
-	for key := range pages {
-		if pages[key] == -1 {
-			return errors.New("sysctl() failed for " + key)
-		}
-		if pages[key] == -2 {
-			return errors.New("sysctl() failed for " + key + ", wrong buffer size")
-		}
-	}
+	pages["active"], _ = unix.SysctlUint32("vm.stats.vm.v_active_count")
+	pages["inactive"], _ = unix.SysctlUint32("vm.stats.vm.v_inactive_count")
+	pages["wire"], _ = unix.SysctlUint32("vm.stats.vm.v_wire_count")
+	pages["cache"], _ = unix.SysctlUint32("vm.stats.vm.v_cache_count")
+	pages["free"], _ = unix.SysctlUint32("vm.stats.vm.v_free_count")
+	pages["swappgsin"], _ = unix.SysctlUint32("vm.stats.vm.v_swappgsin")
+	pages["swappgsout"], _ = unix.SysctlUint32("vm.stats.vm.v_swappgsout")
+	pages["total"], _ = unix.SysctlUint32("vm.stats.vm.v_page_count")
 
 	for k, v := range pages {
 		ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
This PR replaces the loadavg and filesystem collectors for FreeBSD with pure Go versions, using syscalls and sysctl directly.

It is possible that these may also work for other BSDs without changes, but I don't have any machines to test that on.

I use `unsafe` in two places, once for endianness reasons (loadavg) and once to avoid some memory allocations (file systems). I'm happy to remove either of those.