### PR TITLE
Use mac80211_hwsim in travis for wifi collector

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -1,0 +1,7 @@
+.ci
+===
+
+Configuration files that assist in setting up the `node_exporter` CI environment.
+
+- `hostapd.conf` and `wpa_supplicant.conf`: configuration files for use in wifi
+collector end-to-end tests.

--- a/.ci/hostapd.conf
+++ b/.ci/hostapd.conf
@@ -1,0 +1,4 @@
+interface=wlan0
+hw_mode=g
+channel=1
+ssid=test

--- a/.ci/wpa_supplicant.conf
+++ b/.ci/wpa_supplicant.conf
@@ -1,0 +1,4 @@
+network={
+    ssid="test"
+    key_mgmt=NONE
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 
 language: go
 go:
@@ -7,6 +7,12 @@ go:
 - master
 
 go_import_path: github.com/prometheus/node_exporter
+
+before_install:
+- sudo apt install hostapd wpasupplicant
+- sudo modprobe mac80211_hwsim
+- sudo hostapd .ci/hostapd.conf &
+- sudo wpa_supplicant -Dnl80211 -iwlan1 -c .ci/wpa_supplicant.conf &
 
 script:
 - make


### PR DESCRIPTION
An experiment.  If I can figure out how to get hostapd and wpa_supplicant working together in Travis, we can get even more metrics.

Fixes #687 .