### PR TITLE
silently ignore nonexisting bonding_masters file

### DIFF
--- a/collector/bonding_linux.go
+++ b/collector/bonding_linux.go
@@ -67,6 +67,9 @@ func readBondingStats(root string) (status map[string][2]int, err error) {
 	status = map[string][2]int{}
 	masters, err := ioutil.ReadFile(path.Join(root, "bonding_masters"))
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	for _, master := range strings.Fields(string(masters)) {

--- a/collector/bonding_linux.go
+++ b/collector/bonding_linux.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 type bondingCollector struct {
@@ -52,8 +53,13 @@ func NewBondingCollector() (Collector, error) {
 
 // Update reads and exposes bonding states, implements Collector interface. Caution: This works only on linux.
 func (c *bondingCollector) Update(ch chan<- prometheus.Metric) error {
-	bondingStats, err := readBondingStats(sysFilePath("class/net"))
+	statusfile := sysFilePath("class/net")
+	bondingStats, err := readBondingStats(statusfile)
 	if err != nil {
+		if os.IsNotExist(err) {
+			log.Debugf("Not collecting bonding, file does not exist: %s", statusfile)
+			return nil
+		}
 		return err
 	}
 	for master, status := range bondingStats {
@@ -67,9 +73,6 @@ func readBondingStats(root string) (status map[string][2]int, err error) {
 	status = map[string][2]int{}
 	masters, err := ioutil.ReadFile(path.Join(root, "bonding_masters"))
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	for _, master := range strings.Fields(string(masters)) {

--- a/collector/bonding_linux_test.go
+++ b/collector/bonding_linux_test.go
@@ -34,11 +34,3 @@ func TestBonding(t *testing.T) {
 		t.Fatal("dmz in unexpected state")
 	}
 }
-
-func TestBondingAbsent(t *testing.T) {
-	if bondingStats, err := readBondingStats("fixtures/sys/class/net.nobonding"); err != nil {
-		t.Fatalf("Expect no error but got: %+v", err)
-	} else if bondingStats != nil {
-		t.Fatalf("Did not expect to find fixtures for bonding without a bonding configuration")
-	}
-}

--- a/collector/bonding_linux_test.go
+++ b/collector/bonding_linux_test.go
@@ -34,3 +34,11 @@ func TestBonding(t *testing.T) {
 		t.Fatal("dmz in unexpected state")
 	}
 }
+
+func TestBondingAbsent(t *testing.T) {
+	if bondingStats, err := readBondingStats("fixtures/sys/class/net.nobonding"); err != nil {
+		t.Fatalf("Expect no error but got: %+v", err)
+	} else if bondingStats != nil {
+		t.Fatalf("Did not expect to find fixtures for bonding without a bonding configuration")
+	}
+}


### PR DESCRIPTION
@grobie 

Using the bonding collector on a (linux) server that does not have linux bonding gives a very noisy error in the log at each metric scrape:

```
  ERRO[0023] ERROR: bonding collector failed after 0.000191s: open /sys/class/net/bonding_masters: no such file or directory  source=node_exporter.go:91
```

With this PR, the collector will now return (nil, nil) if the error was a non existing bonding_masters file. I've added a test that test against an empty fixtures dir to verify that it does not error on a missing file.

Perhaps I should add a log.Debugf() with the error, so it will show up in the logs when verbosity is requested by the end user?