### PR TITLE
Add a GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--
+	Please note: GitHub issues should only be used for feature requests and
+	bug reports. For general discussions, please refer to one of:
+
+	- #prometheus on freenode
+	- the Prometheus Users list: https://groups.google.com/forum/#!forum/prometheus-users
+
+	Before filing a bug report, note that running node_exporter in Docker is
+	not recommended, for the reasons detailed in the README:
+
+	https://github.com/prometheus/node_exporter#using-docker
+
+	Finally, also note that node_exporter is focused on *NIX kernels, and the
+	WMI exporter should be used instead on Windows.
+
+	For bug reports, please fill out the below fields and provide as much detail
+	as possible about your issue.  For feature requests, you may omit the
+	following template.
+-->
+### Host operating system: output of `uname -a`
+
+### node_exporter version: output of `node_exporter -version`
+<!-- If building from source, run `make` first. -->
+
+### Are you running node_exporter in Docker?
+<!-- Please note the warning above. -->
+
+### What did you do that produced an error?
+
+### What did you expect to see?
+
+### What did you see instead?


### PR DESCRIPTION
My attempt at #511 , based loosely on the template we use for DigitalOcean's NetBox repo, and the one used by the Go project.

Feel free to suggest changes and improvements.

r: @discordianfish @SuperQ 

Fixes #511 .