### PR TITLE
Refactor meminfo and add darwin metrics

### DIFF
--- a/collector/meminfo.go
+++ b/collector/meminfo.go
@@ -1,0 +1,60 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !nomeminfo
+
+package collector
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+)
+
+const (
+	memInfoSubsystem = "memory"
+)
+
+type meminfoCollector struct{}
+
+func init() {
+	Factories["meminfo"] = NewMeminfoCollector
+}
+
+// Takes a prometheus registry and returns a new Collector exposing
+// memory stats.
+func NewMeminfoCollector() (Collector, error) {
+	return &meminfoCollector{}, nil
+}
+
+// Update calls (*meminfoCollector).getMemInfo to get the platform specific
+// memory metrics.
+func (c *meminfoCollector) Update(ch chan<- prometheus.Metric) (err error) {
+	memInfo, err := c.getMemInfo()
+	if err != nil {
+		return fmt.Errorf("couldn't get meminfo: %s", err)
+	}
+	log.Debugf("Set node_mem: %#v", memInfo)
+	for k, v := range memInfo {
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				prometheus.BuildFQName(Namespace, memInfoSubsystem, k),
+				fmt.Sprintf("Memory information field %s.", k),
+				nil, nil,
+			),
+			prometheus.GaugeValue, v,
+		)
+	}
+	return nil
+}

--- a/collector/meminfo.go
+++ b/collector/meminfo.go
@@ -32,8 +32,7 @@ func init() {
 	Factories["meminfo"] = NewMeminfoCollector
 }
 
-// Takes a prometheus registry and returns a new Collector exposing
-// memory stats.
+// NewMeminfoCollector returns a new Collector exposing memory stats.
 func NewMeminfoCollector() (Collector, error) {
 	return &meminfoCollector{}, nil
 }

--- a/collector/meminfo_bsd.go
+++ b/collector/meminfo_bsd.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build freebsd darwin,amd64 dragonfly
+// +build darwin freebsd dragonfly
 // +build !nomeminfo
 
 package collector
@@ -19,52 +19,33 @@ package collector
 import (
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/unix"
 )
 
-const (
-	memInfoSubsystem = "memory"
-)
-
-type meminfoCollector struct{}
-
-func init() {
-	Factories["meminfo"] = NewMeminfoCollector
-}
-
-// Takes a prometheus registry and returns a new Collector exposing
-// Memory stats.
-func NewMeminfoCollector() (Collector, error) {
-	return &meminfoCollector{}, nil
-}
-
-func (c *meminfoCollector) Update(ch chan<- prometheus.Metric) (err error) {
-	pages := make(map[string]uint32)
+func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
+	info := make(map[string]float64)
 
 	size, err := unix.SysctlUint32("vm.stats.vm.v_page_size")
 	if err != nil {
-		return fmt.Errorf("sysctl(vm.stats.vm.v_page_size) failed: %s", err)
+		return nil, fmt.Errorf("sysctl(vm.stats.vm.v_page_size) failed: %s", err)
 	}
-	pages["active"], _ = unix.SysctlUint32("vm.stats.vm.v_active_count")
-	pages["inactive"], _ = unix.SysctlUint32("vm.stats.vm.v_inactive_count")
-	pages["wire"], _ = unix.SysctlUint32("vm.stats.vm.v_wire_count")
-	pages["cache"], _ = unix.SysctlUint32("vm.stats.vm.v_cache_count")
-	pages["free"], _ = unix.SysctlUint32("vm.stats.vm.v_free_count")
-	pages["swappgsin"], _ = unix.SysctlUint32("vm.stats.vm.v_swappgsin")
-	pages["swappgsout"], _ = unix.SysctlUint32("vm.stats.vm.v_swappgsout")
-	pages["total"], _ = unix.SysctlUint32("vm.stats.vm.v_page_count")
 
-	for k, v := range pages {
-		ch <- prometheus.MustNewConstMetric(
-			prometheus.NewDesc(
-				prometheus.BuildFQName(Namespace, memInfoSubsystem, k),
-				k+" from sysctl()",
-				nil, nil,
-			),
-			// Convert metrics to kB (same as Linux meminfo).
-			prometheus.UntypedValue, float64(v)*float64(size),
-		)
+	for key, v := range map[string]string{
+		"active":     "vm.stats.vm.v_active_count",
+		"inactive":   "vm.stats.vm.v_inactive_count",
+		"wire":       "vm.stats.vm.v_wire_count",
+		"cache":      "vm.stats.vm.v_cache_count",
+		"free":       "vm.stats.vm.v_free_count",
+		"swappgsin":  "vm.stats.vm.v_swappgsin",
+		"swappgsout": "vm.stats.vm.v_swappgsout",
+		"total":      "vm.stats.vm.v_page_count",
+	} {
+		value, err := unix.SysctlUint32(v)
+		if err != nil {
+			return nil, err
+		}
+		// Convert metrics to kB (same as Linux meminfo).
+		info[key] = float64(value) * float64(size)
 	}
-	return err
+	return info, nil
 }

--- a/collector/meminfo_bsd.go
+++ b/collector/meminfo_bsd.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin freebsd dragonfly
+// +build freebsd dragonfly
 // +build !nomeminfo
 
 package collector

--- a/collector/meminfo_darwin.go
+++ b/collector/meminfo_darwin.go
@@ -1,0 +1,59 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !nomeminfo
+
+package collector
+
+// #include <mach/mach_host.h>
+import "C"
+
+import (
+	"encoding/binary"
+	"fmt"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
+	infoCount := C.mach_msg_type_number_t(C.HOST_VM_INFO_COUNT)
+	vmstat := C.vm_statistics_data_t{}
+	ret := C.host_statistics(
+		C.host_t(C.mach_host_self()),
+		C.HOST_VM_INFO,
+		C.host_info_t(unsafe.Pointer(&vmstat)),
+		&infoCount,
+	)
+	if ret != C.KERN_SUCCESS {
+		return nil, fmt.Errorf("Couldn't get memory statistics, host_statistics returned %d", ret)
+	}
+	totalb, err := unix.Sysctl("hw.memsize")
+	if err != nil {
+		return nil, err
+	}
+	// Syscall removes terminating NUL which we need to cast to uint64
+	total := binary.LittleEndian.Uint64([]byte(totalb + "\x00"))
+
+	ps := C.natural_t(syscall.Getpagesize())
+	return map[string]float64{
+		"active_bytes_total":      float64(ps * vmstat.active_count),
+		"inactive_bytes_total":    float64(ps * vmstat.inactive_count),
+		"wired_bytes_total":       float64(ps * vmstat.wire_count),
+		"free_bytes_total":        float64(ps * vmstat.free_count),
+		"swapped_in_pages_total":  float64(ps * vmstat.pageins),
+		"swapped_out_pages_total": float64(ps * vmstat.pageouts),
+		"bytes_total":             float64(total),
+	}, nil
+}

--- a/collector/meminfo_linux.go
+++ b/collector/meminfo_linux.go
@@ -23,47 +23,9 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
-const (
-	memInfoSubsystem = "memory"
-)
-
-type meminfoCollector struct{}
-
-func init() {
-	Factories["meminfo"] = NewMeminfoCollector
-}
-
-// Takes a prometheus registry and returns a new Collector exposing
-// memory stats.
-func NewMeminfoCollector() (Collector, error) {
-	return &meminfoCollector{}, nil
-}
-
-func (c *meminfoCollector) Update(ch chan<- prometheus.Metric) (err error) {
-	memInfo, err := getMemInfo()
-	if err != nil {
-		return fmt.Errorf("couldn't get meminfo: %s", err)
-	}
-	log.Debugf("Set node_mem: %#v", memInfo)
-	for k, v := range memInfo {
-		ch <- prometheus.MustNewConstMetric(
-			prometheus.NewDesc(
-				prometheus.BuildFQName(Namespace, memInfoSubsystem, k),
-				fmt.Sprintf("Memory information field %s.", k),
-				nil, nil,
-			),
-			prometheus.GaugeValue, v,
-		)
-	}
-	return nil
-}
-
-func getMemInfo() (map[string]float64, error) {
+func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 	file, err := os.Open(procFilePath("meminfo"))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Instead of doing the whole metric exposition in a platform specific collector implementation, this creates and updates the metrics in meminfo.go and expected a platform specific implementation of getMemInfo on *meminfoCollector.

The second commit adds meminfo metrics on Darwin.

This closes #386 

---
Now I'm not sure about those metrics in general.. It would be much nicer to have a metric that is summed across all dimensions the total memory, basically something like node_memory_bytes_total{area="wire|cache|used.."}.

We decided against this for linux since we just exposed raw procfs values since it seems futile to track all changes there and add whatever was split out from some metrics. Now for all the bsds, we explicitly refer to some vmstat struct fields, so it doesn't really matter if we expose each as flat metrics or one metric with each memory areas as their own field. The only downside I see is breaking the existing metrics. We could also keep the old metrics and add a new one.

Any thoughts on that?
