### PR TITLE
Bump github.com/mdlayher/wifi to relax station info restrictions

### DIFF
--- a/vendor/github.com/mdlayher/wifi/client.go
+++ b/vendor/github.com/mdlayher/wifi/client.go
@@ -1,16 +1,11 @@
 package wifi
 
 import (
-	"errors"
 	"fmt"
 	"runtime"
 )
 
 var (
-	// errNotStation is returned when attempting to query station info for
-	// an interface which is not a station.
-	errNotStation = errors.New("interface is not a station")
-
 	// errUnimplemented is returned by all functions on platforms that
 	// do not have package wifi implemented.
 	errUnimplemented = fmt.Errorf("package wifi not implemented on %s/%s",
@@ -50,13 +45,8 @@ func (c *Client) BSS(ifi *Interface) (*BSS, error) {
 	return c.c.BSS(ifi)
 }
 
-// StationInfo retrieves statistics about a WiFi interface operating in
-// station mode.
+// StationInfo retrieves station statistics about a WiFi interface.
 func (c *Client) StationInfo(ifi *Interface) (*StationInfo, error) {
-	if ifi.Type != InterfaceTypeStation {
-		return nil, errNotStation
-	}
-
 	return c.c.StationInfo(ifi)
 }
 

--- a/vendor/github.com/mdlayher/wifi/wifi.go
+++ b/vendor/github.com/mdlayher/wifi/wifi.go
@@ -69,6 +69,38 @@ const (
 	InterfaceTypeNAN
 )
 
+// String returns the string representation of an InterfaceType.
+func (t InterfaceType) String() string {
+	switch t {
+	case InterfaceTypeUnspecified:
+		return "unspecified"
+	case InterfaceTypeAdHoc:
+		return "ad-hoc"
+	case InterfaceTypeStation:
+		return "station"
+	case InterfaceTypeAP:
+		return "access point"
+	case InterfaceTypeWDS:
+		return "wireless distribution"
+	case InterfaceTypeMonitor:
+		return "monitor"
+	case InterfaceTypeMeshPoint:
+		return "mesh point"
+	case InterfaceTypeP2PClient:
+		return "P2P client"
+	case InterfaceTypeP2PGroupOwner:
+		return "P2P group owner"
+	case InterfaceTypeP2PDevice:
+		return "P2P device"
+	case InterfaceTypeOCB:
+		return "outside context of BSS"
+	case InterfaceTypeNAN:
+		return "near-me area network"
+	default:
+		return fmt.Sprintf("unknown(%d)", t)
+	}
+}
+
 // An Interface is a WiFi network interface.
 type Interface struct {
 	// The index of the interface.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -69,10 +69,10 @@
 			"revisionTime": "2017-01-04T04:59:06Z"
 		},
 		{
-			"checksumSHA1": "XG73RxoI99JeNkxyMStXnlCpXXM=",
+			"checksumSHA1": "FdmT9kyPtsLxk+sgxJmKqcbOCR4=",
 			"path": "github.com/mdlayher/wifi",
-			"revision": "1ccab08abb10805297916157a270d05f562e2647",
-			"revisionTime": "2017-03-01T22:08:15Z"
+			"revision": "567082929344b0af8eb8a2ad6fe4725c0b3c8702",
+			"revisionTime": "2017-03-17T19:22:46Z"
 		},
 		{
 			"checksumSHA1": "VzutdH69PUqRqhrDVv6F91ebQd4=",


### PR DESCRIPTION
This removes and unnecessary restriction and will enable better WiFi collector debugging information in the logs.  PR to follow for the WiFi collector changes.