### PR TITLE
Make wifi collector fail gracefully if metrics not available

### DIFF
--- a/vendor/github.com/mdlayher/wifi/client.go
+++ b/vendor/github.com/mdlayher/wifi/client.go
@@ -1,5 +1,15 @@
 package wifi
 
+import (
+	"errors"
+)
+
+var (
+	// errNotStation is returned when attempting to query station info for
+	// an interface which is not a station.
+	errNotStation = errors.New("interface is not a station")
+)
+
 // A Client is a type which can access WiFi device actions and statistics
 // using operating system-specific operations.
 type Client struct {
@@ -18,6 +28,11 @@ func New() (*Client, error) {
 	}, nil
 }
 
+// Close releases resources used by a Client.
+func (c *Client) Close() error {
+	return c.c.Close()
+}
+
 // Interfaces returns a list of the system's WiFi network interfaces.
 func (c *Client) Interfaces() ([]*Interface, error) {
 	return c.c.Interfaces()
@@ -26,11 +41,16 @@ func (c *Client) Interfaces() ([]*Interface, error) {
 // StationInfo retrieves statistics about a WiFi interface operating in
 // station mode.
 func (c *Client) StationInfo(ifi *Interface) (*StationInfo, error) {
+	if ifi.Type != InterfaceTypeStation {
+		return nil, errNotStation
+	}
+
 	return c.c.StationInfo(ifi)
 }
 
 // An osClient is the operating system-specific implementation of Client.
 type osClient interface {
+	Close() error
 	Interfaces() ([]*Interface, error)
 	StationInfo(ifi *Interface) (*StationInfo, error)
 }

--- a/vendor/github.com/mdlayher/wifi/client_linux.go
+++ b/vendor/github.com/mdlayher/wifi/client_linux.go
@@ -36,6 +36,7 @@ type client struct {
 // genl is an interface over generic netlink, so netlink interactions can
 // be stubbed in tests.
 type genl interface {
+	Close() error
 	GetFamily(name string) (genetlink.Family, error)
 	Execute(m genetlink.Message, family uint16, flags netlink.HeaderFlags) ([]genetlink.Message, error)
 }
@@ -64,6 +65,11 @@ func initClient(c genl) (*client, error) {
 		familyID:      family.ID,
 		familyVersion: family.Version,
 	}, nil
+}
+
+// Close closes the client's generic netlink connection.
+func (c *client) Close() error {
+	return c.c.Close()
 }
 
 // Interfaces requests that nl80211 return a list of all WiFi interfaces present
@@ -117,7 +123,12 @@ func (c *client) StationInfo(ifi *Interface) (*StationInfo, error) {
 		return nil, err
 	}
 
-	if len(msgs) > 1 {
+	switch len(msgs) {
+	case 0:
+		return nil, os.ErrNotExist
+	case 1:
+		break
+	default:
 		return nil, errMultipleMessages
 	}
 

--- a/vendor/github.com/mdlayher/wifi/client_others.go
+++ b/vendor/github.com/mdlayher/wifi/client_others.go
@@ -24,6 +24,11 @@ func newClient() (*client, error) {
 	return nil, errUnimplemented
 }
 
+// Close always returns an error.
+func (c *client) Close() error {
+	return errUnimplemented
+}
+
 // Interfaces always returns an error.
 func (c *client) Interfaces() ([]*Interface, error) {
 	return nil, errUnimplemented

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -51,10 +51,10 @@
 			"revisionTime": "2016-04-24T11:30:07Z"
 		},
 		{
-			"checksumSHA1": "87nUxyFGVJFXB6MQpGCGUHi5NY0=",
+			"checksumSHA1": "n31d2o+dY0HXZTDWE5Rc0+7NEjc=",
 			"path": "github.com/mdlayher/netlink",
-			"revision": "a65cbc3bb3f7a793b7d79ad7d19b16d471ddbd78",
-			"revisionTime": "2017-01-10T22:29:47Z"
+			"revision": "e5da4eb480835e5bce0dc5e526fe5f9a8002b54e",
+			"revisionTime": "2017-01-13T17:56:52Z"
 		},
 		{
 			"checksumSHA1": "+2roeIWCAjCC58tZcs12Vqgf1Io=",
@@ -69,10 +69,10 @@
 			"revisionTime": "2017-01-04T04:59:06Z"
 		},
 		{
-			"checksumSHA1": "dSy4F6HRYyadhiQbv3Bof/Tdxec=",
+			"checksumSHA1": "l8M/rZH5s/ZVtCCyeiUQXZ5FosA=",
 			"path": "github.com/mdlayher/wifi",
-			"revision": "88fd1c0ec178645c1b7d300090b5a9d4b226b8e1",
-			"revisionTime": "2017-01-07T15:17:58Z"
+			"revision": "eb8b29b956ba5ff2fdd2d2f1f0b988b57fd3d8a3",
+			"revisionTime": "2017-01-12T20:47:29Z"
 		},
 		{
 			"checksumSHA1": "VzutdH69PUqRqhrDVv6F91ebQd4=",


### PR DESCRIPTION
Had to update `wifi` because I forgot to add a `Close` method until now.  Oops.

Looks good on my machine that doesn't have nl80211.

```
$ genl-ctrl-list
0x0010 nlctrl version 2
0x0011 VFS_DQUOT version 1
0x0013 NLBL_MGMT version 3
0x0014 NLBL_CIPSOv4 version 3
0x0015 NLBL_UNLBL version 3
0x0016 acpi_event version 1
0x0017 thermal_event version 1
0x0018 tcp_metrics version 1
0x0019 TASKSTATS version 1
$ ./node_exporter -collectors.enabled wifi
INFO[0000] Starting node_exporter (version=, branch=, revision=)  source="node_exporter.go:136"
INFO[0000] Build context (go=go1.7.4, user=, date=)      source="node_exporter.go:137"
INFO[0000] Enabled collectors:                           source="node_exporter.go:156"
INFO[0000]  - wifi                                       source="node_exporter.go:158"
INFO[0000] Listening on :9100                            source="node_exporter.go:176"
```

Fixes #416 .