### PR TITLE
Fixing `docker run` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ docker run -d -p 9100:9100 \
   -v "/:/rootfs:ro" \
   --net="host" \
   quay.io/prometheus/node-exporter \
-    --path.procfs /host/proc \
-    --path.sysfs /host/sys \
+    --collector.procfs /host/proc \
+    --collector.sysfs /host/sys \
     --collector.filesystem.ignored-mount-points "^/(sys|proc|dev|host|etc)($|/)"
 ```
 


### PR DESCRIPTION
The `docker run` example uses `path.procfs` and `path.sysfs`, but these options are apparently no longer available. According to [this](https://github.com/prometheus/node_exporter/issues/474#issuecomment-324513723) the correct ones seem to be `collector.procfs` and `collector.sysfs`

@SuperQ @discordianfish 