### PR TITLE
Update ZFS Collector with most non-zpool metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ stat | Exposes various statistics from `/proc/stat`. This includes CPU usage, bo
 textfile | Exposes statistics read from local disk. The `--collector.textfile.directory` flag must be set. | _any_
 time | Exposes the current system time. | _any_
 vmstat | Exposes statistics from `/proc/vmstat`. | Linux
-zfs | Exposes [ZFS](http://open-zfs.org/) performance statistics.<br/> Linux (ARC) | [Linux](http://zfsonlinux.org/)
+zfs | Exposes [ZFS](http://open-zfs.org/) performance statistics. | [Linux](http://zfsonlinux.org/)
 
 ### Disabled by default
 

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2383,6 +2383,45 @@ node_zfsFetch_stride_hits 7.06799e+06
 # HELP node_zfsFetch_stride_misses kstat.zfs.misc.zfetchstats.stride_misses
 # TYPE node_zfsFetch_stride_misses untyped
 node_zfsFetch_stride_misses 0
+# HELP node_zfsZil_zil_commit_count kstat.zfs.misc.zil.zil_commit_count
+# TYPE node_zfsZil_zil_commit_count untyped
+node_zfsZil_zil_commit_count 10
+# HELP node_zfsZil_zil_commit_writer_count kstat.zfs.misc.zil.zil_commit_writer_count
+# TYPE node_zfsZil_zil_commit_writer_count untyped
+node_zfsZil_zil_commit_writer_count 0
+# HELP node_zfsZil_zil_itx_copied_bytes kstat.zfs.misc.zil.zil_itx_copied_bytes
+# TYPE node_zfsZil_zil_itx_copied_bytes untyped
+node_zfsZil_zil_itx_copied_bytes 0
+# HELP node_zfsZil_zil_itx_copied_count kstat.zfs.misc.zil.zil_itx_copied_count
+# TYPE node_zfsZil_zil_itx_copied_count untyped
+node_zfsZil_zil_itx_copied_count 0
+# HELP node_zfsZil_zil_itx_count kstat.zfs.misc.zil.zil_itx_count
+# TYPE node_zfsZil_zil_itx_count untyped
+node_zfsZil_zil_itx_count 0
+# HELP node_zfsZil_zil_itx_indirect_bytes kstat.zfs.misc.zil.zil_itx_indirect_bytes
+# TYPE node_zfsZil_zil_itx_indirect_bytes untyped
+node_zfsZil_zil_itx_indirect_bytes 0
+# HELP node_zfsZil_zil_itx_indirect_count kstat.zfs.misc.zil.zil_itx_indirect_count
+# TYPE node_zfsZil_zil_itx_indirect_count untyped
+node_zfsZil_zil_itx_indirect_count 0
+# HELP node_zfsZil_zil_itx_metaslab_normal_bytes kstat.zfs.misc.zil.zil_itx_metaslab_normal_bytes
+# TYPE node_zfsZil_zil_itx_metaslab_normal_bytes untyped
+node_zfsZil_zil_itx_metaslab_normal_bytes 0
+# HELP node_zfsZil_zil_itx_metaslab_normal_count kstat.zfs.misc.zil.zil_itx_metaslab_normal_count
+# TYPE node_zfsZil_zil_itx_metaslab_normal_count untyped
+node_zfsZil_zil_itx_metaslab_normal_count 0
+# HELP node_zfsZil_zil_itx_metaslab_slog_bytes kstat.zfs.misc.zil.zil_itx_metaslab_slog_bytes
+# TYPE node_zfsZil_zil_itx_metaslab_slog_bytes untyped
+node_zfsZil_zil_itx_metaslab_slog_bytes 0
+# HELP node_zfsZil_zil_itx_metaslab_slog_count kstat.zfs.misc.zil.zil_itx_metaslab_slog_count
+# TYPE node_zfsZil_zil_itx_metaslab_slog_count untyped
+node_zfsZil_zil_itx_metaslab_slog_count 0
+# HELP node_zfsZil_zil_itx_needcopy_bytes kstat.zfs.misc.zil.zil_itx_needcopy_bytes
+# TYPE node_zfsZil_zil_itx_needcopy_bytes untyped
+node_zfsZil_zil_itx_needcopy_bytes 0
+# HELP node_zfsZil_zil_itx_needcopy_count kstat.zfs.misc.zil.zil_itx_needcopy_count
+# TYPE node_zfsZil_zil_itx_needcopy_count untyped
+node_zfsZil_zil_itx_needcopy_count 0
 # HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
 # TYPE process_cpu_seconds_total counter
 # HELP process_max_fds Maximum number of open file descriptors.

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2350,6 +2350,39 @@ node_zfsArc_prefetch_metadata_misses 16071
 # HELP node_zfsArc_size kstat.zfs.misc.arcstats.size
 # TYPE node_zfsArc_size untyped
 node_zfsArc_size 1.603939792e+09
+# HELP node_zfsFetch_bogus_streams kstat.zfs.misc.zfetchstats.bogus_streams
+# TYPE node_zfsFetch_bogus_streams untyped
+node_zfsFetch_bogus_streams 0
+# HELP node_zfsFetch_colinear_hits kstat.zfs.misc.zfetchstats.colinear_hits
+# TYPE node_zfsFetch_colinear_hits untyped
+node_zfsFetch_colinear_hits 0
+# HELP node_zfsFetch_colinear_misses kstat.zfs.misc.zfetchstats.colinear_misses
+# TYPE node_zfsFetch_colinear_misses untyped
+node_zfsFetch_colinear_misses 11
+# HELP node_zfsFetch_hits kstat.zfs.misc.zfetchstats.hits
+# TYPE node_zfsFetch_hits untyped
+node_zfsFetch_hits 7.067992e+06
+# HELP node_zfsFetch_misses kstat.zfs.misc.zfetchstats.misses
+# TYPE node_zfsFetch_misses untyped
+node_zfsFetch_misses 11
+# HELP node_zfsFetch_reclaim_failures kstat.zfs.misc.zfetchstats.reclaim_failures
+# TYPE node_zfsFetch_reclaim_failures untyped
+node_zfsFetch_reclaim_failures 11
+# HELP node_zfsFetch_reclaim_successes kstat.zfs.misc.zfetchstats.reclaim_successes
+# TYPE node_zfsFetch_reclaim_successes untyped
+node_zfsFetch_reclaim_successes 0
+# HELP node_zfsFetch_streams_noresets kstat.zfs.misc.zfetchstats.streams_noresets
+# TYPE node_zfsFetch_streams_noresets untyped
+node_zfsFetch_streams_noresets 2
+# HELP node_zfsFetch_streams_resets kstat.zfs.misc.zfetchstats.streams_resets
+# TYPE node_zfsFetch_streams_resets untyped
+node_zfsFetch_streams_resets 0
+# HELP node_zfsFetch_stride_hits kstat.zfs.misc.zfetchstats.stride_hits
+# TYPE node_zfsFetch_stride_hits untyped
+node_zfsFetch_stride_hits 7.06799e+06
+# HELP node_zfsFetch_stride_misses kstat.zfs.misc.zfetchstats.stride_misses
+# TYPE node_zfsFetch_stride_misses untyped
+node_zfsFetch_stride_misses 0
 # HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
 # TYPE process_cpu_seconds_total counter
 # HELP process_max_fds Maximum number of open file descriptors.

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2383,6 +2383,15 @@ node_zfsFetch_stride_hits 7.06799e+06
 # HELP node_zfsFetch_stride_misses kstat.zfs.misc.zfetchstats.stride_misses
 # TYPE node_zfsFetch_stride_misses untyped
 node_zfsFetch_stride_misses 0
+# HELP node_zfsVdevCache_delegations kstat.zfs.misc.vdev_cache_stats.delegations
+# TYPE node_zfsVdevCache_delegations untyped
+node_zfsVdevCache_delegations 40
+# HELP node_zfsVdevCache_hits kstat.zfs.misc.vdev_cache_stats.hits
+# TYPE node_zfsVdevCache_hits untyped
+node_zfsVdevCache_hits 0
+# HELP node_zfsVdevCache_misses kstat.zfs.misc.vdev_cache_stats.misses
+# TYPE node_zfsVdevCache_misses untyped
+node_zfsVdevCache_misses 0
 # HELP node_zfsZil_zil_commit_count kstat.zfs.misc.zil.zil_commit_count
 # TYPE node_zfsZil_zil_commit_count untyped
 node_zfsZil_zil_commit_count 10

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2350,6 +2350,39 @@ node_zfsArc_prefetch_metadata_misses 16071
 # HELP node_zfsArc_size kstat.zfs.misc.arcstats.size
 # TYPE node_zfsArc_size untyped
 node_zfsArc_size 1.603939792e+09
+# HELP node_zfsDmuTx_dmu_tx_assigned kstat.zfs.misc.dmu_tx.dmu_tx_assigned
+# TYPE node_zfsDmuTx_dmu_tx_assigned untyped
+node_zfsDmuTx_dmu_tx_assigned 3.532844e+06
+# HELP node_zfsDmuTx_dmu_tx_delay kstat.zfs.misc.dmu_tx.dmu_tx_delay
+# TYPE node_zfsDmuTx_dmu_tx_delay untyped
+node_zfsDmuTx_dmu_tx_delay 0
+# HELP node_zfsDmuTx_dmu_tx_dirty_delay kstat.zfs.misc.dmu_tx.dmu_tx_dirty_delay
+# TYPE node_zfsDmuTx_dmu_tx_dirty_delay untyped
+node_zfsDmuTx_dmu_tx_dirty_delay 0
+# HELP node_zfsDmuTx_dmu_tx_dirty_over_max kstat.zfs.misc.dmu_tx.dmu_tx_dirty_over_max
+# TYPE node_zfsDmuTx_dmu_tx_dirty_over_max untyped
+node_zfsDmuTx_dmu_tx_dirty_over_max 0
+# HELP node_zfsDmuTx_dmu_tx_dirty_throttle kstat.zfs.misc.dmu_tx.dmu_tx_dirty_throttle
+# TYPE node_zfsDmuTx_dmu_tx_dirty_throttle untyped
+node_zfsDmuTx_dmu_tx_dirty_throttle 0
+# HELP node_zfsDmuTx_dmu_tx_error kstat.zfs.misc.dmu_tx.dmu_tx_error
+# TYPE node_zfsDmuTx_dmu_tx_error untyped
+node_zfsDmuTx_dmu_tx_error 0
+# HELP node_zfsDmuTx_dmu_tx_group kstat.zfs.misc.dmu_tx.dmu_tx_group
+# TYPE node_zfsDmuTx_dmu_tx_group untyped
+node_zfsDmuTx_dmu_tx_group 0
+# HELP node_zfsDmuTx_dmu_tx_memory_reclaim kstat.zfs.misc.dmu_tx.dmu_tx_memory_reclaim
+# TYPE node_zfsDmuTx_dmu_tx_memory_reclaim untyped
+node_zfsDmuTx_dmu_tx_memory_reclaim 0
+# HELP node_zfsDmuTx_dmu_tx_memory_reserve kstat.zfs.misc.dmu_tx.dmu_tx_memory_reserve
+# TYPE node_zfsDmuTx_dmu_tx_memory_reserve untyped
+node_zfsDmuTx_dmu_tx_memory_reserve 0
+# HELP node_zfsDmuTx_dmu_tx_quota kstat.zfs.misc.dmu_tx.dmu_tx_quota
+# TYPE node_zfsDmuTx_dmu_tx_quota untyped
+node_zfsDmuTx_dmu_tx_quota 0
+# HELP node_zfsDmuTx_dmu_tx_suspended kstat.zfs.misc.dmu_tx.dmu_tx_suspended
+# TYPE node_zfsDmuTx_dmu_tx_suspended untyped
+node_zfsDmuTx_dmu_tx_suspended 0
 # HELP node_zfsFetch_bogus_streams kstat.zfs.misc.zfetchstats.bogus_streams
 # TYPE node_zfsFetch_bogus_streams untyped
 node_zfsFetch_bogus_streams 0

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2392,6 +2392,24 @@ node_zfsVdevCache_hits 0
 # HELP node_zfsVdevCache_misses kstat.zfs.misc.vdev_cache_stats.misses
 # TYPE node_zfsVdevCache_misses untyped
 node_zfsVdevCache_misses 0
+# HELP node_zfsXuio_onloan_read_buf kstat.zfs.misc.xuio_stats.onloan_read_buf
+# TYPE node_zfsXuio_onloan_read_buf untyped
+node_zfsXuio_onloan_read_buf 32
+# HELP node_zfsXuio_onloan_write_buf kstat.zfs.misc.xuio_stats.onloan_write_buf
+# TYPE node_zfsXuio_onloan_write_buf untyped
+node_zfsXuio_onloan_write_buf 0
+# HELP node_zfsXuio_read_buf_copied kstat.zfs.misc.xuio_stats.read_buf_copied
+# TYPE node_zfsXuio_read_buf_copied untyped
+node_zfsXuio_read_buf_copied 0
+# HELP node_zfsXuio_read_buf_nocopy kstat.zfs.misc.xuio_stats.read_buf_nocopy
+# TYPE node_zfsXuio_read_buf_nocopy untyped
+node_zfsXuio_read_buf_nocopy 0
+# HELP node_zfsXuio_write_buf_copied kstat.zfs.misc.xuio_stats.write_buf_copied
+# TYPE node_zfsXuio_write_buf_copied untyped
+node_zfsXuio_write_buf_copied 0
+# HELP node_zfsXuio_write_buf_nocopy kstat.zfs.misc.xuio_stats.write_buf_nocopy
+# TYPE node_zfsXuio_write_buf_nocopy untyped
+node_zfsXuio_write_buf_nocopy 0
 # HELP node_zfsZil_zil_commit_count kstat.zfs.misc.zil.zil_commit_count
 # TYPE node_zfsZil_zil_commit_count untyped
 node_zfsZil_zil_commit_count 10

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2077,423 +2077,423 @@ node_wifi_station_transmit_failed_total{device="wlan0"} 2
 # HELP node_wifi_station_transmit_retries_total The total number of times a station has had to retry while sending a packet.
 # TYPE node_wifi_station_transmit_retries_total counter
 node_wifi_station_transmit_retries_total{device="wlan0"} 10
-# HELP node_zfsArc_anon_evictable_data kstat.zfs.misc.arcstats.anon_evictable_data
-# TYPE node_zfsArc_anon_evictable_data untyped
-node_zfsArc_anon_evictable_data 0
-# HELP node_zfsArc_anon_evictable_metadata kstat.zfs.misc.arcstats.anon_evictable_metadata
-# TYPE node_zfsArc_anon_evictable_metadata untyped
-node_zfsArc_anon_evictable_metadata 0
-# HELP node_zfsArc_anon_size kstat.zfs.misc.arcstats.anon_size
-# TYPE node_zfsArc_anon_size untyped
-node_zfsArc_anon_size 1.91744e+06
-# HELP node_zfsArc_arc_loaned_bytes kstat.zfs.misc.arcstats.arc_loaned_bytes
-# TYPE node_zfsArc_arc_loaned_bytes untyped
-node_zfsArc_arc_loaned_bytes 0
-# HELP node_zfsArc_arc_meta_limit kstat.zfs.misc.arcstats.arc_meta_limit
-# TYPE node_zfsArc_arc_meta_limit untyped
-node_zfsArc_arc_meta_limit 6.275982336e+09
-# HELP node_zfsArc_arc_meta_max kstat.zfs.misc.arcstats.arc_meta_max
-# TYPE node_zfsArc_arc_meta_max untyped
-node_zfsArc_arc_meta_max 4.49286096e+08
-# HELP node_zfsArc_arc_meta_min kstat.zfs.misc.arcstats.arc_meta_min
-# TYPE node_zfsArc_arc_meta_min untyped
-node_zfsArc_arc_meta_min 1.6777216e+07
-# HELP node_zfsArc_arc_meta_used kstat.zfs.misc.arcstats.arc_meta_used
-# TYPE node_zfsArc_arc_meta_used untyped
-node_zfsArc_arc_meta_used 3.08103632e+08
-# HELP node_zfsArc_arc_need_free kstat.zfs.misc.arcstats.arc_need_free
-# TYPE node_zfsArc_arc_need_free untyped
-node_zfsArc_arc_need_free 0
-# HELP node_zfsArc_arc_no_grow kstat.zfs.misc.arcstats.arc_no_grow
-# TYPE node_zfsArc_arc_no_grow untyped
-node_zfsArc_arc_no_grow 0
-# HELP node_zfsArc_arc_prune kstat.zfs.misc.arcstats.arc_prune
-# TYPE node_zfsArc_arc_prune untyped
-node_zfsArc_arc_prune 0
-# HELP node_zfsArc_arc_sys_free kstat.zfs.misc.arcstats.arc_sys_free
-# TYPE node_zfsArc_arc_sys_free untyped
-node_zfsArc_arc_sys_free 2.61496832e+08
-# HELP node_zfsArc_arc_tempreserve kstat.zfs.misc.arcstats.arc_tempreserve
-# TYPE node_zfsArc_arc_tempreserve untyped
-node_zfsArc_arc_tempreserve 0
-# HELP node_zfsArc_c kstat.zfs.misc.arcstats.c
-# TYPE node_zfsArc_c untyped
-node_zfsArc_c 1.643208777e+09
-# HELP node_zfsArc_c_max kstat.zfs.misc.arcstats.c_max
-# TYPE node_zfsArc_c_max untyped
-node_zfsArc_c_max 8.367976448e+09
-# HELP node_zfsArc_c_min kstat.zfs.misc.arcstats.c_min
-# TYPE node_zfsArc_c_min untyped
-node_zfsArc_c_min 3.3554432e+07
-# HELP node_zfsArc_data_size kstat.zfs.misc.arcstats.data_size
-# TYPE node_zfsArc_data_size untyped
-node_zfsArc_data_size 1.29583616e+09
-# HELP node_zfsArc_deleted kstat.zfs.misc.arcstats.deleted
-# TYPE node_zfsArc_deleted untyped
-node_zfsArc_deleted 60403
-# HELP node_zfsArc_demand_data_hits kstat.zfs.misc.arcstats.demand_data_hits
-# TYPE node_zfsArc_demand_data_hits untyped
-node_zfsArc_demand_data_hits 7.221032e+06
-# HELP node_zfsArc_demand_data_misses kstat.zfs.misc.arcstats.demand_data_misses
-# TYPE node_zfsArc_demand_data_misses untyped
-node_zfsArc_demand_data_misses 73300
-# HELP node_zfsArc_demand_metadata_hits kstat.zfs.misc.arcstats.demand_metadata_hits
-# TYPE node_zfsArc_demand_metadata_hits untyped
-node_zfsArc_demand_metadata_hits 1.464353e+06
-# HELP node_zfsArc_demand_metadata_misses kstat.zfs.misc.arcstats.demand_metadata_misses
-# TYPE node_zfsArc_demand_metadata_misses untyped
-node_zfsArc_demand_metadata_misses 498170
-# HELP node_zfsArc_duplicate_buffers kstat.zfs.misc.arcstats.duplicate_buffers
-# TYPE node_zfsArc_duplicate_buffers untyped
-node_zfsArc_duplicate_buffers 0
-# HELP node_zfsArc_duplicate_buffers_size kstat.zfs.misc.arcstats.duplicate_buffers_size
-# TYPE node_zfsArc_duplicate_buffers_size untyped
-node_zfsArc_duplicate_buffers_size 0
-# HELP node_zfsArc_duplicate_reads kstat.zfs.misc.arcstats.duplicate_reads
-# TYPE node_zfsArc_duplicate_reads untyped
-node_zfsArc_duplicate_reads 0
-# HELP node_zfsArc_evict_l2_cached kstat.zfs.misc.arcstats.evict_l2_cached
-# TYPE node_zfsArc_evict_l2_cached untyped
-node_zfsArc_evict_l2_cached 0
-# HELP node_zfsArc_evict_l2_eligible kstat.zfs.misc.arcstats.evict_l2_eligible
-# TYPE node_zfsArc_evict_l2_eligible untyped
-node_zfsArc_evict_l2_eligible 8.99251456e+09
-# HELP node_zfsArc_evict_l2_ineligible kstat.zfs.misc.arcstats.evict_l2_ineligible
-# TYPE node_zfsArc_evict_l2_ineligible untyped
-node_zfsArc_evict_l2_ineligible 9.92552448e+08
-# HELP node_zfsArc_evict_l2_skip kstat.zfs.misc.arcstats.evict_l2_skip
-# TYPE node_zfsArc_evict_l2_skip untyped
-node_zfsArc_evict_l2_skip 0
-# HELP node_zfsArc_evict_not_enough kstat.zfs.misc.arcstats.evict_not_enough
-# TYPE node_zfsArc_evict_not_enough untyped
-node_zfsArc_evict_not_enough 680
-# HELP node_zfsArc_evict_skip kstat.zfs.misc.arcstats.evict_skip
-# TYPE node_zfsArc_evict_skip untyped
-node_zfsArc_evict_skip 2.265729e+06
-# HELP node_zfsArc_hash_chain_max kstat.zfs.misc.arcstats.hash_chain_max
-# TYPE node_zfsArc_hash_chain_max untyped
-node_zfsArc_hash_chain_max 3
-# HELP node_zfsArc_hash_chains kstat.zfs.misc.arcstats.hash_chains
-# TYPE node_zfsArc_hash_chains untyped
-node_zfsArc_hash_chains 412
-# HELP node_zfsArc_hash_collisions kstat.zfs.misc.arcstats.hash_collisions
-# TYPE node_zfsArc_hash_collisions untyped
-node_zfsArc_hash_collisions 50564
-# HELP node_zfsArc_hash_elements kstat.zfs.misc.arcstats.hash_elements
-# TYPE node_zfsArc_hash_elements untyped
-node_zfsArc_hash_elements 42359
-# HELP node_zfsArc_hash_elements_max kstat.zfs.misc.arcstats.hash_elements_max
-# TYPE node_zfsArc_hash_elements_max untyped
-node_zfsArc_hash_elements_max 88245
-# HELP node_zfsArc_hdr_size kstat.zfs.misc.arcstats.hdr_size
-# TYPE node_zfsArc_hdr_size untyped
-node_zfsArc_hdr_size 1.636108e+07
-# HELP node_zfsArc_hits kstat.zfs.misc.arcstats.hits
-# TYPE node_zfsArc_hits untyped
-node_zfsArc_hits 8.772612e+06
-# HELP node_zfsArc_l2_abort_lowmem kstat.zfs.misc.arcstats.l2_abort_lowmem
-# TYPE node_zfsArc_l2_abort_lowmem untyped
-node_zfsArc_l2_abort_lowmem 0
-# HELP node_zfsArc_l2_asize kstat.zfs.misc.arcstats.l2_asize
-# TYPE node_zfsArc_l2_asize untyped
-node_zfsArc_l2_asize 0
-# HELP node_zfsArc_l2_cdata_free_on_write kstat.zfs.misc.arcstats.l2_cdata_free_on_write
-# TYPE node_zfsArc_l2_cdata_free_on_write untyped
-node_zfsArc_l2_cdata_free_on_write 0
-# HELP node_zfsArc_l2_cksum_bad kstat.zfs.misc.arcstats.l2_cksum_bad
-# TYPE node_zfsArc_l2_cksum_bad untyped
-node_zfsArc_l2_cksum_bad 0
-# HELP node_zfsArc_l2_compress_failures kstat.zfs.misc.arcstats.l2_compress_failures
-# TYPE node_zfsArc_l2_compress_failures untyped
-node_zfsArc_l2_compress_failures 0
-# HELP node_zfsArc_l2_compress_successes kstat.zfs.misc.arcstats.l2_compress_successes
-# TYPE node_zfsArc_l2_compress_successes untyped
-node_zfsArc_l2_compress_successes 0
-# HELP node_zfsArc_l2_compress_zeros kstat.zfs.misc.arcstats.l2_compress_zeros
-# TYPE node_zfsArc_l2_compress_zeros untyped
-node_zfsArc_l2_compress_zeros 0
-# HELP node_zfsArc_l2_evict_l1cached kstat.zfs.misc.arcstats.l2_evict_l1cached
-# TYPE node_zfsArc_l2_evict_l1cached untyped
-node_zfsArc_l2_evict_l1cached 0
-# HELP node_zfsArc_l2_evict_lock_retry kstat.zfs.misc.arcstats.l2_evict_lock_retry
-# TYPE node_zfsArc_l2_evict_lock_retry untyped
-node_zfsArc_l2_evict_lock_retry 0
-# HELP node_zfsArc_l2_evict_reading kstat.zfs.misc.arcstats.l2_evict_reading
-# TYPE node_zfsArc_l2_evict_reading untyped
-node_zfsArc_l2_evict_reading 0
-# HELP node_zfsArc_l2_feeds kstat.zfs.misc.arcstats.l2_feeds
-# TYPE node_zfsArc_l2_feeds untyped
-node_zfsArc_l2_feeds 0
-# HELP node_zfsArc_l2_free_on_write kstat.zfs.misc.arcstats.l2_free_on_write
-# TYPE node_zfsArc_l2_free_on_write untyped
-node_zfsArc_l2_free_on_write 0
-# HELP node_zfsArc_l2_hdr_size kstat.zfs.misc.arcstats.l2_hdr_size
-# TYPE node_zfsArc_l2_hdr_size untyped
-node_zfsArc_l2_hdr_size 0
-# HELP node_zfsArc_l2_hits kstat.zfs.misc.arcstats.l2_hits
-# TYPE node_zfsArc_l2_hits untyped
-node_zfsArc_l2_hits 0
-# HELP node_zfsArc_l2_io_error kstat.zfs.misc.arcstats.l2_io_error
-# TYPE node_zfsArc_l2_io_error untyped
-node_zfsArc_l2_io_error 0
-# HELP node_zfsArc_l2_misses kstat.zfs.misc.arcstats.l2_misses
-# TYPE node_zfsArc_l2_misses untyped
-node_zfsArc_l2_misses 0
-# HELP node_zfsArc_l2_read_bytes kstat.zfs.misc.arcstats.l2_read_bytes
-# TYPE node_zfsArc_l2_read_bytes untyped
-node_zfsArc_l2_read_bytes 0
-# HELP node_zfsArc_l2_rw_clash kstat.zfs.misc.arcstats.l2_rw_clash
-# TYPE node_zfsArc_l2_rw_clash untyped
-node_zfsArc_l2_rw_clash 0
-# HELP node_zfsArc_l2_size kstat.zfs.misc.arcstats.l2_size
-# TYPE node_zfsArc_l2_size untyped
-node_zfsArc_l2_size 0
-# HELP node_zfsArc_l2_write_bytes kstat.zfs.misc.arcstats.l2_write_bytes
-# TYPE node_zfsArc_l2_write_bytes untyped
-node_zfsArc_l2_write_bytes 0
-# HELP node_zfsArc_l2_writes_done kstat.zfs.misc.arcstats.l2_writes_done
-# TYPE node_zfsArc_l2_writes_done untyped
-node_zfsArc_l2_writes_done 0
-# HELP node_zfsArc_l2_writes_error kstat.zfs.misc.arcstats.l2_writes_error
-# TYPE node_zfsArc_l2_writes_error untyped
-node_zfsArc_l2_writes_error 0
-# HELP node_zfsArc_l2_writes_lock_retry kstat.zfs.misc.arcstats.l2_writes_lock_retry
-# TYPE node_zfsArc_l2_writes_lock_retry untyped
-node_zfsArc_l2_writes_lock_retry 0
-# HELP node_zfsArc_l2_writes_sent kstat.zfs.misc.arcstats.l2_writes_sent
-# TYPE node_zfsArc_l2_writes_sent untyped
-node_zfsArc_l2_writes_sent 0
-# HELP node_zfsArc_memory_direct_count kstat.zfs.misc.arcstats.memory_direct_count
-# TYPE node_zfsArc_memory_direct_count untyped
-node_zfsArc_memory_direct_count 542
-# HELP node_zfsArc_memory_indirect_count kstat.zfs.misc.arcstats.memory_indirect_count
-# TYPE node_zfsArc_memory_indirect_count untyped
-node_zfsArc_memory_indirect_count 3006
-# HELP node_zfsArc_memory_throttle_count kstat.zfs.misc.arcstats.memory_throttle_count
-# TYPE node_zfsArc_memory_throttle_count untyped
-node_zfsArc_memory_throttle_count 0
-# HELP node_zfsArc_metadata_size kstat.zfs.misc.arcstats.metadata_size
-# TYPE node_zfsArc_metadata_size untyped
-node_zfsArc_metadata_size 1.7529856e+08
-# HELP node_zfsArc_mfu_evictable_data kstat.zfs.misc.arcstats.mfu_evictable_data
-# TYPE node_zfsArc_mfu_evictable_data untyped
-node_zfsArc_mfu_evictable_data 1.017613824e+09
-# HELP node_zfsArc_mfu_evictable_metadata kstat.zfs.misc.arcstats.mfu_evictable_metadata
-# TYPE node_zfsArc_mfu_evictable_metadata untyped
-node_zfsArc_mfu_evictable_metadata 9.163776e+06
-# HELP node_zfsArc_mfu_ghost_evictable_data kstat.zfs.misc.arcstats.mfu_ghost_evictable_data
-# TYPE node_zfsArc_mfu_ghost_evictable_data untyped
-node_zfsArc_mfu_ghost_evictable_data 9.6731136e+07
-# HELP node_zfsArc_mfu_ghost_evictable_metadata kstat.zfs.misc.arcstats.mfu_ghost_evictable_metadata
-# TYPE node_zfsArc_mfu_ghost_evictable_metadata untyped
-node_zfsArc_mfu_ghost_evictable_metadata 8.205312e+06
-# HELP node_zfsArc_mfu_ghost_hits kstat.zfs.misc.arcstats.mfu_ghost_hits
-# TYPE node_zfsArc_mfu_ghost_hits untyped
-node_zfsArc_mfu_ghost_hits 821
-# HELP node_zfsArc_mfu_ghost_size kstat.zfs.misc.arcstats.mfu_ghost_size
-# TYPE node_zfsArc_mfu_ghost_size untyped
-node_zfsArc_mfu_ghost_size 1.04936448e+08
-# HELP node_zfsArc_mfu_hits kstat.zfs.misc.arcstats.mfu_hits
-# TYPE node_zfsArc_mfu_hits untyped
-node_zfsArc_mfu_hits 7.829854e+06
-# HELP node_zfsArc_mfu_size kstat.zfs.misc.arcstats.mfu_size
-# TYPE node_zfsArc_mfu_size untyped
-node_zfsArc_mfu_size 1.066623488e+09
-# HELP node_zfsArc_misses kstat.zfs.misc.arcstats.misses
-# TYPE node_zfsArc_misses untyped
-node_zfsArc_misses 604635
-# HELP node_zfsArc_mru_evictable_data kstat.zfs.misc.arcstats.mru_evictable_data
-# TYPE node_zfsArc_mru_evictable_data untyped
-node_zfsArc_mru_evictable_data 2.78091264e+08
-# HELP node_zfsArc_mru_evictable_metadata kstat.zfs.misc.arcstats.mru_evictable_metadata
-# TYPE node_zfsArc_mru_evictable_metadata untyped
-node_zfsArc_mru_evictable_metadata 1.8606592e+07
-# HELP node_zfsArc_mru_ghost_evictable_data kstat.zfs.misc.arcstats.mru_ghost_evictable_data
-# TYPE node_zfsArc_mru_ghost_evictable_data untyped
-node_zfsArc_mru_ghost_evictable_data 8.83765248e+08
-# HELP node_zfsArc_mru_ghost_evictable_metadata kstat.zfs.misc.arcstats.mru_ghost_evictable_metadata
-# TYPE node_zfsArc_mru_ghost_evictable_metadata untyped
-node_zfsArc_mru_ghost_evictable_metadata 1.1596288e+08
-# HELP node_zfsArc_mru_ghost_hits kstat.zfs.misc.arcstats.mru_ghost_hits
-# TYPE node_zfsArc_mru_ghost_hits untyped
-node_zfsArc_mru_ghost_hits 21100
-# HELP node_zfsArc_mru_ghost_size kstat.zfs.misc.arcstats.mru_ghost_size
-# TYPE node_zfsArc_mru_ghost_size untyped
-node_zfsArc_mru_ghost_size 9.99728128e+08
-# HELP node_zfsArc_mru_hits kstat.zfs.misc.arcstats.mru_hits
-# TYPE node_zfsArc_mru_hits untyped
-node_zfsArc_mru_hits 855535
-# HELP node_zfsArc_mru_size kstat.zfs.misc.arcstats.mru_size
-# TYPE node_zfsArc_mru_size untyped
-node_zfsArc_mru_size 4.02593792e+08
-# HELP node_zfsArc_mutex_miss kstat.zfs.misc.arcstats.mutex_miss
-# TYPE node_zfsArc_mutex_miss untyped
-node_zfsArc_mutex_miss 2
-# HELP node_zfsArc_other_size kstat.zfs.misc.arcstats.other_size
-# TYPE node_zfsArc_other_size untyped
-node_zfsArc_other_size 1.16443992e+08
-# HELP node_zfsArc_p kstat.zfs.misc.arcstats.p
-# TYPE node_zfsArc_p untyped
-node_zfsArc_p 5.16395305e+08
-# HELP node_zfsArc_prefetch_data_hits kstat.zfs.misc.arcstats.prefetch_data_hits
-# TYPE node_zfsArc_prefetch_data_hits untyped
-node_zfsArc_prefetch_data_hits 3615
-# HELP node_zfsArc_prefetch_data_misses kstat.zfs.misc.arcstats.prefetch_data_misses
-# TYPE node_zfsArc_prefetch_data_misses untyped
-node_zfsArc_prefetch_data_misses 17094
-# HELP node_zfsArc_prefetch_metadata_hits kstat.zfs.misc.arcstats.prefetch_metadata_hits
-# TYPE node_zfsArc_prefetch_metadata_hits untyped
-node_zfsArc_prefetch_metadata_hits 83612
-# HELP node_zfsArc_prefetch_metadata_misses kstat.zfs.misc.arcstats.prefetch_metadata_misses
-# TYPE node_zfsArc_prefetch_metadata_misses untyped
-node_zfsArc_prefetch_metadata_misses 16071
-# HELP node_zfsArc_size kstat.zfs.misc.arcstats.size
-# TYPE node_zfsArc_size untyped
-node_zfsArc_size 1.603939792e+09
-# HELP node_zfsDmuTx_dmu_tx_assigned kstat.zfs.misc.dmu_tx.dmu_tx_assigned
-# TYPE node_zfsDmuTx_dmu_tx_assigned untyped
-node_zfsDmuTx_dmu_tx_assigned 3.532844e+06
-# HELP node_zfsDmuTx_dmu_tx_delay kstat.zfs.misc.dmu_tx.dmu_tx_delay
-# TYPE node_zfsDmuTx_dmu_tx_delay untyped
-node_zfsDmuTx_dmu_tx_delay 0
-# HELP node_zfsDmuTx_dmu_tx_dirty_delay kstat.zfs.misc.dmu_tx.dmu_tx_dirty_delay
-# TYPE node_zfsDmuTx_dmu_tx_dirty_delay untyped
-node_zfsDmuTx_dmu_tx_dirty_delay 0
-# HELP node_zfsDmuTx_dmu_tx_dirty_over_max kstat.zfs.misc.dmu_tx.dmu_tx_dirty_over_max
-# TYPE node_zfsDmuTx_dmu_tx_dirty_over_max untyped
-node_zfsDmuTx_dmu_tx_dirty_over_max 0
-# HELP node_zfsDmuTx_dmu_tx_dirty_throttle kstat.zfs.misc.dmu_tx.dmu_tx_dirty_throttle
-# TYPE node_zfsDmuTx_dmu_tx_dirty_throttle untyped
-node_zfsDmuTx_dmu_tx_dirty_throttle 0
-# HELP node_zfsDmuTx_dmu_tx_error kstat.zfs.misc.dmu_tx.dmu_tx_error
-# TYPE node_zfsDmuTx_dmu_tx_error untyped
-node_zfsDmuTx_dmu_tx_error 0
-# HELP node_zfsDmuTx_dmu_tx_group kstat.zfs.misc.dmu_tx.dmu_tx_group
-# TYPE node_zfsDmuTx_dmu_tx_group untyped
-node_zfsDmuTx_dmu_tx_group 0
-# HELP node_zfsDmuTx_dmu_tx_memory_reclaim kstat.zfs.misc.dmu_tx.dmu_tx_memory_reclaim
-# TYPE node_zfsDmuTx_dmu_tx_memory_reclaim untyped
-node_zfsDmuTx_dmu_tx_memory_reclaim 0
-# HELP node_zfsDmuTx_dmu_tx_memory_reserve kstat.zfs.misc.dmu_tx.dmu_tx_memory_reserve
-# TYPE node_zfsDmuTx_dmu_tx_memory_reserve untyped
-node_zfsDmuTx_dmu_tx_memory_reserve 0
-# HELP node_zfsDmuTx_dmu_tx_quota kstat.zfs.misc.dmu_tx.dmu_tx_quota
-# TYPE node_zfsDmuTx_dmu_tx_quota untyped
-node_zfsDmuTx_dmu_tx_quota 0
-# HELP node_zfsDmuTx_dmu_tx_suspended kstat.zfs.misc.dmu_tx.dmu_tx_suspended
-# TYPE node_zfsDmuTx_dmu_tx_suspended untyped
-node_zfsDmuTx_dmu_tx_suspended 0
-# HELP node_zfsFetch_bogus_streams kstat.zfs.misc.zfetchstats.bogus_streams
-# TYPE node_zfsFetch_bogus_streams untyped
-node_zfsFetch_bogus_streams 0
-# HELP node_zfsFetch_colinear_hits kstat.zfs.misc.zfetchstats.colinear_hits
-# TYPE node_zfsFetch_colinear_hits untyped
-node_zfsFetch_colinear_hits 0
-# HELP node_zfsFetch_colinear_misses kstat.zfs.misc.zfetchstats.colinear_misses
-# TYPE node_zfsFetch_colinear_misses untyped
-node_zfsFetch_colinear_misses 11
-# HELP node_zfsFetch_hits kstat.zfs.misc.zfetchstats.hits
-# TYPE node_zfsFetch_hits untyped
-node_zfsFetch_hits 7.067992e+06
-# HELP node_zfsFetch_misses kstat.zfs.misc.zfetchstats.misses
-# TYPE node_zfsFetch_misses untyped
-node_zfsFetch_misses 11
-# HELP node_zfsFetch_reclaim_failures kstat.zfs.misc.zfetchstats.reclaim_failures
-# TYPE node_zfsFetch_reclaim_failures untyped
-node_zfsFetch_reclaim_failures 11
-# HELP node_zfsFetch_reclaim_successes kstat.zfs.misc.zfetchstats.reclaim_successes
-# TYPE node_zfsFetch_reclaim_successes untyped
-node_zfsFetch_reclaim_successes 0
-# HELP node_zfsFetch_streams_noresets kstat.zfs.misc.zfetchstats.streams_noresets
-# TYPE node_zfsFetch_streams_noresets untyped
-node_zfsFetch_streams_noresets 2
-# HELP node_zfsFetch_streams_resets kstat.zfs.misc.zfetchstats.streams_resets
-# TYPE node_zfsFetch_streams_resets untyped
-node_zfsFetch_streams_resets 0
-# HELP node_zfsFetch_stride_hits kstat.zfs.misc.zfetchstats.stride_hits
-# TYPE node_zfsFetch_stride_hits untyped
-node_zfsFetch_stride_hits 7.06799e+06
-# HELP node_zfsFetch_stride_misses kstat.zfs.misc.zfetchstats.stride_misses
-# TYPE node_zfsFetch_stride_misses untyped
-node_zfsFetch_stride_misses 0
-# HELP node_zfsFm_erpt-dropped kstat.zfs.misc.fm.erpt-dropped
-# TYPE node_zfsFm_erpt-dropped untyped
-node_zfsFm_erpt-dropped 18
-# HELP node_zfsFm_erpt-set-failed kstat.zfs.misc.fm.erpt-set-failed
-# TYPE node_zfsFm_erpt-set-failed untyped
-node_zfsFm_erpt-set-failed 0
-# HELP node_zfsFm_fmri-set-failed kstat.zfs.misc.fm.fmri-set-failed
-# TYPE node_zfsFm_fmri-set-failed untyped
-node_zfsFm_fmri-set-failed 0
-# HELP node_zfsFm_payload-set-failed kstat.zfs.misc.fm.payload-set-failed
-# TYPE node_zfsFm_payload-set-failed untyped
-node_zfsFm_payload-set-failed 0
-# HELP node_zfsVdevCache_delegations kstat.zfs.misc.vdev_cache_stats.delegations
-# TYPE node_zfsVdevCache_delegations untyped
-node_zfsVdevCache_delegations 40
-# HELP node_zfsVdevCache_hits kstat.zfs.misc.vdev_cache_stats.hits
-# TYPE node_zfsVdevCache_hits untyped
-node_zfsVdevCache_hits 0
-# HELP node_zfsVdevCache_misses kstat.zfs.misc.vdev_cache_stats.misses
-# TYPE node_zfsVdevCache_misses untyped
-node_zfsVdevCache_misses 0
-# HELP node_zfsXuio_onloan_read_buf kstat.zfs.misc.xuio_stats.onloan_read_buf
-# TYPE node_zfsXuio_onloan_read_buf untyped
-node_zfsXuio_onloan_read_buf 32
-# HELP node_zfsXuio_onloan_write_buf kstat.zfs.misc.xuio_stats.onloan_write_buf
-# TYPE node_zfsXuio_onloan_write_buf untyped
-node_zfsXuio_onloan_write_buf 0
-# HELP node_zfsXuio_read_buf_copied kstat.zfs.misc.xuio_stats.read_buf_copied
-# TYPE node_zfsXuio_read_buf_copied untyped
-node_zfsXuio_read_buf_copied 0
-# HELP node_zfsXuio_read_buf_nocopy kstat.zfs.misc.xuio_stats.read_buf_nocopy
-# TYPE node_zfsXuio_read_buf_nocopy untyped
-node_zfsXuio_read_buf_nocopy 0
-# HELP node_zfsXuio_write_buf_copied kstat.zfs.misc.xuio_stats.write_buf_copied
-# TYPE node_zfsXuio_write_buf_copied untyped
-node_zfsXuio_write_buf_copied 0
-# HELP node_zfsXuio_write_buf_nocopy kstat.zfs.misc.xuio_stats.write_buf_nocopy
-# TYPE node_zfsXuio_write_buf_nocopy untyped
-node_zfsXuio_write_buf_nocopy 0
-# HELP node_zfsZil_zil_commit_count kstat.zfs.misc.zil.zil_commit_count
-# TYPE node_zfsZil_zil_commit_count untyped
-node_zfsZil_zil_commit_count 10
-# HELP node_zfsZil_zil_commit_writer_count kstat.zfs.misc.zil.zil_commit_writer_count
-# TYPE node_zfsZil_zil_commit_writer_count untyped
-node_zfsZil_zil_commit_writer_count 0
-# HELP node_zfsZil_zil_itx_copied_bytes kstat.zfs.misc.zil.zil_itx_copied_bytes
-# TYPE node_zfsZil_zil_itx_copied_bytes untyped
-node_zfsZil_zil_itx_copied_bytes 0
-# HELP node_zfsZil_zil_itx_copied_count kstat.zfs.misc.zil.zil_itx_copied_count
-# TYPE node_zfsZil_zil_itx_copied_count untyped
-node_zfsZil_zil_itx_copied_count 0
-# HELP node_zfsZil_zil_itx_count kstat.zfs.misc.zil.zil_itx_count
-# TYPE node_zfsZil_zil_itx_count untyped
-node_zfsZil_zil_itx_count 0
-# HELP node_zfsZil_zil_itx_indirect_bytes kstat.zfs.misc.zil.zil_itx_indirect_bytes
-# TYPE node_zfsZil_zil_itx_indirect_bytes untyped
-node_zfsZil_zil_itx_indirect_bytes 0
-# HELP node_zfsZil_zil_itx_indirect_count kstat.zfs.misc.zil.zil_itx_indirect_count
-# TYPE node_zfsZil_zil_itx_indirect_count untyped
-node_zfsZil_zil_itx_indirect_count 0
-# HELP node_zfsZil_zil_itx_metaslab_normal_bytes kstat.zfs.misc.zil.zil_itx_metaslab_normal_bytes
-# TYPE node_zfsZil_zil_itx_metaslab_normal_bytes untyped
-node_zfsZil_zil_itx_metaslab_normal_bytes 0
-# HELP node_zfsZil_zil_itx_metaslab_normal_count kstat.zfs.misc.zil.zil_itx_metaslab_normal_count
-# TYPE node_zfsZil_zil_itx_metaslab_normal_count untyped
-node_zfsZil_zil_itx_metaslab_normal_count 0
-# HELP node_zfsZil_zil_itx_metaslab_slog_bytes kstat.zfs.misc.zil.zil_itx_metaslab_slog_bytes
-# TYPE node_zfsZil_zil_itx_metaslab_slog_bytes untyped
-node_zfsZil_zil_itx_metaslab_slog_bytes 0
-# HELP node_zfsZil_zil_itx_metaslab_slog_count kstat.zfs.misc.zil.zil_itx_metaslab_slog_count
-# TYPE node_zfsZil_zil_itx_metaslab_slog_count untyped
-node_zfsZil_zil_itx_metaslab_slog_count 0
-# HELP node_zfsZil_zil_itx_needcopy_bytes kstat.zfs.misc.zil.zil_itx_needcopy_bytes
-# TYPE node_zfsZil_zil_itx_needcopy_bytes untyped
-node_zfsZil_zil_itx_needcopy_bytes 0
-# HELP node_zfsZil_zil_itx_needcopy_count kstat.zfs.misc.zil.zil_itx_needcopy_count
-# TYPE node_zfsZil_zil_itx_needcopy_count untyped
-node_zfsZil_zil_itx_needcopy_count 0
+# HELP node_zfs_arc_anon_evictable_data kstat.zfs.misc.arcstats.anon_evictable_data
+# TYPE node_zfs_arc_anon_evictable_data untyped
+node_zfs_arc_anon_evictable_data 0
+# HELP node_zfs_arc_anon_evictable_metadata kstat.zfs.misc.arcstats.anon_evictable_metadata
+# TYPE node_zfs_arc_anon_evictable_metadata untyped
+node_zfs_arc_anon_evictable_metadata 0
+# HELP node_zfs_arc_anon_size kstat.zfs.misc.arcstats.anon_size
+# TYPE node_zfs_arc_anon_size untyped
+node_zfs_arc_anon_size 1.91744e+06
+# HELP node_zfs_arc_arc_loaned_bytes kstat.zfs.misc.arcstats.arc_loaned_bytes
+# TYPE node_zfs_arc_arc_loaned_bytes untyped
+node_zfs_arc_arc_loaned_bytes 0
+# HELP node_zfs_arc_arc_meta_limit kstat.zfs.misc.arcstats.arc_meta_limit
+# TYPE node_zfs_arc_arc_meta_limit untyped
+node_zfs_arc_arc_meta_limit 6.275982336e+09
+# HELP node_zfs_arc_arc_meta_max kstat.zfs.misc.arcstats.arc_meta_max
+# TYPE node_zfs_arc_arc_meta_max untyped
+node_zfs_arc_arc_meta_max 4.49286096e+08
+# HELP node_zfs_arc_arc_meta_min kstat.zfs.misc.arcstats.arc_meta_min
+# TYPE node_zfs_arc_arc_meta_min untyped
+node_zfs_arc_arc_meta_min 1.6777216e+07
+# HELP node_zfs_arc_arc_meta_used kstat.zfs.misc.arcstats.arc_meta_used
+# TYPE node_zfs_arc_arc_meta_used untyped
+node_zfs_arc_arc_meta_used 3.08103632e+08
+# HELP node_zfs_arc_arc_need_free kstat.zfs.misc.arcstats.arc_need_free
+# TYPE node_zfs_arc_arc_need_free untyped
+node_zfs_arc_arc_need_free 0
+# HELP node_zfs_arc_arc_no_grow kstat.zfs.misc.arcstats.arc_no_grow
+# TYPE node_zfs_arc_arc_no_grow untyped
+node_zfs_arc_arc_no_grow 0
+# HELP node_zfs_arc_arc_prune kstat.zfs.misc.arcstats.arc_prune
+# TYPE node_zfs_arc_arc_prune untyped
+node_zfs_arc_arc_prune 0
+# HELP node_zfs_arc_arc_sys_free kstat.zfs.misc.arcstats.arc_sys_free
+# TYPE node_zfs_arc_arc_sys_free untyped
+node_zfs_arc_arc_sys_free 2.61496832e+08
+# HELP node_zfs_arc_arc_tempreserve kstat.zfs.misc.arcstats.arc_tempreserve
+# TYPE node_zfs_arc_arc_tempreserve untyped
+node_zfs_arc_arc_tempreserve 0
+# HELP node_zfs_arc_c kstat.zfs.misc.arcstats.c
+# TYPE node_zfs_arc_c untyped
+node_zfs_arc_c 1.643208777e+09
+# HELP node_zfs_arc_c_max kstat.zfs.misc.arcstats.c_max
+# TYPE node_zfs_arc_c_max untyped
+node_zfs_arc_c_max 8.367976448e+09
+# HELP node_zfs_arc_c_min kstat.zfs.misc.arcstats.c_min
+# TYPE node_zfs_arc_c_min untyped
+node_zfs_arc_c_min 3.3554432e+07
+# HELP node_zfs_arc_data_size kstat.zfs.misc.arcstats.data_size
+# TYPE node_zfs_arc_data_size untyped
+node_zfs_arc_data_size 1.29583616e+09
+# HELP node_zfs_arc_deleted kstat.zfs.misc.arcstats.deleted
+# TYPE node_zfs_arc_deleted untyped
+node_zfs_arc_deleted 60403
+# HELP node_zfs_arc_demand_data_hits kstat.zfs.misc.arcstats.demand_data_hits
+# TYPE node_zfs_arc_demand_data_hits untyped
+node_zfs_arc_demand_data_hits 7.221032e+06
+# HELP node_zfs_arc_demand_data_misses kstat.zfs.misc.arcstats.demand_data_misses
+# TYPE node_zfs_arc_demand_data_misses untyped
+node_zfs_arc_demand_data_misses 73300
+# HELP node_zfs_arc_demand_metadata_hits kstat.zfs.misc.arcstats.demand_metadata_hits
+# TYPE node_zfs_arc_demand_metadata_hits untyped
+node_zfs_arc_demand_metadata_hits 1.464353e+06
+# HELP node_zfs_arc_demand_metadata_misses kstat.zfs.misc.arcstats.demand_metadata_misses
+# TYPE node_zfs_arc_demand_metadata_misses untyped
+node_zfs_arc_demand_metadata_misses 498170
+# HELP node_zfs_arc_duplicate_buffers kstat.zfs.misc.arcstats.duplicate_buffers
+# TYPE node_zfs_arc_duplicate_buffers untyped
+node_zfs_arc_duplicate_buffers 0
+# HELP node_zfs_arc_duplicate_buffers_size kstat.zfs.misc.arcstats.duplicate_buffers_size
+# TYPE node_zfs_arc_duplicate_buffers_size untyped
+node_zfs_arc_duplicate_buffers_size 0
+# HELP node_zfs_arc_duplicate_reads kstat.zfs.misc.arcstats.duplicate_reads
+# TYPE node_zfs_arc_duplicate_reads untyped
+node_zfs_arc_duplicate_reads 0
+# HELP node_zfs_arc_evict_l2_cached kstat.zfs.misc.arcstats.evict_l2_cached
+# TYPE node_zfs_arc_evict_l2_cached untyped
+node_zfs_arc_evict_l2_cached 0
+# HELP node_zfs_arc_evict_l2_eligible kstat.zfs.misc.arcstats.evict_l2_eligible
+# TYPE node_zfs_arc_evict_l2_eligible untyped
+node_zfs_arc_evict_l2_eligible 8.99251456e+09
+# HELP node_zfs_arc_evict_l2_ineligible kstat.zfs.misc.arcstats.evict_l2_ineligible
+# TYPE node_zfs_arc_evict_l2_ineligible untyped
+node_zfs_arc_evict_l2_ineligible 9.92552448e+08
+# HELP node_zfs_arc_evict_l2_skip kstat.zfs.misc.arcstats.evict_l2_skip
+# TYPE node_zfs_arc_evict_l2_skip untyped
+node_zfs_arc_evict_l2_skip 0
+# HELP node_zfs_arc_evict_not_enough kstat.zfs.misc.arcstats.evict_not_enough
+# TYPE node_zfs_arc_evict_not_enough untyped
+node_zfs_arc_evict_not_enough 680
+# HELP node_zfs_arc_evict_skip kstat.zfs.misc.arcstats.evict_skip
+# TYPE node_zfs_arc_evict_skip untyped
+node_zfs_arc_evict_skip 2.265729e+06
+# HELP node_zfs_arc_hash_chain_max kstat.zfs.misc.arcstats.hash_chain_max
+# TYPE node_zfs_arc_hash_chain_max untyped
+node_zfs_arc_hash_chain_max 3
+# HELP node_zfs_arc_hash_chains kstat.zfs.misc.arcstats.hash_chains
+# TYPE node_zfs_arc_hash_chains untyped
+node_zfs_arc_hash_chains 412
+# HELP node_zfs_arc_hash_collisions kstat.zfs.misc.arcstats.hash_collisions
+# TYPE node_zfs_arc_hash_collisions untyped
+node_zfs_arc_hash_collisions 50564
+# HELP node_zfs_arc_hash_elements kstat.zfs.misc.arcstats.hash_elements
+# TYPE node_zfs_arc_hash_elements untyped
+node_zfs_arc_hash_elements 42359
+# HELP node_zfs_arc_hash_elements_max kstat.zfs.misc.arcstats.hash_elements_max
+# TYPE node_zfs_arc_hash_elements_max untyped
+node_zfs_arc_hash_elements_max 88245
+# HELP node_zfs_arc_hdr_size kstat.zfs.misc.arcstats.hdr_size
+# TYPE node_zfs_arc_hdr_size untyped
+node_zfs_arc_hdr_size 1.636108e+07
+# HELP node_zfs_arc_hits kstat.zfs.misc.arcstats.hits
+# TYPE node_zfs_arc_hits untyped
+node_zfs_arc_hits 8.772612e+06
+# HELP node_zfs_arc_l2_abort_lowmem kstat.zfs.misc.arcstats.l2_abort_lowmem
+# TYPE node_zfs_arc_l2_abort_lowmem untyped
+node_zfs_arc_l2_abort_lowmem 0
+# HELP node_zfs_arc_l2_asize kstat.zfs.misc.arcstats.l2_asize
+# TYPE node_zfs_arc_l2_asize untyped
+node_zfs_arc_l2_asize 0
+# HELP node_zfs_arc_l2_cdata_free_on_write kstat.zfs.misc.arcstats.l2_cdata_free_on_write
+# TYPE node_zfs_arc_l2_cdata_free_on_write untyped
+node_zfs_arc_l2_cdata_free_on_write 0
+# HELP node_zfs_arc_l2_cksum_bad kstat.zfs.misc.arcstats.l2_cksum_bad
+# TYPE node_zfs_arc_l2_cksum_bad untyped
+node_zfs_arc_l2_cksum_bad 0
+# HELP node_zfs_arc_l2_compress_failures kstat.zfs.misc.arcstats.l2_compress_failures
+# TYPE node_zfs_arc_l2_compress_failures untyped
+node_zfs_arc_l2_compress_failures 0
+# HELP node_zfs_arc_l2_compress_successes kstat.zfs.misc.arcstats.l2_compress_successes
+# TYPE node_zfs_arc_l2_compress_successes untyped
+node_zfs_arc_l2_compress_successes 0
+# HELP node_zfs_arc_l2_compress_zeros kstat.zfs.misc.arcstats.l2_compress_zeros
+# TYPE node_zfs_arc_l2_compress_zeros untyped
+node_zfs_arc_l2_compress_zeros 0
+# HELP node_zfs_arc_l2_evict_l1cached kstat.zfs.misc.arcstats.l2_evict_l1cached
+# TYPE node_zfs_arc_l2_evict_l1cached untyped
+node_zfs_arc_l2_evict_l1cached 0
+# HELP node_zfs_arc_l2_evict_lock_retry kstat.zfs.misc.arcstats.l2_evict_lock_retry
+# TYPE node_zfs_arc_l2_evict_lock_retry untyped
+node_zfs_arc_l2_evict_lock_retry 0
+# HELP node_zfs_arc_l2_evict_reading kstat.zfs.misc.arcstats.l2_evict_reading
+# TYPE node_zfs_arc_l2_evict_reading untyped
+node_zfs_arc_l2_evict_reading 0
+# HELP node_zfs_arc_l2_feeds kstat.zfs.misc.arcstats.l2_feeds
+# TYPE node_zfs_arc_l2_feeds untyped
+node_zfs_arc_l2_feeds 0
+# HELP node_zfs_arc_l2_free_on_write kstat.zfs.misc.arcstats.l2_free_on_write
+# TYPE node_zfs_arc_l2_free_on_write untyped
+node_zfs_arc_l2_free_on_write 0
+# HELP node_zfs_arc_l2_hdr_size kstat.zfs.misc.arcstats.l2_hdr_size
+# TYPE node_zfs_arc_l2_hdr_size untyped
+node_zfs_arc_l2_hdr_size 0
+# HELP node_zfs_arc_l2_hits kstat.zfs.misc.arcstats.l2_hits
+# TYPE node_zfs_arc_l2_hits untyped
+node_zfs_arc_l2_hits 0
+# HELP node_zfs_arc_l2_io_error kstat.zfs.misc.arcstats.l2_io_error
+# TYPE node_zfs_arc_l2_io_error untyped
+node_zfs_arc_l2_io_error 0
+# HELP node_zfs_arc_l2_misses kstat.zfs.misc.arcstats.l2_misses
+# TYPE node_zfs_arc_l2_misses untyped
+node_zfs_arc_l2_misses 0
+# HELP node_zfs_arc_l2_read_bytes kstat.zfs.misc.arcstats.l2_read_bytes
+# TYPE node_zfs_arc_l2_read_bytes untyped
+node_zfs_arc_l2_read_bytes 0
+# HELP node_zfs_arc_l2_rw_clash kstat.zfs.misc.arcstats.l2_rw_clash
+# TYPE node_zfs_arc_l2_rw_clash untyped
+node_zfs_arc_l2_rw_clash 0
+# HELP node_zfs_arc_l2_size kstat.zfs.misc.arcstats.l2_size
+# TYPE node_zfs_arc_l2_size untyped
+node_zfs_arc_l2_size 0
+# HELP node_zfs_arc_l2_write_bytes kstat.zfs.misc.arcstats.l2_write_bytes
+# TYPE node_zfs_arc_l2_write_bytes untyped
+node_zfs_arc_l2_write_bytes 0
+# HELP node_zfs_arc_l2_writes_done kstat.zfs.misc.arcstats.l2_writes_done
+# TYPE node_zfs_arc_l2_writes_done untyped
+node_zfs_arc_l2_writes_done 0
+# HELP node_zfs_arc_l2_writes_error kstat.zfs.misc.arcstats.l2_writes_error
+# TYPE node_zfs_arc_l2_writes_error untyped
+node_zfs_arc_l2_writes_error 0
+# HELP node_zfs_arc_l2_writes_lock_retry kstat.zfs.misc.arcstats.l2_writes_lock_retry
+# TYPE node_zfs_arc_l2_writes_lock_retry untyped
+node_zfs_arc_l2_writes_lock_retry 0
+# HELP node_zfs_arc_l2_writes_sent kstat.zfs.misc.arcstats.l2_writes_sent
+# TYPE node_zfs_arc_l2_writes_sent untyped
+node_zfs_arc_l2_writes_sent 0
+# HELP node_zfs_arc_memory_direct_count kstat.zfs.misc.arcstats.memory_direct_count
+# TYPE node_zfs_arc_memory_direct_count untyped
+node_zfs_arc_memory_direct_count 542
+# HELP node_zfs_arc_memory_indirect_count kstat.zfs.misc.arcstats.memory_indirect_count
+# TYPE node_zfs_arc_memory_indirect_count untyped
+node_zfs_arc_memory_indirect_count 3006
+# HELP node_zfs_arc_memory_throttle_count kstat.zfs.misc.arcstats.memory_throttle_count
+# TYPE node_zfs_arc_memory_throttle_count untyped
+node_zfs_arc_memory_throttle_count 0
+# HELP node_zfs_arc_metadata_size kstat.zfs.misc.arcstats.metadata_size
+# TYPE node_zfs_arc_metadata_size untyped
+node_zfs_arc_metadata_size 1.7529856e+08
+# HELP node_zfs_arc_mfu_evictable_data kstat.zfs.misc.arcstats.mfu_evictable_data
+# TYPE node_zfs_arc_mfu_evictable_data untyped
+node_zfs_arc_mfu_evictable_data 1.017613824e+09
+# HELP node_zfs_arc_mfu_evictable_metadata kstat.zfs.misc.arcstats.mfu_evictable_metadata
+# TYPE node_zfs_arc_mfu_evictable_metadata untyped
+node_zfs_arc_mfu_evictable_metadata 9.163776e+06
+# HELP node_zfs_arc_mfu_ghost_evictable_data kstat.zfs.misc.arcstats.mfu_ghost_evictable_data
+# TYPE node_zfs_arc_mfu_ghost_evictable_data untyped
+node_zfs_arc_mfu_ghost_evictable_data 9.6731136e+07
+# HELP node_zfs_arc_mfu_ghost_evictable_metadata kstat.zfs.misc.arcstats.mfu_ghost_evictable_metadata
+# TYPE node_zfs_arc_mfu_ghost_evictable_metadata untyped
+node_zfs_arc_mfu_ghost_evictable_metadata 8.205312e+06
+# HELP node_zfs_arc_mfu_ghost_hits kstat.zfs.misc.arcstats.mfu_ghost_hits
+# TYPE node_zfs_arc_mfu_ghost_hits untyped
+node_zfs_arc_mfu_ghost_hits 821
+# HELP node_zfs_arc_mfu_ghost_size kstat.zfs.misc.arcstats.mfu_ghost_size
+# TYPE node_zfs_arc_mfu_ghost_size untyped
+node_zfs_arc_mfu_ghost_size 1.04936448e+08
+# HELP node_zfs_arc_mfu_hits kstat.zfs.misc.arcstats.mfu_hits
+# TYPE node_zfs_arc_mfu_hits untyped
+node_zfs_arc_mfu_hits 7.829854e+06
+# HELP node_zfs_arc_mfu_size kstat.zfs.misc.arcstats.mfu_size
+# TYPE node_zfs_arc_mfu_size untyped
+node_zfs_arc_mfu_size 1.066623488e+09
+# HELP node_zfs_arc_misses kstat.zfs.misc.arcstats.misses
+# TYPE node_zfs_arc_misses untyped
+node_zfs_arc_misses 604635
+# HELP node_zfs_arc_mru_evictable_data kstat.zfs.misc.arcstats.mru_evictable_data
+# TYPE node_zfs_arc_mru_evictable_data untyped
+node_zfs_arc_mru_evictable_data 2.78091264e+08
+# HELP node_zfs_arc_mru_evictable_metadata kstat.zfs.misc.arcstats.mru_evictable_metadata
+# TYPE node_zfs_arc_mru_evictable_metadata untyped
+node_zfs_arc_mru_evictable_metadata 1.8606592e+07
+# HELP node_zfs_arc_mru_ghost_evictable_data kstat.zfs.misc.arcstats.mru_ghost_evictable_data
+# TYPE node_zfs_arc_mru_ghost_evictable_data untyped
+node_zfs_arc_mru_ghost_evictable_data 8.83765248e+08
+# HELP node_zfs_arc_mru_ghost_evictable_metadata kstat.zfs.misc.arcstats.mru_ghost_evictable_metadata
+# TYPE node_zfs_arc_mru_ghost_evictable_metadata untyped
+node_zfs_arc_mru_ghost_evictable_metadata 1.1596288e+08
+# HELP node_zfs_arc_mru_ghost_hits kstat.zfs.misc.arcstats.mru_ghost_hits
+# TYPE node_zfs_arc_mru_ghost_hits untyped
+node_zfs_arc_mru_ghost_hits 21100
+# HELP node_zfs_arc_mru_ghost_size kstat.zfs.misc.arcstats.mru_ghost_size
+# TYPE node_zfs_arc_mru_ghost_size untyped
+node_zfs_arc_mru_ghost_size 9.99728128e+08
+# HELP node_zfs_arc_mru_hits kstat.zfs.misc.arcstats.mru_hits
+# TYPE node_zfs_arc_mru_hits untyped
+node_zfs_arc_mru_hits 855535
+# HELP node_zfs_arc_mru_size kstat.zfs.misc.arcstats.mru_size
+# TYPE node_zfs_arc_mru_size untyped
+node_zfs_arc_mru_size 4.02593792e+08
+# HELP node_zfs_arc_mutex_miss kstat.zfs.misc.arcstats.mutex_miss
+# TYPE node_zfs_arc_mutex_miss untyped
+node_zfs_arc_mutex_miss 2
+# HELP node_zfs_arc_other_size kstat.zfs.misc.arcstats.other_size
+# TYPE node_zfs_arc_other_size untyped
+node_zfs_arc_other_size 1.16443992e+08
+# HELP node_zfs_arc_p kstat.zfs.misc.arcstats.p
+# TYPE node_zfs_arc_p untyped
+node_zfs_arc_p 5.16395305e+08
+# HELP node_zfs_arc_prefetch_data_hits kstat.zfs.misc.arcstats.prefetch_data_hits
+# TYPE node_zfs_arc_prefetch_data_hits untyped
+node_zfs_arc_prefetch_data_hits 3615
+# HELP node_zfs_arc_prefetch_data_misses kstat.zfs.misc.arcstats.prefetch_data_misses
+# TYPE node_zfs_arc_prefetch_data_misses untyped
+node_zfs_arc_prefetch_data_misses 17094
+# HELP node_zfs_arc_prefetch_metadata_hits kstat.zfs.misc.arcstats.prefetch_metadata_hits
+# TYPE node_zfs_arc_prefetch_metadata_hits untyped
+node_zfs_arc_prefetch_metadata_hits 83612
+# HELP node_zfs_arc_prefetch_metadata_misses kstat.zfs.misc.arcstats.prefetch_metadata_misses
+# TYPE node_zfs_arc_prefetch_metadata_misses untyped
+node_zfs_arc_prefetch_metadata_misses 16071
+# HELP node_zfs_arc_size kstat.zfs.misc.arcstats.size
+# TYPE node_zfs_arc_size untyped
+node_zfs_arc_size 1.603939792e+09
+# HELP node_zfs_dmu_tx_dmu_tx_assigned kstat.zfs.misc.dmu_tx.dmu_tx_assigned
+# TYPE node_zfs_dmu_tx_dmu_tx_assigned untyped
+node_zfs_dmu_tx_dmu_tx_assigned 3.532844e+06
+# HELP node_zfs_dmu_tx_dmu_tx_delay kstat.zfs.misc.dmu_tx.dmu_tx_delay
+# TYPE node_zfs_dmu_tx_dmu_tx_delay untyped
+node_zfs_dmu_tx_dmu_tx_delay 0
+# HELP node_zfs_dmu_tx_dmu_tx_dirty_delay kstat.zfs.misc.dmu_tx.dmu_tx_dirty_delay
+# TYPE node_zfs_dmu_tx_dmu_tx_dirty_delay untyped
+node_zfs_dmu_tx_dmu_tx_dirty_delay 0
+# HELP node_zfs_dmu_tx_dmu_tx_dirty_over_max kstat.zfs.misc.dmu_tx.dmu_tx_dirty_over_max
+# TYPE node_zfs_dmu_tx_dmu_tx_dirty_over_max untyped
+node_zfs_dmu_tx_dmu_tx_dirty_over_max 0
+# HELP node_zfs_dmu_tx_dmu_tx_dirty_throttle kstat.zfs.misc.dmu_tx.dmu_tx_dirty_throttle
+# TYPE node_zfs_dmu_tx_dmu_tx_dirty_throttle untyped
+node_zfs_dmu_tx_dmu_tx_dirty_throttle 0
+# HELP node_zfs_dmu_tx_dmu_tx_error kstat.zfs.misc.dmu_tx.dmu_tx_error
+# TYPE node_zfs_dmu_tx_dmu_tx_error untyped
+node_zfs_dmu_tx_dmu_tx_error 0
+# HELP node_zfs_dmu_tx_dmu_tx_group kstat.zfs.misc.dmu_tx.dmu_tx_group
+# TYPE node_zfs_dmu_tx_dmu_tx_group untyped
+node_zfs_dmu_tx_dmu_tx_group 0
+# HELP node_zfs_dmu_tx_dmu_tx_memory_reclaim kstat.zfs.misc.dmu_tx.dmu_tx_memory_reclaim
+# TYPE node_zfs_dmu_tx_dmu_tx_memory_reclaim untyped
+node_zfs_dmu_tx_dmu_tx_memory_reclaim 0
+# HELP node_zfs_dmu_tx_dmu_tx_memory_reserve kstat.zfs.misc.dmu_tx.dmu_tx_memory_reserve
+# TYPE node_zfs_dmu_tx_dmu_tx_memory_reserve untyped
+node_zfs_dmu_tx_dmu_tx_memory_reserve 0
+# HELP node_zfs_dmu_tx_dmu_tx_quota kstat.zfs.misc.dmu_tx.dmu_tx_quota
+# TYPE node_zfs_dmu_tx_dmu_tx_quota untyped
+node_zfs_dmu_tx_dmu_tx_quota 0
+# HELP node_zfs_dmu_tx_dmu_tx_suspended kstat.zfs.misc.dmu_tx.dmu_tx_suspended
+# TYPE node_zfs_dmu_tx_dmu_tx_suspended untyped
+node_zfs_dmu_tx_dmu_tx_suspended 0
+# HELP node_zfs_fm_erpt-dropped kstat.zfs.misc.fm.erpt-dropped
+# TYPE node_zfs_fm_erpt-dropped untyped
+node_zfs_fm_erpt-dropped 18
+# HELP node_zfs_fm_erpt-set-failed kstat.zfs.misc.fm.erpt-set-failed
+# TYPE node_zfs_fm_erpt-set-failed untyped
+node_zfs_fm_erpt-set-failed 0
+# HELP node_zfs_fm_fmri-set-failed kstat.zfs.misc.fm.fmri-set-failed
+# TYPE node_zfs_fm_fmri-set-failed untyped
+node_zfs_fm_fmri-set-failed 0
+# HELP node_zfs_fm_payload-set-failed kstat.zfs.misc.fm.payload-set-failed
+# TYPE node_zfs_fm_payload-set-failed untyped
+node_zfs_fm_payload-set-failed 0
+# HELP node_zfs_vdev_cache_delegations kstat.zfs.misc.vdev_cache_stats.delegations
+# TYPE node_zfs_vdev_cache_delegations untyped
+node_zfs_vdev_cache_delegations 40
+# HELP node_zfs_vdev_cache_hits kstat.zfs.misc.vdev_cache_stats.hits
+# TYPE node_zfs_vdev_cache_hits untyped
+node_zfs_vdev_cache_hits 0
+# HELP node_zfs_vdev_cache_misses kstat.zfs.misc.vdev_cache_stats.misses
+# TYPE node_zfs_vdev_cache_misses untyped
+node_zfs_vdev_cache_misses 0
+# HELP node_zfs_xuio_onloan_read_buf kstat.zfs.misc.xuio_stats.onloan_read_buf
+# TYPE node_zfs_xuio_onloan_read_buf untyped
+node_zfs_xuio_onloan_read_buf 32
+# HELP node_zfs_xuio_onloan_write_buf kstat.zfs.misc.xuio_stats.onloan_write_buf
+# TYPE node_zfs_xuio_onloan_write_buf untyped
+node_zfs_xuio_onloan_write_buf 0
+# HELP node_zfs_xuio_read_buf_copied kstat.zfs.misc.xuio_stats.read_buf_copied
+# TYPE node_zfs_xuio_read_buf_copied untyped
+node_zfs_xuio_read_buf_copied 0
+# HELP node_zfs_xuio_read_buf_nocopy kstat.zfs.misc.xuio_stats.read_buf_nocopy
+# TYPE node_zfs_xuio_read_buf_nocopy untyped
+node_zfs_xuio_read_buf_nocopy 0
+# HELP node_zfs_xuio_write_buf_copied kstat.zfs.misc.xuio_stats.write_buf_copied
+# TYPE node_zfs_xuio_write_buf_copied untyped
+node_zfs_xuio_write_buf_copied 0
+# HELP node_zfs_xuio_write_buf_nocopy kstat.zfs.misc.xuio_stats.write_buf_nocopy
+# TYPE node_zfs_xuio_write_buf_nocopy untyped
+node_zfs_xuio_write_buf_nocopy 0
+# HELP node_zfs_zfetch_bogus_streams kstat.zfs.misc.zfetchstats.bogus_streams
+# TYPE node_zfs_zfetch_bogus_streams untyped
+node_zfs_zfetch_bogus_streams 0
+# HELP node_zfs_zfetch_colinear_hits kstat.zfs.misc.zfetchstats.colinear_hits
+# TYPE node_zfs_zfetch_colinear_hits untyped
+node_zfs_zfetch_colinear_hits 0
+# HELP node_zfs_zfetch_colinear_misses kstat.zfs.misc.zfetchstats.colinear_misses
+# TYPE node_zfs_zfetch_colinear_misses untyped
+node_zfs_zfetch_colinear_misses 11
+# HELP node_zfs_zfetch_hits kstat.zfs.misc.zfetchstats.hits
+# TYPE node_zfs_zfetch_hits untyped
+node_zfs_zfetch_hits 7.067992e+06
+# HELP node_zfs_zfetch_misses kstat.zfs.misc.zfetchstats.misses
+# TYPE node_zfs_zfetch_misses untyped
+node_zfs_zfetch_misses 11
+# HELP node_zfs_zfetch_reclaim_failures kstat.zfs.misc.zfetchstats.reclaim_failures
+# TYPE node_zfs_zfetch_reclaim_failures untyped
+node_zfs_zfetch_reclaim_failures 11
+# HELP node_zfs_zfetch_reclaim_successes kstat.zfs.misc.zfetchstats.reclaim_successes
+# TYPE node_zfs_zfetch_reclaim_successes untyped
+node_zfs_zfetch_reclaim_successes 0
+# HELP node_zfs_zfetch_streams_noresets kstat.zfs.misc.zfetchstats.streams_noresets
+# TYPE node_zfs_zfetch_streams_noresets untyped
+node_zfs_zfetch_streams_noresets 2
+# HELP node_zfs_zfetch_streams_resets kstat.zfs.misc.zfetchstats.streams_resets
+# TYPE node_zfs_zfetch_streams_resets untyped
+node_zfs_zfetch_streams_resets 0
+# HELP node_zfs_zfetch_stride_hits kstat.zfs.misc.zfetchstats.stride_hits
+# TYPE node_zfs_zfetch_stride_hits untyped
+node_zfs_zfetch_stride_hits 7.06799e+06
+# HELP node_zfs_zfetch_stride_misses kstat.zfs.misc.zfetchstats.stride_misses
+# TYPE node_zfs_zfetch_stride_misses untyped
+node_zfs_zfetch_stride_misses 0
+# HELP node_zfs_zil_zil_commit_count kstat.zfs.misc.zil.zil_commit_count
+# TYPE node_zfs_zil_zil_commit_count untyped
+node_zfs_zil_zil_commit_count 10
+# HELP node_zfs_zil_zil_commit_writer_count kstat.zfs.misc.zil.zil_commit_writer_count
+# TYPE node_zfs_zil_zil_commit_writer_count untyped
+node_zfs_zil_zil_commit_writer_count 0
+# HELP node_zfs_zil_zil_itx_copied_bytes kstat.zfs.misc.zil.zil_itx_copied_bytes
+# TYPE node_zfs_zil_zil_itx_copied_bytes untyped
+node_zfs_zil_zil_itx_copied_bytes 0
+# HELP node_zfs_zil_zil_itx_copied_count kstat.zfs.misc.zil.zil_itx_copied_count
+# TYPE node_zfs_zil_zil_itx_copied_count untyped
+node_zfs_zil_zil_itx_copied_count 0
+# HELP node_zfs_zil_zil_itx_count kstat.zfs.misc.zil.zil_itx_count
+# TYPE node_zfs_zil_zil_itx_count untyped
+node_zfs_zil_zil_itx_count 0
+# HELP node_zfs_zil_zil_itx_indirect_bytes kstat.zfs.misc.zil.zil_itx_indirect_bytes
+# TYPE node_zfs_zil_zil_itx_indirect_bytes untyped
+node_zfs_zil_zil_itx_indirect_bytes 0
+# HELP node_zfs_zil_zil_itx_indirect_count kstat.zfs.misc.zil.zil_itx_indirect_count
+# TYPE node_zfs_zil_zil_itx_indirect_count untyped
+node_zfs_zil_zil_itx_indirect_count 0
+# HELP node_zfs_zil_zil_itx_metaslab_normal_bytes kstat.zfs.misc.zil.zil_itx_metaslab_normal_bytes
+# TYPE node_zfs_zil_zil_itx_metaslab_normal_bytes untyped
+node_zfs_zil_zil_itx_metaslab_normal_bytes 0
+# HELP node_zfs_zil_zil_itx_metaslab_normal_count kstat.zfs.misc.zil.zil_itx_metaslab_normal_count
+# TYPE node_zfs_zil_zil_itx_metaslab_normal_count untyped
+node_zfs_zil_zil_itx_metaslab_normal_count 0
+# HELP node_zfs_zil_zil_itx_metaslab_slog_bytes kstat.zfs.misc.zil.zil_itx_metaslab_slog_bytes
+# TYPE node_zfs_zil_zil_itx_metaslab_slog_bytes untyped
+node_zfs_zil_zil_itx_metaslab_slog_bytes 0
+# HELP node_zfs_zil_zil_itx_metaslab_slog_count kstat.zfs.misc.zil.zil_itx_metaslab_slog_count
+# TYPE node_zfs_zil_zil_itx_metaslab_slog_count untyped
+node_zfs_zil_zil_itx_metaslab_slog_count 0
+# HELP node_zfs_zil_zil_itx_needcopy_bytes kstat.zfs.misc.zil.zil_itx_needcopy_bytes
+# TYPE node_zfs_zil_zil_itx_needcopy_bytes untyped
+node_zfs_zil_zil_itx_needcopy_bytes 0
+# HELP node_zfs_zil_zil_itx_needcopy_count kstat.zfs.misc.zil.zil_itx_needcopy_count
+# TYPE node_zfs_zil_zil_itx_needcopy_count untyped
+node_zfs_zil_zil_itx_needcopy_count 0
 # HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
 # TYPE process_cpu_seconds_total counter
 # HELP process_max_fds Maximum number of open file descriptors.

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2383,6 +2383,18 @@ node_zfsFetch_stride_hits 7.06799e+06
 # HELP node_zfsFetch_stride_misses kstat.zfs.misc.zfetchstats.stride_misses
 # TYPE node_zfsFetch_stride_misses untyped
 node_zfsFetch_stride_misses 0
+# HELP node_zfsFm_erpt-dropped kstat.zfs.misc.fm.erpt-dropped
+# TYPE node_zfsFm_erpt-dropped untyped
+node_zfsFm_erpt-dropped 18
+# HELP node_zfsFm_erpt-set-failed kstat.zfs.misc.fm.erpt-set-failed
+# TYPE node_zfsFm_erpt-set-failed untyped
+node_zfsFm_erpt-set-failed 0
+# HELP node_zfsFm_fmri-set-failed kstat.zfs.misc.fm.fmri-set-failed
+# TYPE node_zfsFm_fmri-set-failed untyped
+node_zfsFm_fmri-set-failed 0
+# HELP node_zfsFm_payload-set-failed kstat.zfs.misc.fm.payload-set-failed
+# TYPE node_zfsFm_payload-set-failed untyped
+node_zfsFm_payload-set-failed 0
 # HELP node_zfsVdevCache_delegations kstat.zfs.misc.vdev_cache_stats.delegations
 # TYPE node_zfsVdevCache_delegations untyped
 node_zfsVdevCache_delegations 40

--- a/collector/fixtures/proc/spl/kstat/zfs/dmu_tx
+++ b/collector/fixtures/proc/spl/kstat/zfs/dmu_tx
@@ -1,0 +1,13 @@
+5 1 0x01 11 528 8010436841 354962070418194
+name                            type data
+dmu_tx_assigned                 4    3532844
+dmu_tx_delay                    4    0
+dmu_tx_error                    4    0
+dmu_tx_suspended                4    0
+dmu_tx_group                    4    0
+dmu_tx_memory_reserve           4    0
+dmu_tx_memory_reclaim           4    0
+dmu_tx_dirty_throttle           4    0
+dmu_tx_dirty_delay              4    0
+dmu_tx_dirty_over_max           4    0
+dmu_tx_quota                    4    0

--- a/collector/fixtures/proc/spl/kstat/zfs/fm
+++ b/collector/fixtures/proc/spl/kstat/zfs/fm
@@ -1,0 +1,6 @@
+0 1 0x01 4 192 8007255140 354329591145385
+name                            type data
+erpt-dropped                    4    18
+erpt-set-failed                 4    0
+fmri-set-failed                 4    0
+payload-set-failed              4    0

--- a/collector/fixtures/proc/spl/kstat/zfs/vdev_cache_stats
+++ b/collector/fixtures/proc/spl/kstat/zfs/vdev_cache_stats
@@ -1,0 +1,5 @@
+8 1 0x01 3 144 8012540758 352116106118781
+name                            type data
+delegations                     4    40
+hits                            4    0
+misses                          4    0

--- a/collector/fixtures/proc/spl/kstat/zfs/xuio_stats
+++ b/collector/fixtures/proc/spl/kstat/zfs/xuio_stats
@@ -1,0 +1,8 @@
+2 1 0x01 6 288 8009100742 353415816865654
+name                            type data
+onloan_read_buf                 4    32
+onloan_write_buf                4    0
+read_buf_copied                 4    0
+read_buf_nocopy                 4    0
+write_buf_copied                4    0
+write_buf_nocopy                4    0

--- a/collector/fixtures/proc/spl/kstat/zfs/zfetchstats
+++ b/collector/fixtures/proc/spl/kstat/zfs/zfetchstats
@@ -1,0 +1,13 @@
+4 1 0x01 11 528 8010434610 345692669858836
+name                            type data
+hits                            4    7067992
+misses                          4    11
+colinear_hits                   4    0
+colinear_misses                 4    11
+stride_hits                     4    7067990
+stride_misses                   4    0
+reclaim_successes               4    0
+reclaim_failures                4    11
+streams_resets                  4    0
+streams_noresets                4    2
+bogus_streams                   4    0

--- a/collector/fixtures/proc/spl/kstat/zfs/zil
+++ b/collector/fixtures/proc/spl/kstat/zfs/zil
@@ -1,0 +1,15 @@
+7 1 0x01 13 624 8012538347 351689526932992
+name                            type data
+zil_commit_count                4    10
+zil_commit_writer_count         4    0
+zil_itx_count                   4    0
+zil_itx_indirect_count          4    0
+zil_itx_indirect_bytes          4    0
+zil_itx_copied_count            4    0
+zil_itx_copied_bytes            4    0
+zil_itx_needcopy_count          4    0
+zil_itx_needcopy_bytes          4    0
+zil_itx_metaslab_normal_count   4    0
+zil_itx_metaslab_normal_bytes   4    0
+zil_itx_metaslab_slog_count     4    0
+zil_itx_metaslab_slog_bytes     4    0

--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -52,13 +52,13 @@ func NewZFSCollector() (Collector, error) {
 	var z zfsCollector
 	z.linuxProcpathBase = "spl/kstat/zfs"
 	z.linuxPathMap = map[string]string{
-		"zfsArc":       "arcstats",
-		"zfsDmuTx":     "dmu_tx",
-		"zfsFm":        "fm",
-		"zfsFetch":     "zfetchstats",
-		"zfsVdevCache": "vdev_cache_stats",
-		"zfsXuio":      "xuio_stats",
-		"zfsZil":       "zil",
+		"zfs_arc":        "arcstats",
+		"zfs_dmu_tx":     "dmu_tx",
+		"zfs_fm":         "fm",
+		"zfs_zfetch":     "zfetchstats",
+		"zfs_vdev_cache": "vdev_cache_stats",
+		"zfs_xuio":       "xuio_stats",
+		"zfs_zil":        "zil",
 	}
 	return &z, nil
 }

--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -35,6 +35,7 @@ type zfsSubsystemName string
 
 const (
 	arc            = zfsSubsystemName("zfsArc")
+	zfetch         = zfsSubsystemName("zfsFetch")
 	zpoolSubsystem = zfsSubsystemName("zfsPool")
 )
 
@@ -70,6 +71,10 @@ func (c *zfsCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	case err != nil:
 		return err
 	}
+
+	// Zfetchstats
+	err = c.updateZfetchstats(ch)
+	if err != nil { return err }
 
 	// Pool stats
 	return c.updatePoolStats(ch)

--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -35,6 +35,7 @@ type zfsSubsystemName string
 
 const (
 	arc            = zfsSubsystemName("zfsArc")
+	fm             = zfsSubsystemName("zfsFm")
 	vdevCache      = zfsSubsystemName("zfsVdevCache")
 	xuio           = zfsSubsystemName("zfsXuio")
 	zfetch         = zfsSubsystemName("zfsFetch")
@@ -89,6 +90,10 @@ func (c *zfsCollector) Update(ch chan<- prometheus.Metric) (err error) {
 
 	// XuioStats
 	err = c.updateXuioStats(ch)
+	if err != nil { return err }
+
+	// Fm
+	err = c.updateFm(ch)
 	if err != nil { return err }
 
 	// Pool stats

--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -35,6 +35,7 @@ type zfsSubsystemName string
 
 const (
 	arc            = zfsSubsystemName("zfsArc")
+	vdevCache      = zfsSubsystemName("zfsVdevCache")
 	zfetch         = zfsSubsystemName("zfsFetch")
 	zil            = zfsSubsystemName("zfsZil")
 	zpoolSubsystem = zfsSubsystemName("zfsPool")
@@ -79,6 +80,10 @@ func (c *zfsCollector) Update(ch chan<- prometheus.Metric) (err error) {
 
 	// Zil
 	err = c.updateZil(ch)
+	if err != nil { return err }
+
+	// VdevCacheStats
+	err = c.updateVdevCacheStats(ch)
 	if err != nil { return err }
 
 	// Pool stats

--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -36,6 +36,7 @@ type zfsSubsystemName string
 const (
 	arc            = zfsSubsystemName("zfsArc")
 	zfetch         = zfsSubsystemName("zfsFetch")
+	zil            = zfsSubsystemName("zfsZil")
 	zpoolSubsystem = zfsSubsystemName("zfsPool")
 )
 
@@ -74,6 +75,10 @@ func (c *zfsCollector) Update(ch chan<- prometheus.Metric) (err error) {
 
 	// Zfetchstats
 	err = c.updateZfetchstats(ch)
+	if err != nil { return err }
+
+	// Zil
+	err = c.updateZil(ch)
 	if err != nil { return err }
 
 	// Pool stats

--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -36,6 +36,7 @@ type zfsSubsystemName string
 const (
 	arc            = zfsSubsystemName("zfsArc")
 	vdevCache      = zfsSubsystemName("zfsVdevCache")
+	xuio           = zfsSubsystemName("zfsXuio")
 	zfetch         = zfsSubsystemName("zfsFetch")
 	zil            = zfsSubsystemName("zfsZil")
 	zpoolSubsystem = zfsSubsystemName("zfsPool")
@@ -84,6 +85,10 @@ func (c *zfsCollector) Update(ch chan<- prometheus.Metric) (err error) {
 
 	// VdevCacheStats
 	err = c.updateVdevCacheStats(ch)
+	if err != nil { return err }
+
+	// XuioStats
+	err = c.updateXuioStats(ch)
 	if err != nil { return err }
 
 	// Pool stats

--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -35,6 +35,7 @@ type zfsSubsystemName string
 
 const (
 	arc            = zfsSubsystemName("zfsArc")
+	dmuTx          = zfsSubsystemName("zfsDmuTx")
 	fm             = zfsSubsystemName("zfsFm")
 	vdevCache      = zfsSubsystemName("zfsVdevCache")
 	xuio           = zfsSubsystemName("zfsXuio")
@@ -78,23 +79,39 @@ func (c *zfsCollector) Update(ch chan<- prometheus.Metric) (err error) {
 
 	// Zfetchstats
 	err = c.updateZfetchstats(ch)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 
 	// Zil
 	err = c.updateZil(ch)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 
 	// VdevCacheStats
 	err = c.updateVdevCacheStats(ch)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 
 	// XuioStats
 	err = c.updateXuioStats(ch)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 
 	// Fm
 	err = c.updateFm(ch)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
+
+	// DmuTx
+	err = c.updateDmuTx(ch)
+	if err != nil {
+		return err
+	}
 
 	// Pool stats
 	return c.updatePoolStats(ch)

--- a/collector/zfs_linux.go
+++ b/collector/zfs_linux.go
@@ -30,6 +30,7 @@ const (
 	zfsProcpathBase  = "spl/kstat/zfs/"
 	zfsArcstatsExt   = "arcstats"
 	zfsFetchstatsExt = "zfetchstats"
+	zfsZilExt        = "zil"
 )
 
 func (c *zfsCollector) openProcFile(path string) (file *os.File, err error) {
@@ -62,6 +63,18 @@ func (c *zfsCollector) updateZfetchstats(ch chan<- prometheus.Metric) (err error
 
 	return c.parseProcfsFile(file, zfsFetchstatsExt, func(s zfsSysctl, v zfsMetricValue) {
 		ch <- c.constSysctlMetric(zfetch, s, v)
+	})
+}
+
+func (c *zfsCollector) updateZil(ch chan<- prometheus.Metric) (err error) {
+	file, err := c.openProcFile(filepath.Join(zfsProcpathBase, zfsZilExt))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return c.parseProcfsFile(file, zfsZilExt, func(s zfsSysctl, v zfsMetricValue) {
+		ch <- c.constSysctlMetric(zil, s, v)
 	})
 }
 

--- a/collector/zfs_linux.go
+++ b/collector/zfs_linux.go
@@ -31,6 +31,7 @@ const (
 	zfsArcstatsExt       = "arcstats"
 	zfsFetchstatsExt     = "zfetchstats"
 	zfsVdevCacheStatsExt = "vdev_cache_stats"
+	zfsXuioStatsExt      = "xuio_stats"
 	zfsZilExt            = "zil"
 )
 
@@ -88,6 +89,18 @@ func (c *zfsCollector) updateVdevCacheStats(ch chan<- prometheus.Metric) (err er
 
 	return c.parseProcfsFile(file, zfsVdevCacheStatsExt, func(s zfsSysctl, v zfsMetricValue) {
 		ch <- c.constSysctlMetric(vdevCache, s, v)
+	})
+}
+
+func (c *zfsCollector) updateXuioStats(ch chan<- prometheus.Metric) (err error) {
+	file, err := c.openProcFile(filepath.Join(zfsProcpathBase, zfsXuioStatsExt))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return c.parseProcfsFile(file, zfsXuioStatsExt, func(s zfsSysctl, v zfsMetricValue) {
+		ch <- c.constSysctlMetric(xuio, s, v)
 	})
 }
 

--- a/collector/zfs_linux.go
+++ b/collector/zfs_linux.go
@@ -27,10 +27,11 @@ import (
 )
 
 const (
-	zfsProcpathBase  = "spl/kstat/zfs/"
-	zfsArcstatsExt   = "arcstats"
-	zfsFetchstatsExt = "zfetchstats"
-	zfsZilExt        = "zil"
+	zfsProcpathBase      = "spl/kstat/zfs/"
+	zfsArcstatsExt       = "arcstats"
+	zfsFetchstatsExt     = "zfetchstats"
+	zfsVdevCacheStatsExt = "vdev_cache_stats"
+	zfsZilExt            = "zil"
 )
 
 func (c *zfsCollector) openProcFile(path string) (file *os.File, err error) {
@@ -75,6 +76,18 @@ func (c *zfsCollector) updateZil(ch chan<- prometheus.Metric) (err error) {
 
 	return c.parseProcfsFile(file, zfsZilExt, func(s zfsSysctl, v zfsMetricValue) {
 		ch <- c.constSysctlMetric(zil, s, v)
+	})
+}
+
+func (c *zfsCollector) updateVdevCacheStats(ch chan<- prometheus.Metric) (err error) {
+	file, err := c.openProcFile(filepath.Join(zfsProcpathBase, zfsVdevCacheStatsExt))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return c.parseProcfsFile(file, zfsVdevCacheStatsExt, func(s zfsSysctl, v zfsMetricValue) {
+		ch <- c.constSysctlMetric(vdevCache, s, v)
 	})
 }
 

--- a/collector/zfs_linux.go
+++ b/collector/zfs_linux.go
@@ -29,6 +29,7 @@ import (
 const (
 	zfsProcpathBase      = "spl/kstat/zfs/"
 	zfsArcstatsExt       = "arcstats"
+	zfsFmExt             = "fm"
 	zfsFetchstatsExt     = "zfetchstats"
 	zfsVdevCacheStatsExt = "vdev_cache_stats"
 	zfsXuioStatsExt      = "xuio_stats"
@@ -101,6 +102,18 @@ func (c *zfsCollector) updateXuioStats(ch chan<- prometheus.Metric) (err error) 
 
 	return c.parseProcfsFile(file, zfsXuioStatsExt, func(s zfsSysctl, v zfsMetricValue) {
 		ch <- c.constSysctlMetric(xuio, s, v)
+	})
+}
+
+func (c *zfsCollector) updateFm(ch chan<- prometheus.Metric) (err error) {
+	file, err := c.openProcFile(filepath.Join(zfsProcpathBase, zfsFmExt))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return c.parseProcfsFile(file, zfsFmExt, func(s zfsSysctl, v zfsMetricValue) {
+		ch <- c.constSysctlMetric(fm, s, v)
 	})
 }
 

--- a/collector/zfs_linux_test.go
+++ b/collector/zfs_linux_test.go
@@ -89,3 +89,39 @@ func TestZfetchstatsParsing(t *testing.T) {
 		t.Fatal("Zfetchstats parsing handler was not called for some expected sysctls")
 	}
 }
+
+func TestZilParsing(t *testing.T) {
+	zilFile, err := os.Open("fixtures/proc/spl/kstat/zfs/zil")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zilFile.Close()
+
+	c := zfsCollector{}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handlerCalled := false
+	err = c.parseProcfsFile(zilFile, "zil", func(s zfsSysctl, v zfsMetricValue) {
+
+		if s != zfsSysctl("kstat.zfs.misc.zil.zil_commit_count") {
+			return
+		}
+
+		handlerCalled = true
+
+		if v != zfsMetricValue(10) {
+			t.Fatalf("Incorrect value parsed from procfs data")
+		}
+
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !handlerCalled {
+		t.Fatal("Zil parsing handler was not called for some expected sysctls")
+	}
+}

--- a/collector/zfs_linux_test.go
+++ b/collector/zfs_linux_test.go
@@ -31,7 +31,7 @@ func TestArcstatsParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseProcfsFile(arcstatsFile, "arcstats", func(s zfsSysctl, v zfsMetricValue) {
+	err = c.parseProcfsFile(arcstatsFile, "arcstats", func(s zfsSysctl, v int) {
 
 		if s != zfsSysctl("kstat.zfs.misc.arcstats.hits") {
 			return
@@ -39,7 +39,7 @@ func TestArcstatsParsing(t *testing.T) {
 
 		handlerCalled = true
 
-		if v != zfsMetricValue(8772612) {
+		if v != int(8772612) {
 			t.Fatalf("Incorrect value parsed from procfs data")
 		}
 
@@ -67,7 +67,7 @@ func TestZfetchstatsParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseProcfsFile(zfetchstatsFile, "zfetchstats", func(s zfsSysctl, v zfsMetricValue) {
+	err = c.parseProcfsFile(zfetchstatsFile, "zfetchstats", func(s zfsSysctl, v int) {
 
 		if s != zfsSysctl("kstat.zfs.misc.zfetchstats.hits") {
 			return
@@ -75,7 +75,7 @@ func TestZfetchstatsParsing(t *testing.T) {
 
 		handlerCalled = true
 
-		if v != zfsMetricValue(7067992) {
+		if v != int(7067992) {
 			t.Fatalf("Incorrect value parsed from procfs data")
 		}
 
@@ -103,7 +103,7 @@ func TestZilParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseProcfsFile(zilFile, "zil", func(s zfsSysctl, v zfsMetricValue) {
+	err = c.parseProcfsFile(zilFile, "zil", func(s zfsSysctl, v int) {
 
 		if s != zfsSysctl("kstat.zfs.misc.zil.zil_commit_count") {
 			return
@@ -111,7 +111,7 @@ func TestZilParsing(t *testing.T) {
 
 		handlerCalled = true
 
-		if v != zfsMetricValue(10) {
+		if v != int(10) {
 			t.Fatalf("Incorrect value parsed from procfs data")
 		}
 
@@ -139,7 +139,7 @@ func TestVdevCacheStatsParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseProcfsFile(vdevCacheStatsFile, "vdev_cache_stats", func(s zfsSysctl, v zfsMetricValue) {
+	err = c.parseProcfsFile(vdevCacheStatsFile, "vdev_cache_stats", func(s zfsSysctl, v int) {
 
 		if s != zfsSysctl("kstat.zfs.misc.vdev_cache_stats.delegations") {
 			return
@@ -147,7 +147,7 @@ func TestVdevCacheStatsParsing(t *testing.T) {
 
 		handlerCalled = true
 
-		if v != zfsMetricValue(40) {
+		if v != int(40) {
 			t.Fatalf("Incorrect value parsed from procfs data")
 		}
 
@@ -175,7 +175,7 @@ func TestXuioStatsParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseProcfsFile(xuioStatsFile, "xuio_stats", func(s zfsSysctl, v zfsMetricValue) {
+	err = c.parseProcfsFile(xuioStatsFile, "xuio_stats", func(s zfsSysctl, v int) {
 
 		if s != zfsSysctl("kstat.zfs.misc.xuio_stats.onloan_read_buf") {
 			return
@@ -183,7 +183,7 @@ func TestXuioStatsParsing(t *testing.T) {
 
 		handlerCalled = true
 
-		if v != zfsMetricValue(32) {
+		if v != int(32) {
 			t.Fatalf("Incorrect value parsed from procfs data")
 		}
 
@@ -211,7 +211,7 @@ func TestFmParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseProcfsFile(fmFile, "fm", func(s zfsSysctl, v zfsMetricValue) {
+	err = c.parseProcfsFile(fmFile, "fm", func(s zfsSysctl, v int) {
 
 		if s != zfsSysctl("kstat.zfs.misc.fm.erpt-dropped") {
 			return
@@ -219,7 +219,7 @@ func TestFmParsing(t *testing.T) {
 
 		handlerCalled = true
 
-		if v != zfsMetricValue(18) {
+		if v != int(18) {
 			t.Fatalf("Incorrect value parsed from procfs data")
 		}
 
@@ -247,7 +247,7 @@ func TestDmuTxParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseProcfsFile(dmuTxFile, "dmu_tx", func(s zfsSysctl, v zfsMetricValue) {
+	err = c.parseProcfsFile(dmuTxFile, "dmu_tx", func(s zfsSysctl, v int) {
 
 		if s != zfsSysctl("kstat.zfs.misc.dmu_tx.dmu_tx_assigned") {
 			return
@@ -255,7 +255,7 @@ func TestDmuTxParsing(t *testing.T) {
 
 		handlerCalled = true
 
-		if v != zfsMetricValue(3532844) {
+		if v != int(3532844) {
 			t.Fatalf("Incorrect value parsed from procfs data")
 		}
 

--- a/collector/zfs_linux_test.go
+++ b/collector/zfs_linux_test.go
@@ -31,7 +31,7 @@ func TestArcstatsParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseArcstatsProcfsFile(arcstatsFile, func(s zfsSysctl, v zfsMetricValue) {
+	err = c.parseProcfsFile(arcstatsFile, "arcstats", func(s zfsSysctl, v zfsMetricValue) {
 
 		if s != zfsSysctl("kstat.zfs.misc.arcstats.hits") {
 			return
@@ -51,5 +51,41 @@ func TestArcstatsParsing(t *testing.T) {
 
 	if !handlerCalled {
 		t.Fatal("Arcstats parsing handler was not called for some expected sysctls")
+	}
+}
+
+func TestZfetchstatsParsing(t *testing.T) {
+	zfetchstatsFile, err := os.Open("fixtures/proc/spl/kstat/zfs/zfetchstats")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zfetchstatsFile.Close()
+
+	c := zfsCollector{}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handlerCalled := false
+	err = c.parseProcfsFile(zfetchstatsFile, "zfetchstats", func(s zfsSysctl, v zfsMetricValue) {
+
+		if s != zfsSysctl("kstat.zfs.misc.zfetchstats.hits") {
+			return
+		}
+
+		handlerCalled = true
+
+		if v != zfsMetricValue(7067992) {
+			t.Fatalf("Incorrect value parsed from procfs data")
+		}
+
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !handlerCalled {
+		t.Fatal("Zfetchstats parsing handler was not called for some expected sysctls")
 	}
 }

--- a/collector/zfs_linux_test.go
+++ b/collector/zfs_linux_test.go
@@ -197,3 +197,39 @@ func TestXuioStatsParsing(t *testing.T) {
 		t.Fatal("XuioStats parsing handler was not called for some expected sysctls")
 	}
 }
+
+func TestFmParsing(t *testing.T) {
+	fmFile, err := os.Open("fixtures/proc/spl/kstat/zfs/fm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fmFile.Close()
+
+	c := zfsCollector{}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handlerCalled := false
+	err = c.parseProcfsFile(fmFile, "fm", func(s zfsSysctl, v zfsMetricValue) {
+
+		if s != zfsSysctl("kstat.zfs.misc.fm.erpt-dropped") {
+			return
+		}
+
+		handlerCalled = true
+
+		if v != zfsMetricValue(18) {
+			t.Fatalf("Incorrect value parsed from procfs data")
+		}
+
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !handlerCalled {
+		t.Fatal("Fm parsing handler was not called for some expected sysctls")
+	}
+}

--- a/collector/zfs_linux_test.go
+++ b/collector/zfs_linux_test.go
@@ -125,3 +125,39 @@ func TestZilParsing(t *testing.T) {
 		t.Fatal("Zil parsing handler was not called for some expected sysctls")
 	}
 }
+
+func TestVdevCacheStatsParsing(t *testing.T) {
+	vdevCacheStatsFile, err := os.Open("fixtures/proc/spl/kstat/zfs/vdev_cache_stats")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer vdevCacheStatsFile.Close()
+
+	c := zfsCollector{}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handlerCalled := false
+	err = c.parseProcfsFile(vdevCacheStatsFile, "vdev_cache_stats", func(s zfsSysctl, v zfsMetricValue) {
+
+		if s != zfsSysctl("kstat.zfs.misc.vdev_cache_stats.delegations") {
+			return
+		}
+
+		handlerCalled = true
+
+		if v != zfsMetricValue(40) {
+			t.Fatalf("Incorrect value parsed from procfs data")
+		}
+
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !handlerCalled {
+		t.Fatal("VdevCacheStats parsing handler was not called for some expected sysctls")
+	}
+}

--- a/collector/zfs_linux_test.go
+++ b/collector/zfs_linux_test.go
@@ -161,3 +161,39 @@ func TestVdevCacheStatsParsing(t *testing.T) {
 		t.Fatal("VdevCacheStats parsing handler was not called for some expected sysctls")
 	}
 }
+
+func TestXuioStatsParsing(t *testing.T) {
+	xuioStatsFile, err := os.Open("fixtures/proc/spl/kstat/zfs/xuio_stats")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer xuioStatsFile.Close()
+
+	c := zfsCollector{}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handlerCalled := false
+	err = c.parseProcfsFile(xuioStatsFile, "xuio_stats", func(s zfsSysctl, v zfsMetricValue) {
+
+		if s != zfsSysctl("kstat.zfs.misc.xuio_stats.onloan_read_buf") {
+			return
+		}
+
+		handlerCalled = true
+
+		if v != zfsMetricValue(32) {
+			t.Fatalf("Incorrect value parsed from procfs data")
+		}
+
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !handlerCalled {
+		t.Fatal("XuioStats parsing handler was not called for some expected sysctls")
+	}
+}

--- a/collector/zfs_linux_test.go
+++ b/collector/zfs_linux_test.go
@@ -233,3 +233,39 @@ func TestFmParsing(t *testing.T) {
 		t.Fatal("Fm parsing handler was not called for some expected sysctls")
 	}
 }
+
+func TestDmuTxParsing(t *testing.T) {
+	dmuTxFile, err := os.Open("fixtures/proc/spl/kstat/zfs/dmu_tx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dmuTxFile.Close()
+
+	c := zfsCollector{}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handlerCalled := false
+	err = c.parseProcfsFile(dmuTxFile, "dmu_tx", func(s zfsSysctl, v zfsMetricValue) {
+
+		if s != zfsSysctl("kstat.zfs.misc.dmu_tx.dmu_tx_assigned") {
+			return
+		}
+
+		handlerCalled = true
+
+		if v != zfsMetricValue(3532844) {
+			t.Fatalf("Incorrect value parsed from procfs data")
+		}
+
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !handlerCalled {
+		t.Fatal("DmuTx parsing handler was not called for some expected sysctls")
+	}
+}


### PR DESCRIPTION
This covers the majority of the missing data from ZFS's procfs data beyond Arcstats. Each path is broken up into a separate commit for cleanliness, with a slight refactor in the first commit that made the initial Arcstats code more easily extensible with less repetition. 