### PR TITLE
Make sure we only return one metric per mounted fs

### DIFF
--- a/collector/filesystem_bsd.go
+++ b/collector/filesystem_bsd.go
@@ -66,15 +66,18 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 			ro = 1
 		}
 
-		labelValues := []string{device, mountpoint, fstype}
 		stats = append(stats, filesystemStats{
-			labelValues: labelValues,
-			size:        float64(mnt[i].f_blocks) * float64(mnt[i].f_bsize),
-			free:        float64(mnt[i].f_bfree) * float64(mnt[i].f_bsize),
-			avail:       float64(mnt[i].f_bavail) * float64(mnt[i].f_bsize),
-			files:       float64(mnt[i].f_files),
-			filesFree:   float64(mnt[i].f_ffree),
-			ro:          ro,
+			labels: filesystemLabels{
+				device:     device,
+				mountPoint: mountpoint,
+				fsType:     fstype,
+			},
+			size:      float64(mnt[i].f_blocks) * float64(mnt[i].f_bsize),
+			free:      float64(mnt[i].f_bfree) * float64(mnt[i].f_bsize),
+			avail:     float64(mnt[i].f_bavail) * float64(mnt[i].f_bsize),
+			files:     float64(mnt[i].f_files),
+			filesFree: float64(mnt[i].f_ffree),
+			ro:        ro,
 		})
 	}
 	return stats, nil

--- a/collector/filesystem_freebsd.go
+++ b/collector/filesystem_freebsd.go
@@ -73,15 +73,18 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 			ro = 1
 		}
 
-		labelValues := []string{device, mountpoint, fstype}
 		stats = append(stats, filesystemStats{
-			labelValues: labelValues,
-			size:        float64(fs.Blocks) * float64(fs.Bsize),
-			free:        float64(fs.Bfree) * float64(fs.Bsize),
-			avail:       float64(fs.Bavail) * float64(fs.Bsize),
-			files:       float64(fs.Files),
-			filesFree:   float64(fs.Ffree),
-			ro:          ro,
+			labels: filesystemLabels{
+				device:     device,
+				mountPoint: mountpoint,
+				fsType:     fstype,
+			},
+			size:      float64(fs.Blocks) * float64(fs.Bsize),
+			free:      float64(fs.Bfree) * float64(fs.Bsize),
+			avail:     float64(fs.Bavail) * float64(fs.Bsize),
+			files:     float64(fs.Files),
+			filesFree: float64(fs.Ffree),
+			ro:        ro,
 		})
 	}
 	return stats, nil


### PR DESCRIPTION
Closes #377


--
Now we should also have tests for that. I've tried enabling the filesystem collector in the end to end tests but failed. Somehow it always showed a difference for my root filesystem. Anyone know why the collector isn't included in the tests?
Either way, we should have end-to-end tests for that, but I don't think it should block this bugfix here either.