### PR TITLE
Allow graceful failure in hwmon collector

### DIFF
--- a/collector/hwmon_linux.go
+++ b/collector/hwmon_linux.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 const (
@@ -399,6 +400,11 @@ func (c *hwMonCollector) Update(ch chan<- prometheus.Metric) (err error) {
 
 	hwmonFiles, err := ioutil.ReadDir(hwmonPathName)
 	if err != nil {
+		if os.IsNotExist(err) {
+			log.Debug("hwmon collector metrics are not available for this system")
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
```
$ ./node_exporter -web.listen-address 192.168.1.1:9100 -collectors.enabled hwmon -log.level debug
INFO[0000] Starting node_exporter (version=, branch=, revision=)  source="node_exporter.go:136"
INFO[0000] Build context (go=go1.7.4, user=, date=)      source="node_exporter.go:137"
INFO[0000] Enabled collectors:                           source="node_exporter.go:156"
INFO[0000]  - hwmon                                      source="node_exporter.go:158"
INFO[0000] Listening on 192.168.1.1:9100                 source="node_exporter.go:176"
DEBU[0001] hwmon collector metrics are not available for this system  source="hwmon_linux.go:404"
DEBU[0001] OK: hwmon collector succeeded after 0.002255s.  source="node_exporter.go:95"
```

Fixes #426 