### PR TITLE
Ignore wifi collector permission errors

### DIFF
--- a/collector/wifi_linux.go
+++ b/collector/wifi_linux.go
@@ -144,9 +144,13 @@ func NewWifiCollector() (Collector, error) {
 func (c *wifiCollector) Update(ch chan<- prometheus.Metric) error {
 	stat, err := newWifiStater(*collectorWifi)
 	if err != nil {
-		// Cannot access wifi metrics, report no error
+		// Cannot access wifi metrics, report no error.
 		if os.IsNotExist(err) {
 			log.Debug("wifi collector metrics are not available for this system")
+			return nil
+		}
+		if os.IsPermission(err) {
+			log.Debug("wifi collector got permission denied when accessing metrics")
 			return nil
 		}
 


### PR DESCRIPTION
Ignore the permission denined error when the wifi collector has no
permission to read metrics.

Closes: https://github.com/prometheus/node_exporter/issues/649