### PR TITLE
Fix Makefile by using first element of GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GO    ?= GO15VENDOREXPERIMENT=1 go
-PROMU ?= $(GOPATH)/bin/promu
-pkgs   = $(shell $(GO) list ./... | grep -v /vendor/)
+GO     ?= GO15VENDOREXPERIMENT=1 go
+GOPATH := $(firstword $(subst :, ,$(GOPATH)))
+PROMU  ?= $(GOPATH)/bin/promu
+pkgs    = $(shell $(GO) list ./... | grep -v /vendor/)
 
 PREFIX                  ?= $(shell pwd)
 BIN_DIR                 ?= $(shell pwd)


### PR DESCRIPTION
If GOPATH includes multiple paths, running `make promu` would fail.
This fixes it by always using the first path.