### PR TITLE
Make the docker image work until we fix linux/amd64 static build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM        quay.io/prometheus/busybox:latest
+FROM        quay.io/prometheus/busybox:glibc
 MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 
 COPY node_exporter /bin/node_exporter


### PR DESCRIPTION
Use glibc variation of quay.io/prometheus/busybox image to make the docker image work until we find how to rebuild node_exporter statically for linux/amd64

@SuperQ 