### PR TITLE
Add exec_boot_time for freebsd, dragonfly

### DIFF
--- a/collector/exec_bsd.go
+++ b/collector/exec_bsd.go
@@ -76,7 +76,7 @@ func NewExecCollector() (Collector, error) {
 				mib:         "vm.stats.vm.v_forks",
 			},
 			{
-				name:        "boot_time",
+				name:        "boot_timestamp_seconds",
 				description: "Unix time of last boot, including microseconds.",
 				mib:         "kern.boottime",
 				dataType:    bsdSysctlTypeStructTimeval,

--- a/collector/exec_bsd.go
+++ b/collector/exec_bsd.go
@@ -39,6 +39,9 @@ func NewExecCollector() (Collector, error) {
 	// vm.stats.sys.v_intr: Device interrupts
 	// vm.stats.sys.v_soft: Software interrupts
 	// vm.stats.vm.v_forks: Number of fork() calls
+	//
+	// From sys/kern/kern_tc.c:
+	// kern.boottime is an S,timeval
 
 	return &execCollector{
 		sysctls: []bsdSysctl{
@@ -71,6 +74,12 @@ func NewExecCollector() (Collector, error) {
 				name:        "forks_total",
 				description: "Number of fork() calls since system boot.  Resets at architeture unsigned integer.",
 				mib:         "vm.stats.vm.v_forks",
+			},
+			{
+				name:        "boot_time",
+				description: "Unix time of last boot, including microseconds.",
+				mib:         "kern.boottime",
+				dataType:    bsdSysctlTypeStructTimeval,
 			},
 		},
 	}, nil

--- a/collector/meminfo_bsd.go
+++ b/collector/meminfo_bsd.go
@@ -29,8 +29,8 @@ func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 	if err != nil {
 		return nil, fmt.Errorf("sysctl(vm.stats.vm.v_page_size) failed: %s", err)
 	}
-	size := uint64(tmp32)
-	fromPage := func(v uint64) uint64 {
+	size := float64(tmp32)
+	fromPage := func(v float64) float64 {
 		return v * size
 	}
 


### PR DESCRIPTION
Adds new sysctl type, bsdSysctlTypeStructTimeval to enable parsing of
timevals from raw memory.  Assumes LittleEndian.