### PR TITLE
Run node-exporter in Docker as nobody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 COPY node_exporter /bin/node_exporter
 
 EXPOSE      9100
+USER        nobody
 ENTRYPOINT  [ "/bin/node_exporter" ]


### PR DESCRIPTION
We probably should have done that earlier. Anyway, the node-exporter doesn't require root, in fact that a requirement for any collector we accept into the node-exporter.

Still, the Dockerfile we provide runs the node-exporter as root. While that's common for docker containers and prometheus itself isn't an exception, the node-exporter runs with bind-mounts to /sys and / and while encourage to be read-only, still has a bigger attack surface.