### PR TITLE
Add missing dependency for static FreeBSD build

### DIFF
--- a/collector/devstat_freebsd.go
+++ b/collector/devstat_freebsd.go
@@ -24,7 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// #cgo LDFLAGS: -ldevstat -lkvm
+// #cgo LDFLAGS: -ldevstat -lkvm -lelf
 // #include "devstat_freebsd.h"
 import "C"
 


### PR DESCRIPTION
Static linking requires all  (recursive) library dependencies to be  listed  explicitly.

Fixes this build error on FreeBSD 11:

```
# github.com/prometheus/node_exporter
/usr/local/go/pkg/tool/freebsd_amd64/link: running cc failed: exit status 1
/usr/lib/libkvm.a(kvm.o): In function `_kvm_read_core_phdrs':
/usr/src/lib/libkvm/kvm.c:(.text+0x3a4): undefined reference to `elf_begin'
/usr/src/lib/libkvm/kvm.c:(.text+0x3b8): undefined reference to `elf_kind'
/usr/src/lib/libkvm/kvm.c:(.text+0x3c9): undefined reference to `gelf_getclass'
/usr/src/lib/libkvm/kvm.c:(.text+0x3e5): undefined reference to `gelf_getehdr'
/usr/src/lib/libkvm/kvm.c:(.text+0x41c): undefined reference to `elf_getphdrnum'
/usr/src/lib/libkvm/kvm.c:(.text+0x46d): undefined reference to `gelf_getphdr'
/usr/src/lib/libkvm/kvm.c:(.text+0x48b): undefined reference to `elf_end'
/usr/src/lib/libkvm/kvm.c:(.text+0x4c4): undefined reference to `elf_end'
/usr/src/lib/libkvm/kvm.c:(.text+0x4d6): undefined reference to `elf_errmsg'
/usr/src/lib/libkvm/kvm.c:(.text+0x519): undefined reference to `elf_errmsg'
/usr/lib/libkvm.a(kvm.o): In function `_kvm_open':
/usr/src/lib/libkvm/kvm.c:(.text+0xab4): undefined reference to `elf_version'
/usr/src/lib/libkvm/kvm.c:(.text+0xace): undefined reference to `elf_begin'
/usr/src/lib/libkvm/kvm.c:(.text+0xae2): undefined reference to `elf_kind'
/usr/src/lib/libkvm/kvm.c:(.text+0xafa): undefined reference to `gelf_getehdr'
/usr/src/lib/libkvm/kvm.c:(.text+0xb0b): undefined reference to `elf_end'
/usr/src/lib/libkvm/kvm.c:(.text+0xbc0): undefined reference to `elf_errmsg'
/usr/src/lib/libkvm/kvm.c:(.text+0xc2f): undefined reference to `elf_errmsg'
/usr/src/lib/libkvm/kvm.c:(.text+0xc4c): undefined reference to `elf_end'
cc: error: linker command failed with exit code 1 (use -v to see invocation)

``` 