### PR TITLE
Fix cpufreq statistics by converting kHz to Hz

### DIFF
--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -104,20 +104,21 @@ func (c *cpuCollector) updateCPUfreq(ch chan<- prometheus.Metric) error {
 		if _, err := os.Stat(filepath.Join(cpu, "cpufreq")); os.IsNotExist(err) {
 			log.Debugf("CPU %q is missing cpufreq", cpu)
 		} else {
+			// cpufreq values are kHz, multiply by 1000 for hz
 			if value, err = readUintFromFile(filepath.Join(cpu, "cpufreq/scaling_cur_freq")); err != nil {
 				return err
 			}
-			ch <- prometheus.MustNewConstMetric(c.cpuFreq, prometheus.GaugeValue, float64(value), cpuname)
+			ch <- prometheus.MustNewConstMetric(c.cpuFreq, prometheus.GaugeValue, float64(value)*1000.0, cpuname)
 
 			if value, err = readUintFromFile(filepath.Join(cpu, "cpufreq/scaling_min_freq")); err != nil {
 				return err
 			}
-			ch <- prometheus.MustNewConstMetric(c.cpuFreqMin, prometheus.GaugeValue, float64(value), cpuname)
+			ch <- prometheus.MustNewConstMetric(c.cpuFreqMin, prometheus.GaugeValue, float64(value)*1000.0, cpuname)
 
 			if value, err = readUintFromFile(filepath.Join(cpu, "cpufreq/scaling_max_freq")); err != nil {
 				return err
 			}
-			ch <- prometheus.MustNewConstMetric(c.cpuFreqMax, prometheus.GaugeValue, float64(value), cpuname)
+			ch <- prometheus.MustNewConstMetric(c.cpuFreqMax, prometheus.GaugeValue, float64(value)*1000.0, cpuname)
 		}
 
 		if _, err := os.Stat(filepath.Join(cpu, "thermal_throttle")); os.IsNotExist(err) {

--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -104,7 +104,8 @@ func (c *cpuCollector) updateCPUfreq(ch chan<- prometheus.Metric) error {
 		if _, err := os.Stat(filepath.Join(cpu, "cpufreq")); os.IsNotExist(err) {
 			log.Debugf("CPU %q is missing cpufreq", cpu)
 		} else {
-			// cpufreq values are kHz, multiply by 1000 for hz
+			// sysfs cpufreq values are kHz, thus multiply by 1000 to export base units (hz).
+			// See https://www.kernel.org/doc/Documentation/cpu-freq/user-guide.txt
 			if value, err = readUintFromFile(filepath.Join(cpu, "cpufreq/scaling_cur_freq")); err != nil {
 				return err
 			}

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -215,19 +215,19 @@ node_cpu_core_throttles_total{cpu="cpu1"} 0
 node_cpu_core_throttles_total{cpu="cpu2"} 40
 # HELP node_cpu_frequency_hertz Current cpu thread frequency in hertz.
 # TYPE node_cpu_frequency_hertz gauge
-node_cpu_frequency_hertz{cpu="cpu0"} 1.699981e+06
-node_cpu_frequency_hertz{cpu="cpu1"} 1.699981e+06
-node_cpu_frequency_hertz{cpu="cpu3"} 8000
+node_cpu_frequency_hertz{cpu="cpu0"} 1.699981e+09
+node_cpu_frequency_hertz{cpu="cpu1"} 1.699981e+09
+node_cpu_frequency_hertz{cpu="cpu3"} 8e+06
 # HELP node_cpu_frequency_max_hertz Maximum cpu thread frequency in hertz.
 # TYPE node_cpu_frequency_max_hertz gauge
-node_cpu_frequency_max_hertz{cpu="cpu0"} 3.7e+06
-node_cpu_frequency_max_hertz{cpu="cpu1"} 3.7e+06
-node_cpu_frequency_max_hertz{cpu="cpu3"} 4.2e+06
+node_cpu_frequency_max_hertz{cpu="cpu0"} 3.7e+09
+node_cpu_frequency_max_hertz{cpu="cpu1"} 3.7e+09
+node_cpu_frequency_max_hertz{cpu="cpu3"} 4.2e+09
 # HELP node_cpu_frequency_min_hertz Minimum cpu thread frequency in hertz.
 # TYPE node_cpu_frequency_min_hertz gauge
-node_cpu_frequency_min_hertz{cpu="cpu0"} 800000
-node_cpu_frequency_min_hertz{cpu="cpu1"} 800000
-node_cpu_frequency_min_hertz{cpu="cpu3"} 1000
+node_cpu_frequency_min_hertz{cpu="cpu0"} 8e+08
+node_cpu_frequency_min_hertz{cpu="cpu1"} 8e+08
+node_cpu_frequency_min_hertz{cpu="cpu3"} 1e+06
 # HELP node_cpu_package_throttles_total Number of times this cpu package has been throttled.
 # TYPE node_cpu_package_throttles_total counter
 node_cpu_package_throttles_total{cpu="cpu0"} 30


### PR DESCRIPTION
I've missed that the cpufreq values are actually kHz, not Hz. Thus translate from kHz to Hz before exporting.