### PR TITLE
Make bind-mounts in Docker example read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ options and bind-mounts:
 
 ```bash
 docker run -d -p 9100:9100 \
-  -v "/proc:/host/proc" \
-  -v "/sys:/host/sys" \
-  -v "/:/rootfs" \
+  -v "/proc:/host/proc:ro" \
+  -v "/sys:/host/sys:ro" \
+  -v "/:/rootfs:ro" \
   --net="host" \
   quay.io/prometheus/node-exporter \
     -collector.procfs /host/proc \


### PR DESCRIPTION
It's probably a bad idea to bind-mount them read/write and should be entirely unnecessary.