### PR TITLE
Update github.com/mdlayher/netlink with code simplifications

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -51,10 +51,10 @@
 			"revisionTime": "2016-04-24T11:30:07Z"
 		},
 		{
-			"checksumSHA1": "yDvo49XwrEOOzk4g5eMtz7aZ1RY=",
+			"checksumSHA1": "r3t+HDvOEQVCaLjuMT8rl6opbNQ=",
 			"path": "github.com/mdlayher/netlink",
-			"revision": "11047e3e3daa32f7b757bc9ab59c413cadeccfa1",
-			"revisionTime": "2017-03-02T15:49:27Z"
+			"revision": "343c07bd16ebbc714f19c528a6deb6723ace06f3",
+			"revisionTime": "2017-03-10T17:31:27Z"
 		},
 		{
 			"checksumSHA1": "+2roeIWCAjCC58tZcs12Vqgf1Io=",


### PR DESCRIPTION
Basically, this replaces some of my complicated netlink PID assignment logic with a call to `getsockname()`. I don't know why I didn't think of this before today.

There should be no effect on `node_exporter`.  I'm making this PR so that this update doesn't catch someone by surprise later on.