### PR TITLE
uname_linux: Build for 32bit MIPS too

### DIFF
--- a/collector/uname_linux_int8.go
+++ b/collector/uname_linux_int8.go
@@ -11,7 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !nouname,linux,386 !nouname,linux,amd64 !nouname,linux,arm64 !nouname,linux,mips64 !nouname,linux,mips64le
+// +build 386 amd64 arm64 mips64 mips64le mips mipsle
+// +build linux
+// +build !nouname
 
 package collector
 


### PR DESCRIPTION
Since Go 1.8 32bit MIPS Big/Little Endian are supported assuming the target runs Linux and the kernel either emulates an FPU or can access the CPU one.

This allows the node_collector to build for `mips` and `mipsle` `GOARCH` paired with `GOOS` set to `linux`, opening up the possibility of running it on things like home routers. (DD-|Open|ASUS-)Wrt firmware usually has the necessary bits in place.

## Before
`env GOOS=linux env GOARCH=mipsle go build node_exporter.go`
```
# github.com/prometheus/node_exporter/collector
collector/uname_linux.go:56: undefined: unameToString
collector/uname_linux.go:57: undefined: unameToString
collector/uname_linux.go:58: undefined: unameToString
collector/uname_linux.go:59: undefined: unameToString
collector/uname_linux.go:60: undefined: unameToString
collector/uname_linux.go:61: undefined: unameToString
```

## After

It builds and the result can be executed on a router with a BCM4706 running a Linux flavour.

However, there's a bug:

```
INFO[0000] Starting node_exporter (version=, branch=, revision=)  source="node_exporter.go:140"
INFO[0000] Build context (go=go1.8.1, user=, date=)      source="node_exporter.go:141"
INFO[0000] No directory specified, see --collector.textfile.directory  source="textfile.go:57"
INFO[0000] Enabled collectors:                           source="node_exporter.go:160"
INFO[0000]  - hwmon                                      source="node_exporter.go:162"
INFO[0000]  - mdadm                                      source="node_exporter.go:162"
INFO[0000]  - netstat                                    source="node_exporter.go:162"
INFO[0000]  - time                                       source="node_exporter.go:162"
INFO[0000]  - uname                                      source="node_exporter.go:162"
INFO[0000]  - filesystem                                 source="node_exporter.go:162"
INFO[0000]  - wifi                                       source="node_exporter.go:162"
INFO[0000]  - zfs                                        source="node_exporter.go:162"
INFO[0000]  - netdev                                     source="node_exporter.go:162"
INFO[0000]  - diskstats                                  source="node_exporter.go:162"
INFO[0000]  - infiniband                                 source="node_exporter.go:162"
INFO[0000]  - stat                                       source="node_exporter.go:162"
INFO[0000]  - textfile                                   source="node_exporter.go:162"
INFO[0000]  - conntrack                                  source="node_exporter.go:162"
INFO[0000]  - entropy                                    source="node_exporter.go:162"
INFO[0000]  - edac                                       source="node_exporter.go:162"
INFO[0000]  - filefd                                     source="node_exporter.go:162"
INFO[0000]  - loadavg                                    source="node_exporter.go:162"
INFO[0000]  - meminfo                                    source="node_exporter.go:162"
INFO[0000]  - sockstat                                   source="node_exporter.go:162"
INFO[0000]  - vmstat                                     source="node_exporter.go:162"
INFO[0000]  - arp                                        source="node_exporter.go:162"
INFO[0000] Listening on :19100                           source="node_exporter.go:186"
FATA[0000] listen tcp :19100: errno -9                   source="node_exporter.go:189"
```

It can't seem to ever bind on a port. Whichever port I pass to `-web.listen-address` I always end up with: `FATA[0000] listen tcp :19100: errno -9                   source="node_exporter.go:189"` (where `:19100` is the argument I passed to `-web.listen-address`). The bit it crashes on is:

```go
	err = http.ListenAndServe(*listenAddress, nil)
	if err != nil {
		log.Fatal(err)
	}
```

`err` is not `nil` in this case.

I'm unsure how to debug that but if anyone has any pointers I'm happy to give it a go.

## Environment

```
[I] 12:51:47 ~ $ go version
go version go1.8.1 darwin/amd64
```
```
[I] 12:51:48 ~ $ go env
GOARCH="amd64"
GOBIN=""
GOEXE=""
GOHOSTARCH="amd64"
GOHOSTOS="darwin"
GOOS="darwin"
GOPATH="/Users/daenney/Development/go"
GORACE=""
GOROOT="/Users/daenney/homebrew/Cellar/go/1.8.1/libexec"
GOTOOLDIR="/Users/daenney/homebrew/Cellar/go/1.8.1/libexec/pkg/tool/darwin_amd64"
GCCGO="gccgo"
CC="clang"
GOGCCFLAGS="-fPIC -m64 -pthread -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -fdebug-prefix-map=/var/folders/hj/msj37yd53052rhjn6c7v7s4r0000gn/T/go-build842260930=/tmp/go-build -gno-record-gcc-switches -fno-common"
CXX="clang++"
CGO_ENABLED="1"
PKG_CONFIG="pkg-config"
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"
```