### PR TITLE
Fix smartmon.sh textfile script

### DIFF
--- a/text_collector_examples/smartmon.sh
+++ b/text_collector_examples/smartmon.sh
@@ -7,8 +7,6 @@
 #       data in them than you'd think.
 #       http://arstechnica.com/civis/viewtopic.php?p=22062211
 
-disks="$(/usr/sbin/smartctl --scan | awk '{print $1 "|" $3}')"
-
 parse_smartctl_attributes_awk="$(cat << 'SMARTCTLAWK'
 $1 ~ /^[0-9]+$/ && $2 ~ /^[a-zA-Z0-9_-]+$/ {
   gsub(/-/, "_");
@@ -136,7 +134,7 @@ if [[ "$(expr "${smartctl_version}" : '\([0-9]*\)\..*')" -lt 6 ]] ; then
   exit
 fi
 
-device_list="$(/usr/sbin/smartctl --scan-open | awk '{print $1 "|" $3}')"
+device_list="$(/usr/sbin/smartctl --scan-open | awk '/^\/dev/{print $1 "|" $3}')"
 
 for device in ${device_list}; do
   disk="$(echo ${device} | cut -f1 -d'|')"


### PR DESCRIPTION
When there are no SMART compatible devices (Raspberry Pi for example) an
error is returned, but the return code is still 0.

`# scan_smart_devices: glob(3) aborted matching pattern /dev/discs/disc*`

* Remove unused `disks` variable.
* Filter for only valid `/dev` devices.