### PR TITLE
Bump github.com/mdlayher/netlink to clean up on bind failure

### DIFF
--- a/vendor/github.com/mdlayher/netlink/conn_linux.go
+++ b/vendor/github.com/mdlayher/netlink/conn_linux.go
@@ -62,6 +62,9 @@ func bind(s socket, config *Config) (*conn, error) {
 	}
 
 	if err := s.Bind(addr); err != nil {
+		// Since this never returns conn (and as such, the caller cannot close it),
+		// close the socket here in the event of a failure to bind.
+		_ = s.Close()
 		return nil, err
 	}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -51,10 +51,10 @@
 			"revisionTime": "2016-04-24T11:30:07Z"
 		},
 		{
-			"checksumSHA1": "zAMSb+r3Hh8AFE+Oc8NrL7F+j6o=",
+			"checksumSHA1": "yDvo49XwrEOOzk4g5eMtz7aZ1RY=",
 			"path": "github.com/mdlayher/netlink",
-			"revision": "6ad102ec4b0fb2ed33be30ee3bf714333420658e",
-			"revisionTime": "2017-02-27T17:09:03Z"
+			"revision": "11047e3e3daa32f7b757bc9ab59c413cadeccfa1",
+			"revisionTime": "2017-03-02T15:49:27Z"
 		},
 		{
 			"checksumSHA1": "+2roeIWCAjCC58tZcs12Vqgf1Io=",


### PR DESCRIPTION
This one hasn't caused a bug in node_exporter yet, but in the case of a failure to `bind()`, the socket should still be cleaned up.