### PR TITLE
Make ZFS collector fail gracefully when not available

### DIFF
--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -63,10 +63,6 @@ func NewZFSCollector() (Collector, error) {
 func (c *zfsCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	// Arcstats
 	err = c.updateArcstats(ch)
-	if err != nil {
-		return err
-	}
-
 	switch {
 	case err == zfsNotAvailableError:
 		log.Debug(err)


### PR DESCRIPTION
Appears to have just been a simple mistake, since the switch below handles this case.

```
$ ./node_exporter -log.level debug
INFO[0000] Starting node_exporter (version=, branch=, revision=)  source="node_exporter.go:136"
INFO[0000] Build context (go=go1.7.4, user=, date=)      source="node_exporter.go:137"
INFO[0000] No directory specified, see --collector.textfile.directory  source="textfile.go:57"
INFO[0000] Enabled collectors:                           source="node_exporter.go:156"
INFO[0000]  - edac                                       source="node_exporter.go:158"
INFO[0000]  - loadavg                                    source="node_exporter.go:158"
INFO[0000]  - netdev                                     source="node_exporter.go:158"
INFO[0000]  - netstat                                    source="node_exporter.go:158"
INFO[0000]  - sockstat                                   source="node_exporter.go:158"
INFO[0000]  - stat                                       source="node_exporter.go:158"
INFO[0000]  - mdadm                                      source="node_exporter.go:158"
INFO[0000]  - uname                                      source="node_exporter.go:158"
INFO[0000]  - zfs                                        source="node_exporter.go:158"
INFO[0000]  - entropy                                    source="node_exporter.go:158"
INFO[0000]  - meminfo                                    source="node_exporter.go:158"
INFO[0000]  - textfile                                   source="node_exporter.go:158"
INFO[0000]  - conntrack                                  source="node_exporter.go:158"
INFO[0000]  - diskstats                                  source="node_exporter.go:158"
INFO[0000]  - filefd                                     source="node_exporter.go:158"
INFO[0000]  - filesystem                                 source="node_exporter.go:158"
INFO[0000]  - hwmon                                      source="node_exporter.go:158"
INFO[0000]  - time                                       source="node_exporter.go:158"
INFO[0000]  - vmstat                                     source="node_exporter.go:158"
INFO[0000] Listening on :9100                            source="node_exporter.go:176"
DEBU[0002] OK: hwmon collector succeeded after 0.000117s.  source="node_exporter.go:95"
DEBU[0002] Cannot open "/proc/spl/kstat/zfs/arcstats" for reading. Is the kernel module loaded?  source="zfs_linux.go:36"
DEBU[0002] ZFS / ZFS statistics are not available        source="zfs.go:68"
```

Fixes #417 .