### PR TITLE
Status information in /proc/drbd

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Name     | Description | OS
 bonding | Exposes the number of configured and active slaves of Linux bonding interfaces. | Linux
 buddyinfo | Exposes statistics of memory fragments as reported by /proc/buddyinfo. | Linux
 devstat | Exposes device statistics | Dragonfly, FreeBSD
-drbd | Exposes Distributed Replicated Block Device statistics | Linux
+drbd | Exposes Distributed Replicated Block Device statistics (to version 8.4) | Linux
 interrupts | Exposes detailed interrupts statistics. | Linux, OpenBSD
 ksmd | Exposes kernel and system statistics from `/sys/kernel/mm/ksm`. | Linux
 logind | Exposes session counts from [logind](http://www.freedesktop.org/wiki/Software/systemd/logind/). | Linux


### PR DESCRIPTION
in version 8.4 deprecated (but won’t be removed)