### PR TITLE
Strip leading and trailing quotes from filenames for consistency

### DIFF
--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -48,7 +48,7 @@ func init() {
 // in the given textfile directory.
 func NewTextFileCollector() (Collector, error) {
 	c := &textFileCollector{
-		path: strings.Trim(*textFileDirectory, "'\""
+		path: strings.Trim(*textFileDirectory, "'\"")
 	}
 
 	if c.path == "" {

--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -48,7 +48,7 @@ func init() {
 // in the given textfile directory.
 func NewTextFileCollector() (Collector, error) {
 	c := &textFileCollector{
-		path: *textFileDirectory,
+		path: strings.Trim(*textFileDirectory, "'\""
 	}
 
 	if c.path == "" {


### PR DESCRIPTION
I guess this is as much a style issue as anything else, so you can take it or leave it:

Spent hours debugging why the textfile exporter wasn't working, and eventually figured that quotes around the pathname when setting the flag thus:
-collector.textfile.directory="/foo"
resulted in File Not Found as the quotes weren't stripped and the quoted filepath in the error message just looked like it was being quoted for readability. :)
-collector.textfile.directory "/foo"
would presumably be okay thanks to the shell's argument handling, but it makes sense to me to strip leading/trailing quotes anyway so both variants behave in the same way.