### PR TITLE
Use go env to fetch GOPATH to support Go 1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 GO     ?= GO15VENDOREXPERIMENT=1 go
-GOPATH := $(firstword $(subst :, ,$(GOPATH)))
+GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 
 PROMU       ?= $(GOPATH)/bin/promu
 STATICCHECK ?= $(GOPATH)/bin/staticcheck


### PR DESCRIPTION
Go 1.8 do not require env GOPATH to be set and `make` will fail if it isn't set.

@SuperQ @discordianfish 