### PR TITLE
xfs: expose correct fields, fix metric names

### DIFF
--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2660,18 +2660,18 @@ node_xfs_allocation_btree_records_deleted_total{device="sda1"} 0
 # HELP node_xfs_allocation_btree_records_inserted_total Number of allocation B-tree records inserted for a filesystem.
 # TYPE node_xfs_allocation_btree_records_inserted_total counter
 node_xfs_allocation_btree_records_inserted_total{device="sda1"} 0
-# HELP node_xfs_block_mapping_btree_compares_total Number of block map B-tree compares for a filesystem.
-# TYPE node_xfs_block_mapping_btree_compares_total counter
-node_xfs_block_mapping_btree_compares_total{device="sda1"} 0
-# HELP node_xfs_block_mapping_btree_lookups_total Number of block map B-tree lookups for a filesystem.
-# TYPE node_xfs_block_mapping_btree_lookups_total counter
-node_xfs_block_mapping_btree_lookups_total{device="sda1"} 0
-# HELP node_xfs_block_mapping_btree_records_deleted_total Number of block map B-tree records deleted for a filesystem.
-# TYPE node_xfs_block_mapping_btree_records_deleted_total counter
-node_xfs_block_mapping_btree_records_deleted_total{device="sda1"} 0
-# HELP node_xfs_block_mapping_btree_records_inserted_total Number of block map B-tree records inserted for a filesystem.
-# TYPE node_xfs_block_mapping_btree_records_inserted_total counter
-node_xfs_block_mapping_btree_records_inserted_total{device="sda1"} 0
+# HELP node_xfs_block_map_btree_compares_total Number of block map B-tree compares for a filesystem.
+# TYPE node_xfs_block_map_btree_compares_total counter
+node_xfs_block_map_btree_compares_total{device="sda1"} 0
+# HELP node_xfs_block_map_btree_lookups_total Number of block map B-tree lookups for a filesystem.
+# TYPE node_xfs_block_map_btree_lookups_total counter
+node_xfs_block_map_btree_lookups_total{device="sda1"} 0
+# HELP node_xfs_block_map_btree_records_deleted_total Number of block map B-tree records deleted for a filesystem.
+# TYPE node_xfs_block_map_btree_records_deleted_total counter
+node_xfs_block_map_btree_records_deleted_total{device="sda1"} 0
+# HELP node_xfs_block_map_btree_records_inserted_total Number of block map B-tree records inserted for a filesystem.
+# TYPE node_xfs_block_map_btree_records_inserted_total counter
+node_xfs_block_map_btree_records_inserted_total{device="sda1"} 0
 # HELP node_xfs_block_mapping_extent_list_compares_total Number of extent list compares for a filesystem.
 # TYPE node_xfs_block_mapping_extent_list_compares_total counter
 node_xfs_block_mapping_extent_list_compares_total{device="sda1"} 0

--- a/collector/xfs_linux.go
+++ b/collector/xfs_linux.go
@@ -156,24 +156,24 @@ func (c *xfsCollector) updateXFSStats(ch chan<- prometheus.Metric, s *xfs.Stats)
 			value: float64(s.BlockMapping.ExtentListCompares),
 		},
 		{
-			name:  "block_mapping_btree_lookups_total",
+			name:  "block_map_btree_lookups_total",
 			desc:  "Number of block map B-tree lookups for a filesystem.",
-			value: float64(s.AllocationBTree.Lookups),
+			value: float64(s.BlockMapBTree.Lookups),
 		},
 		{
-			name:  "block_mapping_btree_compares_total",
+			name:  "block_map_btree_compares_total",
 			desc:  "Number of block map B-tree compares for a filesystem.",
-			value: float64(s.AllocationBTree.Compares),
+			value: float64(s.BlockMapBTree.Compares),
 		},
 		{
-			name:  "block_mapping_btree_records_inserted_total",
+			name:  "block_map_btree_records_inserted_total",
 			desc:  "Number of block map B-tree records inserted for a filesystem.",
-			value: float64(s.AllocationBTree.RecordsInserted),
+			value: float64(s.BlockMapBTree.RecordsInserted),
 		},
 		{
-			name:  "block_mapping_btree_records_deleted_total",
+			name:  "block_map_btree_records_deleted_total",
 			desc:  "Number of block map B-tree records deleted for a filesystem.",
-			value: float64(s.AllocationBTree.RecordsDeleted),
+			value: float64(s.BlockMapBTree.RecordsDeleted),
 		},
 	}
 


### PR DESCRIPTION
I made two mistakes:
- I was using allocation btree stats as the source for block map btree stats.
- I named the metrics "block_mapping" instead of "block_map".  Too late to fix now?  We're not 1.0 so I'd rather just fix it if possible.