### PR TITLE
Add go path help to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ mv /path/to/directory/role.prom.$$ /path/to/directory/role.prom
 
 ## Building and running
 
+    go get github.com/prometheus/node_exporter
+    cd ${GOPATH-$HOME/go}/src/github.com/prometheus/node_exporter
     make
     ./node_exporter <flags>
 


### PR DESCRIPTION
Add `go get` and source directory requirements to the build
instructions.