### PR TITLE
Remove netbsd/arm support for now

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -26,7 +26,6 @@ crossbuild:
         - netbsd/386
         - linux/arm
         - linux/arm64
-        - netbsd/arm
         # Temporarily deactivated as this does not currently build with promu.
         #- linux/mips64
         #- linux/mips64le


### PR DESCRIPTION
There are crossbuild errors on netbsd/arm with go1.8. Assuming there is
only a small minority of people running netbsd on ARM processors,
disabling these builds is the fastest workaround.

@derekmarcotte @sdurrheimer 