### PR TITLE
Remove Windows support

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -20,8 +20,6 @@ crossbuild:
         - linux/386
         - darwin/amd64
         - darwin/386
-        - windows/amd64
-        - windows/386
         - netbsd/amd64
         - netbsd/386
         - linux/arm

--- a/collector/buddyinfo.go
+++ b/collector/buddyinfo.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // +build !nobuddyinfo
-// +build !windows,!netbsd
+// +build !netbsd
 
 package collector
 

--- a/collector/loadavg.go
+++ b/collector/loadavg.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 // +build !noloadavg
-// +build !windows
 
 package collector
 

--- a/collector/meminfo.go
+++ b/collector/meminfo.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // +build !nomeminfo
-// +build !windows,!netbsd
+// +build !netbsd
 
 package collector
 


### PR DESCRIPTION
Use https://github.com/martinlindhe/wmi_exporter instead.

Fixes #542.

Once merged the following steps will remove Windows from the prometheus.io/download page:

1. manually delete the Windows binaries from the latest release
2. trigger a prometheus/docs travisci run