### PR TITLE
Add synthetic node_wifi_station_info metric for BSS information

### DIFF
--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2158,6 +2158,9 @@ node_wifi_station_connected_seconds_total{device="wlan0"} 30
 # HELP node_wifi_station_inactive_seconds The number of seconds since any wireless activity has occurred on a station.
 # TYPE node_wifi_station_inactive_seconds gauge
 node_wifi_station_inactive_seconds{device="wlan0"} 0.4
+# HELP node_wifi_station_info Labeled WiFi interface station information as provided by the operating system.
+# TYPE node_wifi_station_info gauge
+node_wifi_station_info{bssid="00:11:22:33:44:55",device="wlan0",mode="client",ssid="Example"} 1
 # HELP node_wifi_station_receive_bits_per_second The current WiFi receive bitrate of a station, in bits per second.
 # TYPE node_wifi_station_receive_bits_per_second gauge
 node_wifi_station_receive_bits_per_second{device="wlan0"} 1.28e+08

--- a/collector/fixtures/wifi/wlan0/bss.json
+++ b/collector/fixtures/wifi/wlan0/bss.json
@@ -1,0 +1,5 @@
+{
+	"ssid": "Example",
+	"bssid": "ABEiM0RV",
+	"status": 1
+}


### PR DESCRIPTION
Tested on my laptop:

```
$ curl -s http://192.168.1.20:9101/metrics | grep "node_wifi_station_info"            
# HELP node_wifi_station_info Labeled WiFi interface station information as provided by the operating system.
# TYPE node_wifi_station_info gauge
node_wifi_station_info{bssid="44:d9:e7:03:2a:56",device="wlp2s0",mode="client",ssid="The Red Dragon Inn"} 1
```

Fixes #508 .