### PR TITLE
Multiply port data XMIT/RCV metrics by 4

### DIFF
--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -703,12 +703,12 @@ node_hwmon_temp_max_celsius{chip="platform_coretemp_1",sensor="temp4"} 84
 node_hwmon_temp_max_celsius{chip="platform_coretemp_1",sensor="temp5"} 84
 # HELP node_infiniband_legacy_data_received_bytes_total Number of data octets received on all links
 # TYPE node_infiniband_legacy_data_received_bytes_total counter
-node_infiniband_legacy_data_received_bytes_total{device="mlx4_0",port="1"} 4.631917e+06
-node_infiniband_legacy_data_received_bytes_total{device="mlx4_0",port="2"} 4.631917e+06
+node_infiniband_legacy_data_received_bytes_total{device="mlx4_0",port="1"} 1.8527668e+07
+node_infiniband_legacy_data_received_bytes_total{device="mlx4_0",port="2"} 1.8527668e+07
 # HELP node_infiniband_legacy_data_transmitted_bytes_total Number of data octets transmitted on all links
 # TYPE node_infiniband_legacy_data_transmitted_bytes_total counter
-node_infiniband_legacy_data_transmitted_bytes_total{device="mlx4_0",port="1"} 3.73344e+06
-node_infiniband_legacy_data_transmitted_bytes_total{device="mlx4_0",port="2"} 3.73344e+06
+node_infiniband_legacy_data_transmitted_bytes_total{device="mlx4_0",port="1"} 1.493376e+07
+node_infiniband_legacy_data_transmitted_bytes_total{device="mlx4_0",port="2"} 1.493376e+07
 # HELP node_infiniband_legacy_multicast_packets_received_total Number of multicast packets received
 # TYPE node_infiniband_legacy_multicast_packets_received_total counter
 node_infiniband_legacy_multicast_packets_received_total{device="mlx4_0",port="1"} 93
@@ -751,11 +751,11 @@ node_infiniband_multicast_packets_transmitted_total{device="mlx4_0",port="1"} 16
 node_infiniband_multicast_packets_transmitted_total{device="mlx4_0",port="2"} 0
 # HELP node_infiniband_port_data_received_bytes Number of data octets received on all links
 # TYPE node_infiniband_port_data_received_bytes counter
-node_infiniband_port_data_received_bytes{device="mlx4_0",port="1"} 4.631917e+06
+node_infiniband_port_data_received_bytes{device="mlx4_0",port="1"} 1.8527668e+07
 node_infiniband_port_data_received_bytes{device="mlx4_0",port="2"} 0
 # HELP node_infiniband_port_data_transmitted_bytes Number of data octets transmitted on all links
 # TYPE node_infiniband_port_data_transmitted_bytes counter
-node_infiniband_port_data_transmitted_bytes{device="mlx4_0",port="1"} 3.73344e+06
+node_infiniband_port_data_transmitted_bytes{device="mlx4_0",port="1"} 1.493376e+07
 node_infiniband_port_data_transmitted_bytes{device="mlx4_0",port="2"} 0
 # HELP node_infiniband_unicast_packets_received_total Number of unicast packets received (including errors)
 # TYPE node_infiniband_unicast_packets_received_total counter

--- a/collector/infiniband_linux.go
+++ b/collector/infiniband_linux.go
@@ -148,6 +148,15 @@ func readMetric(directory, metricFile string) (uint64, error) {
 		return 0, err
 	}
 
+	// According to Mellanox, the following metrics "are divided by 4 unconditionally"
+	// as they represent the amount of data being transmitted and received per lane.
+	// Mellanox cards have 4 lanes per port, so all values must be multiplied by 4
+	// to get the expected value.
+	switch metricFile {
+	case "port_rcv_data", "port_xmit_data", "port_rcv_data_64", "port_xmit_data_64":
+		metric *= 4
+	}
+
 	return metric, nil
 }
 


### PR DESCRIPTION
According to Mellanox, it is standard practice that the port_xmit_data and port_rcv_data
files are split into 4 lanes. To get the actual transmit and receive values for each
port, the metric needs to be multiplied by 4.

If applied, this fixes #573.

Signed-Off-By: Robert Clark <robert.d.clark@hpe.com>