### PR TITLE
cpu: Metric 'package_throttles_total' is per package.

### DIFF
--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -153,11 +153,10 @@ func (c *cpuCollector) updateCPUfreq(ch chan<- prometheus.Metric) error {
 			return err
 		}
 		// cpulist example of one package/node with HT: "0-11,24-35"
-		firstCPU := strings.Split(string(cpulist), "\n")[0]
-		if strings.Contains(firstCPU, "-") {
-			// multi-core: Use first cpu of package
-			firstCPU = strings.Split(firstCPU, "-")[0]
-		}
+		line := strings.Split(string(cpulist), "\n")[0]
+		firstCPU := strings.FieldsFunc(line, func(r rune) bool {
+			return r == '-' || r == ','
+		})[0]
 		if _, err := os.Stat(filepath.Join(pkg, "cpu"+firstCPU, "thermal_throttle", "package_throttle_count")); os.IsNotExist(err) {
 			log.Debugf("Package %q CPU %q is missing package_throttle", pkg, firstCPU)
 			continue

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -299,9 +299,7 @@ node_cpu_frequency_min_hertz{cpu="cpu1"} 8e+08
 node_cpu_frequency_min_hertz{cpu="cpu3"} 1e+06
 # HELP node_cpu_package_throttles_total Number of times this cpu package has been throttled.
 # TYPE node_cpu_package_throttles_total counter
-node_cpu_package_throttles_total{cpu="cpu0"} 30
-node_cpu_package_throttles_total{cpu="cpu1"} 30
-node_cpu_package_throttles_total{cpu="cpu2"} 6
+node_cpu_package_throttles_total{node="0"} 30
 # HELP node_disk_bytes_read The total number of bytes read successfully.
 # TYPE node_disk_bytes_read counter
 node_disk_bytes_read{device="dm-0"} 5.13708655616e+11

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -136,6 +136,17 @@ Lines: 1
 30
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/node/devices/node0/cpu1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/node/devices/node0/cpu1/thermal_throttle
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/node/devices/node0/cpu1/thermal_throttle/package_throttle_count
+Lines: 1
+30
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/bus/node/devices/node0/cpulist
 Lines: 1
 0-3

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -116,6 +116,31 @@ Lines: 1
 1000
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/node
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/node/devices
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/node/devices/node0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/node/devices/node0/cpu0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/node/devices/node0/cpu0/thermal_throttle
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/node/devices/node0/cpu0/thermal_throttle/package_throttle_count
+Lines: 1
+30
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/node/devices/node0/cpulist
+Lines: 1
+0-3
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/class
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
'package_throttles_total' is per package, not per cpu. This also reduces
the total number of cpu time series a lot (esp for multi core cpus).

Also add some missing fixtures for cpu2 and cpu3 for consistency.