### PR TITLE
ZFS Collector: Convert dashes to underscores for metrics

### DIFF
--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2383,18 +2383,18 @@ node_zfs_dmu_tx_dmu_tx_quota 0
 # HELP node_zfs_dmu_tx_dmu_tx_suspended kstat.zfs.misc.dmu_tx.dmu_tx_suspended
 # TYPE node_zfs_dmu_tx_dmu_tx_suspended untyped
 node_zfs_dmu_tx_dmu_tx_suspended 0
-# HELP node_zfs_fm_erpt-dropped kstat.zfs.misc.fm.erpt-dropped
-# TYPE node_zfs_fm_erpt-dropped untyped
-node_zfs_fm_erpt-dropped 18
-# HELP node_zfs_fm_erpt-set-failed kstat.zfs.misc.fm.erpt-set-failed
-# TYPE node_zfs_fm_erpt-set-failed untyped
-node_zfs_fm_erpt-set-failed 0
-# HELP node_zfs_fm_fmri-set-failed kstat.zfs.misc.fm.fmri-set-failed
-# TYPE node_zfs_fm_fmri-set-failed untyped
-node_zfs_fm_fmri-set-failed 0
-# HELP node_zfs_fm_payload-set-failed kstat.zfs.misc.fm.payload-set-failed
-# TYPE node_zfs_fm_payload-set-failed untyped
-node_zfs_fm_payload-set-failed 0
+# HELP node_zfs_fm_erpt_dropped kstat.zfs.misc.fm.erpt-dropped
+# TYPE node_zfs_fm_erpt_dropped untyped
+node_zfs_fm_erpt_dropped 18
+# HELP node_zfs_fm_erpt_set_failed kstat.zfs.misc.fm.erpt-set-failed
+# TYPE node_zfs_fm_erpt_set_failed untyped
+node_zfs_fm_erpt_set_failed 0
+# HELP node_zfs_fm_fmri_set_failed kstat.zfs.misc.fm.fmri-set-failed
+# TYPE node_zfs_fm_fmri_set_failed untyped
+node_zfs_fm_fmri_set_failed 0
+# HELP node_zfs_fm_payload_set_failed kstat.zfs.misc.fm.payload-set-failed
+# TYPE node_zfs_fm_payload_set_failed untyped
+node_zfs_fm_payload_set_failed 0
 # HELP node_zfs_vdev_cache_delegations kstat.zfs.misc.vdev_cache_stats.delegations
 # TYPE node_zfs_vdev_cache_delegations untyped
 node_zfs_vdev_cache_delegations 40

--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -81,7 +81,7 @@ func (c *zfsCollector) Update(ch chan<- prometheus.Metric) (err error) {
 
 func (s zfsSysctl) metricName() string {
 	parts := strings.Split(string(s), ".")
-	return parts[len(parts)-1]
+	return strings.Replace(parts[len(parts)-1], "-", "_", -1)
 }
 
 func (c *zfsCollector) constSysctlMetric(subsystem string, sysctl zfsSysctl, value int) prometheus.Metric {


### PR DESCRIPTION
This fixes #442, and prevents other ZFS metrics from slipping through in the future.

Signed-Off-By: Joe Handzik <joseph.t.handzik@hpe.com>