### PR TITLE
Golint fixes

### DIFF
--- a/collector/cpu_darwin.go
+++ b/collector/cpu_darwin.go
@@ -91,17 +91,17 @@ func (c *statCollector) Update(ch chan<- prometheus.Metric) error {
 
 	// the body of struct processor_cpu_load_info
 	// aka processor_cpu_load_info_data_t
-	var cpu_ticks [C.CPU_STATE_MAX]uint32
+	var cpuTicks [C.CPU_STATE_MAX]uint32
 
 	// copy the cpuload array to a []byte buffer
 	// where we can binary.Read the data
-	size := int(ncpu) * binary.Size(cpu_ticks)
+	size := int(ncpu) * binary.Size(cpuTicks)
 	buf := (*[1 << 30]byte)(unsafe.Pointer(cpuload))[:size:size]
 
 	bbuf := bytes.NewBuffer(buf)
 
 	for i := 0; i < int(ncpu); i++ {
-		err := binary.Read(bbuf, binary.LittleEndian, &cpu_ticks)
+		err := binary.Read(bbuf, binary.LittleEndian, &cpuTicks)
 		if err != nil {
 			return err
 		}
@@ -111,7 +111,7 @@ func (c *statCollector) Update(ch chan<- prometheus.Metric) error {
 			"nice":   C.CPU_STATE_NICE,
 			"idle":   C.CPU_STATE_IDLE,
 		} {
-			ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, float64(cpu_ticks[v])/ClocksPerSec, "cpu"+strconv.Itoa(i), k)
+			ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, float64(cpuTicks[v])/ClocksPerSec, "cpu"+strconv.Itoa(i), k)
 		}
 	}
 	return nil

--- a/collector/cpu_darwin.go
+++ b/collector/cpu_darwin.go
@@ -44,7 +44,7 @@ import (
 */
 import "C"
 
-// default value. from time.h
+// ClocksPerSec default value. from time.h
 const ClocksPerSec = float64(128)
 
 type statCollector struct {
@@ -55,8 +55,7 @@ func init() {
 	Factories["cpu"] = NewCPUCollector
 }
 
-// Takes a prometheus registry and returns a new Collector exposing
-// CPU stats.
+// NewCPUCollector returns a new Collector exposing CPU stats.
 func NewCPUCollector() (Collector, error) {
 	return &statCollector{
 		cpu: prometheus.NewDesc(

--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -91,8 +91,7 @@ func init() {
 	Factories["cpu"] = NewStatCollector
 }
 
-// Takes a prometheus registry and returns a new Collector exposing
-// CPU stats.
+// NewStatCollector returns a new Collector exposing CPU stats.
 func NewStatCollector() (Collector, error) {
 	return &statCollector{
 		cpu: prometheus.NewDesc(

--- a/collector/cpu_freebsd.go
+++ b/collector/cpu_freebsd.go
@@ -89,8 +89,7 @@ func init() {
 	Factories["cpu"] = NewStatCollector
 }
 
-// Takes a prometheus registry and returns a new Collector exposing
-// CPU stats.
+// NewStatCollector returns a new Collector exposing CPU stats.
 func NewStatCollector() (Collector, error) {
 	return &statCollector{
 		cpu: typedDesc{prometheus.NewDesc(

--- a/collector/devstat_dragonfly.go
+++ b/collector/devstat_dragonfly.go
@@ -102,8 +102,7 @@ func init() {
 	Factories["devstat"] = NewDevstatCollector
 }
 
-// Takes a prometheus registry and returns a new Collector exposing
-// Device stats.
+// NewDevstatCollector returns a new Collector exposing Device stats.
 func NewDevstatCollector() (Collector, error) {
 	return &devstatCollector{
 		bytesDesc: prometheus.NewDesc(

--- a/collector/devstat_freebsd.go
+++ b/collector/devstat_freebsd.go
@@ -36,12 +36,11 @@ type devstatCollector struct {
 	mu      sync.Mutex
 	devinfo *C.struct_devinfo
 
-	bytes       typedDesc
-	bytes_total typedDesc
-	transfers   typedDesc
-	duration    typedDesc
-	busyTime    typedDesc
-	blocks      typedDesc
+	bytes     typedDesc
+	transfers typedDesc
+	duration  typedDesc
+	busyTime  typedDesc
+	blocks    typedDesc
 }
 
 func init() {

--- a/collector/devstat_freebsd.go
+++ b/collector/devstat_freebsd.go
@@ -48,8 +48,7 @@ func init() {
 	Factories["devstat"] = NewDevstatCollector
 }
 
-// Takes a prometheus registry and returns a new Collector exposing
-// Device stats.
+// NewDevstatCollector returns a new Collector exposing Device stats.
 func NewDevstatCollector() (Collector, error) {
 	return &devstatCollector{
 		devinfo: &C.struct_devinfo{},

--- a/collector/loadavg_solaris.go
+++ b/collector/loadavg_solaris.go
@@ -34,7 +34,6 @@ func getLoad() ([]float64, error) {
 	samples := C.getloadavg(&loadavg[0], 3)
 	if samples > 0 {
 		return []float64{float64(loadavg[0]), float64(loadavg[1]), float64(loadavg[2])}, nil
-	} else {
-		return nil, errors.New("failed to get load average")
 	}
+	return nil, errors.New("failed to get load average")
 }

--- a/collector/loadavg_solaris.go
+++ b/collector/loadavg_solaris.go
@@ -32,8 +32,8 @@ import "C"
 func getLoad() ([]float64, error) {
 	var loadavg [3]C.double
 	samples := C.getloadavg(&loadavg[0], 3)
-	if samples > 0 {
-		return []float64{float64(loadavg[0]), float64(loadavg[1]), float64(loadavg[2])}, nil
+	if samples != 3 {
+		return nil, errors.New("failed to get load average")
 	}
-	return nil, errors.New("failed to get load average")
+	return []float64{float64(loadavg[0]), float64(loadavg[1]), float64(loadavg[2])}, nil
 }

--- a/collector/loadavg_unix.go
+++ b/collector/loadavg_unix.go
@@ -26,8 +26,8 @@ import "C"
 func getLoad() ([]float64, error) {
 	var loadavg [3]C.double
 	samples := C.getloadavg(&loadavg[0], 3)
-	if samples > 0 {
-		return []float64{float64(loadavg[0]), float64(loadavg[1]), float64(loadavg[2])}, nil
+	if samples != 3 {
+		return nil, errors.New("failed to get load average")
 	}
-	return nil, errors.New("failed to get load average")
+	return []float64{float64(loadavg[0]), float64(loadavg[1]), float64(loadavg[2])}, nil
 }

--- a/collector/loadavg_unix.go
+++ b/collector/loadavg_unix.go
@@ -28,7 +28,6 @@ func getLoad() ([]float64, error) {
 	samples := C.getloadavg(&loadavg[0], 3)
 	if samples > 0 {
 		return []float64{float64(loadavg[0]), float64(loadavg[1]), float64(loadavg[2])}, nil
-	} else {
-		return nil, errors.New("failed to get load average")
 	}
+	return nil, errors.New("failed to get load average")
 }

--- a/collector/sysctl_bsd.go
+++ b/collector/sysctl_bsd.go
@@ -94,7 +94,7 @@ func (b bsdSysctl) Value() (float64, error) {
 		if len(raw) != (C.sizeof_time_t + C.sizeof_suseconds_t) {
 			// Shouldn't get here, unless the ABI changes...
 			return 0, fmt.Errorf(
-				"Length of bytes recieved from sysctl (%d) does not match expected bytes (%d).",
+				"length of bytes received from sysctl (%d) does not match expected bytes (%d)",
 				len(raw),
 				C.sizeof_time_t+C.sizeof_suseconds_t,
 			)

--- a/collector/tcpstat_linux.go
+++ b/collector/tcpstat_linux.go
@@ -61,8 +61,7 @@ func init() {
 	Factories["tcpstat"] = NewTCPStatCollector
 }
 
-// NewTCPStatCollector takes a returns
-// a new Collector exposing network stats.
+// NewTCPStatCollector returns a new Collector exposing network stats.
 func NewTCPStatCollector() (Collector, error) {
 	return &tcpStatCollector{
 		desc: typedDesc{prometheus.NewDesc(


### PR DESCRIPTION
I was playing around with `golint` and decided to fix some trivial issues.

One `golint` warning for `collector/devstat_freebsd.go` remains:
```
collector/devstat_freebsd.go:40:2: don't use underscores in Go names; struct field bytes_total should be bytesTotal
```
However, the `bytes` vs `bytes_total` typedDesc looks suspicious and I decided not to touch it.