### PR TITLE
Handle smart raw values >2^31

### DIFF
--- a/text_collector_examples/smartmon.sh
+++ b/text_collector_examples/smartmon.sh
@@ -15,7 +15,7 @@ $1 ~ /^[0-9]+$/ && $2 ~ /^[a-zA-Z0-9_-]+$/ {
   printf "%s_value{%s,smart_id=\"%s\"} %d\n", $2, labels, $1, $4
   printf "%s_worst{%s,smart_id=\"%s\"} %d\n", $2, labels, $1, $5
   printf "%s_threshold{%s,smart_id=\"%s\"} %d\n", $2, labels, $1, $6
-  printf "%s_raw_value{%s,smart_id=\"%s\"} %d\n", $2, labels, $1, $10
+  printf "%s_raw_value{%s,smart_id=\"%s\"} %e\n", $2, labels, $1, $10
 }
 SMARTCTLAWK
 )"


### PR DESCRIPTION
"%d" in awk truncates values at 2^31. S.M.A.R.T. raw values can exceed that, thus use a floating point notation instead to encode larger values (at the possible cost of some precision).