### PR TITLE
edac: Fix typo in node_edac_csrow_uncorrectable_errors_total

### DIFF
--- a/collector/edac_linux.go
+++ b/collector/edac_linux.go
@@ -108,7 +108,7 @@ func (c *edacCollector) Update(ch chan<- prometheus.Metric) error {
 			return fmt.Errorf("couldn't get ue_noinfo_count for controller %s: %s", controllerNumber, err)
 		}
 		ch <- prometheus.MustNewConstMetric(
-			c.csRowUECount, prometheus.CounterValue, float64(value), controllerNumber, "uknown")
+			c.csRowUECount, prometheus.CounterValue, float64(value), controllerNumber, "unknown")
 
 		// For each controller, walk the csrow directories.
 		csrows, err := filepath.Glob(controller + "/csrow[0-9]*")

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -460,7 +460,7 @@ node_edac_csrow_correctable_errors_total{controller="0",csrow="unknown"} 2
 # HELP node_edac_csrow_uncorrectable_errors_total Total uncorrectable memory errors for this csrow.
 # TYPE node_edac_csrow_uncorrectable_errors_total counter
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="0"} 4
-node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="uknown"} 6
+node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="unknown"} 6
 # HELP node_edac_uncorrectable_errors_total Total uncorrectable memory errors.
 # TYPE node_edac_uncorrectable_errors_total counter
 node_edac_uncorrectable_errors_total{controller="0"} 5


### PR DESCRIPTION
Fix typo in `csrow` label of `node_edac_csrow_uncorrectable_errors_total` metric: "uknown" => "unknown"