### PR TITLE
Use go1.8 in CircleCI tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   environment:
     DOCKER_IMAGE_NAME: prom/node-exporter
     QUAY_IMAGE_NAME: quay.io/prometheus/node-exporter
-    DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.7-base
+    DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.8-base
     REPO_PATH: github.com/prometheus/node_exporter
   pre:
     - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.1-circleci'


### PR DESCRIPTION
We already use go1.8 in promu, so loading another image slows down the
build.

@sdurrheimer @SuperQ 