### PR TITLE
Correct buffer_bytes > INT_MAX on BSD/amd64.

### DIFF
--- a/collector/meminfo_bsd.go
+++ b/collector/meminfo_bsd.go
@@ -39,7 +39,7 @@ func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 		{name: "inactive_bytes", mib: "vm.stats.vm.v_inactive_count", conversion: fromPage},
 		{name: "wired_bytes", mib: "vm.stats.vm.v_wire_count", conversion: fromPage},
 		{name: "cache_bytes", mib: "vm.stats.vm.v_cache_count", conversion: fromPage},
-		{name: "buffer_bytes", mib: "vfs.bufspace"},
+		{name: "buffer_bytes", mib: "vfs.bufspace", dataType: bsdSysctlTypeCLong},
 		{name: "free_bytes", mib: "vm.stats.vm.v_free_count", conversion: fromPage},
 		{name: "size_bytes", mib: "vm.stats.vm.v_page_count", conversion: fromPage},
 		{name: "swap_in_bytes_total", mib: "vm.stats.vm.v_swappgsin", conversion: fromPage},

--- a/collector/sysctl_bsd.go
+++ b/collector/sysctl_bsd.go
@@ -134,11 +134,11 @@ func (b bsdSysctl) getCLong() (float64, error) {
 		return 0, err
 	}
 
-	if len(raw) == (C.sizeof_long) {
+	if len(raw) == C.sizeof_long {
 		return float64(*(*C.long)(unsafe.Pointer(&raw[0]))), nil
 	}
 
-	if len(raw) == (C.sizeof_int) {
+	if len(raw) == C.sizeof_int {
 		// Not sure this is valid for all CLongs.  It is at least for
 		// vfs.bufspace:
 		//   https://github.com/freebsd/freebsd/blob/releng/10.3/sys/kern/vfs_bio.c#L338

--- a/collector/sysctl_bsd.go
+++ b/collector/sysctl_bsd.go
@@ -38,7 +38,8 @@ const (
 	bsdSysctlTypeCLong
 )
 
-// Contains all the info needed to map a single bsd-sysctl to a prometheus value.
+// Contains all the info needed to map a single bsd-sysctl to a prometheus
+// value.
 type bsdSysctl struct {
 	// Prometheus name
 	name string
@@ -123,8 +124,8 @@ func (b bsdSysctl) getStructTimeval() (float64, error) {
 	unix := float64(*(*C.time_t)(secondsUp))
 	usec := float64(*(*C.suseconds_t)(unsafe.Pointer(susecondsUp)))
 
-	// This conversion maintains the usec precision.  Using
-	// the time package did not.
+	// This conversion maintains the usec precision.  Using the time
+	// package did not.
 	return (unix + (usec / float64(1000*1000))), nil
 }
 
@@ -139,9 +140,10 @@ func (b bsdSysctl) getCLong() (float64, error) {
 	}
 
 	if len(raw) == C.sizeof_int {
-		// Not sure this is valid for all CLongs.  It is at least for
-		// vfs.bufspace:
+		// This is valid for at least vfs.bufspace, and the default
+		// long handler - which can clamp longs to 32-bits:
 		//   https://github.com/freebsd/freebsd/blob/releng/10.3/sys/kern/vfs_bio.c#L338
+		//   https://github.com/freebsd/freebsd/blob/releng/10.3/sys/kern/kern_sysctl.c#L1062
 		return float64(*(*C.int)(unsafe.Pointer(&raw[0]))), nil
 	}
 

--- a/collector/sysctl_bsd.go
+++ b/collector/sysctl_bsd.go
@@ -115,18 +115,18 @@ func (b bsdSysctl) Value() (float64, error) {
 			return 0, err
 		}
 
-		if len(raw) > (C.sizeof_long) {
-			return 0, fmt.Errorf(
-				"length of bytes received from sysctl (%d) is greater than expected bytes (%d)",
-				len(raw),
-				C.sizeof_long,
-			)
-		}
+		if len(raw) != (C.sizeof_long) {
+			if len(raw) != (C.sizeof_int) {
+				return 0, fmt.Errorf(
+					"length of bytes received from sysctl (%d) does not match expected bytes (%d)",
+					len(raw),
+					C.sizeof_long,
+				)
+			}
 
-		if len(raw) < (C.sizeof_long) {
-			// Not sure this is valid for all CLongs, at least for
-			// bufspace:
-			//  https://github.com/freebsd/freebsd/blob/releng/10.3/sys/kern/vfs_bio.c#L338
+			// Not sure this is valid for all CLongs.  It is at
+			// least for vfs.bufspace:
+			//   https://github.com/freebsd/freebsd/blob/releng/10.3/sys/kern/vfs_bio.c#L338
 			tmpf64 = float64(*(*C.int)(unsafe.Pointer(&raw[0])))
 			break
 		}


### PR DESCRIPTION
The sysctl vfs.bufspace returns either an int or a long, depending on
the value.  Large values of vfs.bufspace will result in error messages
like:

  couldn't get meminfo: cannot allocate memory

This will detect the returned data type, and cast appropriately.

This is an updated fix to the one provided in #710.

I suspect that there'll be more re-factoring here, if other uses show up.