### PR TITLE
define consistent binary filename in promu configuration file

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -3,6 +3,8 @@ go:
 repository:
     path: github.com/prometheus/node_exporter
 build:
+    binaries:
+        - name: node_exporter
     flags: -a -tags 'netgo static_build'
     ldflags: |
         -X {{repoPath}}/vendor/github.com/prometheus/common/version.Version={{.Version}}


### PR DESCRIPTION
Maintaining a fork with a different folder name breaks the travis build/test.

Sympton:
```$ make
>> formatting code
>> vetting code
>> running staticcheck
>> building binaries
 >   prometheus-node-exporter
./ttar -C collector/fixtures -x -f collector/fixtures/sys.ttar
touch collector/fixtures/sys/.unpacked
>> running tests
ok  	github.com/prometheus/node_exporter	1.029s
ok  	github.com/prometheus/node_exporter/collector	1.068s
?   	github.com/prometheus/node_exporter/collector/ganglia	[no test files]
>> running end-to-end tests
./end-to-end-test.sh
./node_exporter not found. Consider running `go build` first.
make: *** [test-e2e] Error 1
The command "make" exited with 2.
Done. Your build exited with 1.
```

This pull request defines a consistent binary filename in the promu configuration file.

After applying this pull request:
```
>> building binaries
 >   node_exporter
./ttar -C collector/fixtures -x -f collector/fixtures/sys.ttar
touch collector/fixtures/sys/.unpacked
>> running tests
ok  	github.com/prometheus/node_exporter	1.508s
ok  	github.com/prometheus/node_exporter/collector	1.089s
?   	github.com/prometheus/node_exporter/collector/ganglia	[no test files]
>> running end-to-end tests
./end-to-end-test.sh
The command "make" exited with 0.
Done. Your build exited with 0.
```

Best Regards