### PR TITLE
Fix a memory allocation error on FreeBSD 10.3R

### DIFF
--- a/collector/meminfo_bsd.go
+++ b/collector/meminfo_bsd.go
@@ -39,7 +39,7 @@ func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 		{name: "inactive_bytes", mib: "vm.stats.vm.v_inactive_count", conversion: fromPage},
 		{name: "wired_bytes", mib: "vm.stats.vm.v_wire_count", conversion: fromPage},
 		{name: "cache_bytes", mib: "vm.stats.vm.v_cache_count", conversion: fromPage},
-		{name: "buffer_bytes", mib: "vfs.bufspace"},
+		{name: "buffer_bytes", mib: "vfs.bufspace", dataType: bsdSysctlTypeUint64},
 		{name: "free_bytes", mib: "vm.stats.vm.v_free_count", conversion: fromPage},
 		{name: "size_bytes", mib: "vm.stats.vm.v_page_count", conversion: fromPage},
 		{name: "swap_in_bytes_total", mib: "vm.stats.vm.v_swappgsin", conversion: fromPage},


### PR DESCRIPTION
Under some condition[1], it is possible to hit a memory allocation failure when retrieving the `buffer_bytes` via `sysctl()`.
Adding the `dataType` seems to fix this issue.

[1] happened on a heavy memory loaded FreeBSD 10.3R