### PR TITLE
Restrict build tags of collectors to supported operating systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ dependencies-stamp
 
 /.idea
 *.iml
+
+# Test files extracted from ttar
+collector/fixtures/sys/

--- a/collector/loadavg.go
+++ b/collector/loadavg.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 // +build !noloadavg
 
 package collector

--- a/collector/loadavg_freebsd.go
+++ b/collector/loadavg_freebsd.go
@@ -1,3 +1,16 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build !noloadavg
 
 package collector

--- a/collector/loadavg_solaris.go
+++ b/collector/loadavg_solaris.go
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build solaris
 // +build !noloadavg
 
 package collector

--- a/collector/meminfo.go
+++ b/collector/meminfo.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build darwin dragonfly freebsd linux
 // +build !nomeminfo
-// +build !netbsd
 
 package collector
 


### PR DESCRIPTION
The meminfo and loadavg collectors aren't available on all operating systems supported by go, we need to list the supported ones explicitly.

Fixes #596.