### PR TITLE
Blacklist systemd scope units

### DIFF
--- a/collector/systemd_linux.go
+++ b/collector/systemd_linux.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	unitWhitelist = flag.String("collector.systemd.unit-whitelist", ".+", "Regexp of systemd units to whitelist. Units must both match whitelist and not match blacklist to be included.")
-	unitBlacklist = flag.String("collector.systemd.unit-blacklist", "", "Regexp of systemd units to blacklist. Units must both match whitelist and not match blacklist to be included.")
+	unitBlacklist = flag.String("collector.systemd.unit-blacklist", ".+\\.scope", "Regexp of systemd units to blacklist. Units must both match whitelist and not match blacklist to be included.")
 )
 
 type systemdCollector struct {


### PR DESCRIPTION
Blacklist `scope` units from systemd collector by default.

These units are created with unique IDs programatically[0].  This leads to
huge cardinality problems.

[0]: https://www.freedesktop.org/software/systemd/man/systemd.scope.html