### PR TITLE
Set Go import path on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,7 @@ go:
 - 1.8.x
 - tip
 
+go_import_path: github.com/prometheus/node_exporter
+
 script:
 - make


### PR DESCRIPTION
That's changes nothing for this repository but allows forks to use Travis CI without hacking configuration and makes merging with upstream easier.