### PR TITLE
Use float64 in the ZFS collector

### DIFF
--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -75,7 +75,7 @@ func (s zfsSysctl) metricName() string {
 	return strings.Replace(parts[len(parts)-1], "-", "_", -1)
 }
 
-func (c *zfsCollector) constSysctlMetric(subsystem string, sysctl zfsSysctl, value int64) prometheus.Metric {
+func (c *zfsCollector) constSysctlMetric(subsystem string, sysctl zfsSysctl, value float64) prometheus.Metric {
 	metricName := sysctl.metricName()
 
 	return prometheus.MustNewConstMetric(
@@ -86,11 +86,11 @@ func (c *zfsCollector) constSysctlMetric(subsystem string, sysctl zfsSysctl, val
 			nil,
 		),
 		prometheus.UntypedValue,
-		float64(value),
+		value,
 	)
 }
 
-func (c *zfsCollector) constPoolMetric(poolName string, sysctl zfsSysctl, value int64) prometheus.Metric {
+func (c *zfsCollector) constPoolMetric(poolName string, sysctl zfsSysctl, value float64) prometheus.Metric {
 	metricName := sysctl.metricName()
 
 	return prometheus.MustNewConstMetric(
@@ -101,7 +101,7 @@ func (c *zfsCollector) constPoolMetric(poolName string, sysctl zfsSysctl, value 
 			nil,
 		),
 		prometheus.UntypedValue,
-		float64(value),
+		value,
 		poolName,
 	)
 }

--- a/collector/zfs_linux.go
+++ b/collector/zfs_linux.go
@@ -42,7 +42,7 @@ func (c *zfsCollector) updateZfsStats(subsystem string, ch chan<- prometheus.Met
 	}
 	defer file.Close()
 
-	return c.parseProcfsFile(file, c.linuxPathMap[subsystem], func(s zfsSysctl, v int64) {
+	return c.parseProcfsFile(file, c.linuxPathMap[subsystem], func(s zfsSysctl, v float64) {
 		ch <- c.constSysctlMetric(subsystem, s, v)
 	})
 }
@@ -64,7 +64,7 @@ func (c *zfsCollector) updatePoolStats(ch chan<- prometheus.Metric) error {
 			return errZFSNotAvailable
 		}
 
-		err = c.parsePoolProcfsFile(file, zpoolPath, func(poolName string, s zfsSysctl, v int64) {
+		err = c.parsePoolProcfsFile(file, zpoolPath, func(poolName string, s zfsSysctl, v float64) {
 			ch <- c.constPoolMetric(poolName, s, v)
 		})
 		file.Close()
@@ -76,7 +76,7 @@ func (c *zfsCollector) updatePoolStats(ch chan<- prometheus.Metric) error {
 	return nil
 }
 
-func (c *zfsCollector) parseProcfsFile(reader io.Reader, fmtExt string, handler func(zfsSysctl, int64)) error {
+func (c *zfsCollector) parseProcfsFile(reader io.Reader, fmtExt string, handler func(zfsSysctl, float64)) error {
 	scanner := bufio.NewScanner(reader)
 
 	parseLine := false
@@ -95,7 +95,7 @@ func (c *zfsCollector) parseProcfsFile(reader io.Reader, fmtExt string, handler 
 
 		key := fmt.Sprintf("kstat.zfs.misc.%s.%s", fmtExt, parts[0])
 
-		value, err := strconv.ParseInt(parts[2], 10, 64)
+		value, err := strconv.ParseFloat(parts[2], 64)
 		if err != nil {
 			return fmt.Errorf("could not parse expected integer value for %q", key)
 		}
@@ -109,7 +109,7 @@ func (c *zfsCollector) parseProcfsFile(reader io.Reader, fmtExt string, handler 
 	return scanner.Err()
 }
 
-func (c *zfsCollector) parsePoolProcfsFile(reader io.Reader, zpoolPath string, handler func(string, zfsSysctl, int64)) error {
+func (c *zfsCollector) parsePoolProcfsFile(reader io.Reader, zpoolPath string, handler func(string, zfsSysctl, float64)) error {
 	scanner := bufio.NewScanner(reader)
 
 	parseLine := false
@@ -139,7 +139,7 @@ func (c *zfsCollector) parsePoolProcfsFile(reader io.Reader, zpoolPath string, h
 		for i, field := range fields {
 			key := fmt.Sprintf("kstat.zfs.misc.%s.%s", zpoolFile, field)
 
-			value, err := strconv.ParseInt(line[i], 10, 64)
+			value, err := strconv.ParseFloat(line[i], 64)
 			if err != nil {
 				return fmt.Errorf("could not parse expected integer value for %q: %v", key, err)
 			}

--- a/collector/zfs_linux_test.go
+++ b/collector/zfs_linux_test.go
@@ -32,7 +32,7 @@ func TestArcstatsParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseProcfsFile(arcstatsFile, "arcstats", func(s zfsSysctl, v int64) {
+	err = c.parseProcfsFile(arcstatsFile, "arcstats", func(s zfsSysctl, v float64) {
 
 		if s != zfsSysctl("kstat.zfs.misc.arcstats.hits") {
 			return
@@ -40,7 +40,7 @@ func TestArcstatsParsing(t *testing.T) {
 
 		handlerCalled = true
 
-		if v != int64(8772612) {
+		if v != float64(8772612) {
 			t.Fatalf("Incorrect value parsed from procfs data")
 		}
 
@@ -68,7 +68,7 @@ func TestZfetchstatsParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseProcfsFile(zfetchstatsFile, "zfetchstats", func(s zfsSysctl, v int64) {
+	err = c.parseProcfsFile(zfetchstatsFile, "zfetchstats", func(s zfsSysctl, v float64) {
 
 		if s != zfsSysctl("kstat.zfs.misc.zfetchstats.hits") {
 			return
@@ -76,7 +76,7 @@ func TestZfetchstatsParsing(t *testing.T) {
 
 		handlerCalled = true
 
-		if v != int64(7067992) {
+		if v != float64(7067992) {
 			t.Fatalf("Incorrect value parsed from procfs data")
 		}
 
@@ -104,7 +104,7 @@ func TestZilParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseProcfsFile(zilFile, "zil", func(s zfsSysctl, v int64) {
+	err = c.parseProcfsFile(zilFile, "zil", func(s zfsSysctl, v float64) {
 
 		if s != zfsSysctl("kstat.zfs.misc.zil.zil_commit_count") {
 			return
@@ -112,7 +112,7 @@ func TestZilParsing(t *testing.T) {
 
 		handlerCalled = true
 
-		if v != int64(10) {
+		if v != float64(10) {
 			t.Fatalf("Incorrect value parsed from procfs data")
 		}
 
@@ -140,7 +140,7 @@ func TestVdevCacheStatsParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseProcfsFile(vdevCacheStatsFile, "vdev_cache_stats", func(s zfsSysctl, v int64) {
+	err = c.parseProcfsFile(vdevCacheStatsFile, "vdev_cache_stats", func(s zfsSysctl, v float64) {
 
 		if s != zfsSysctl("kstat.zfs.misc.vdev_cache_stats.delegations") {
 			return
@@ -148,7 +148,7 @@ func TestVdevCacheStatsParsing(t *testing.T) {
 
 		handlerCalled = true
 
-		if v != int64(40) {
+		if v != float64(40) {
 			t.Fatalf("Incorrect value parsed from procfs data")
 		}
 
@@ -176,7 +176,7 @@ func TestXuioStatsParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseProcfsFile(xuioStatsFile, "xuio_stats", func(s zfsSysctl, v int64) {
+	err = c.parseProcfsFile(xuioStatsFile, "xuio_stats", func(s zfsSysctl, v float64) {
 
 		if s != zfsSysctl("kstat.zfs.misc.xuio_stats.onloan_read_buf") {
 			return
@@ -184,7 +184,7 @@ func TestXuioStatsParsing(t *testing.T) {
 
 		handlerCalled = true
 
-		if v != int64(32) {
+		if v != float64(32) {
 			t.Fatalf("Incorrect value parsed from procfs data")
 		}
 
@@ -212,7 +212,7 @@ func TestFmParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseProcfsFile(fmFile, "fm", func(s zfsSysctl, v int64) {
+	err = c.parseProcfsFile(fmFile, "fm", func(s zfsSysctl, v float64) {
 
 		if s != zfsSysctl("kstat.zfs.misc.fm.erpt-dropped") {
 			return
@@ -220,7 +220,7 @@ func TestFmParsing(t *testing.T) {
 
 		handlerCalled = true
 
-		if v != int64(18) {
+		if v != float64(18) {
 			t.Fatalf("Incorrect value parsed from procfs data")
 		}
 
@@ -248,7 +248,7 @@ func TestDmuTxParsing(t *testing.T) {
 	}
 
 	handlerCalled := false
-	err = c.parseProcfsFile(dmuTxFile, "dmu_tx", func(s zfsSysctl, v int64) {
+	err = c.parseProcfsFile(dmuTxFile, "dmu_tx", func(s zfsSysctl, v float64) {
 
 		if s != zfsSysctl("kstat.zfs.misc.dmu_tx.dmu_tx_assigned") {
 			return
@@ -256,7 +256,7 @@ func TestDmuTxParsing(t *testing.T) {
 
 		handlerCalled = true
 
-		if v != int64(3532844) {
+		if v != float64(3532844) {
 			t.Fatalf("Incorrect value parsed from procfs data")
 		}
 
@@ -289,14 +289,14 @@ func TestZpoolParsing(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = c.parsePoolProcfsFile(file, zpoolPath, func(poolName string, s zfsSysctl, v int64) {
+		err = c.parsePoolProcfsFile(file, zpoolPath, func(poolName string, s zfsSysctl, v float64) {
 			if s != zfsSysctl("kstat.zfs.misc.io.nread") {
 				return
 			}
 
 			handlerCalled = true
 
-			if v != int64(1884160) && v != int64(2826240) {
+			if v != float64(1884160) && v != float64(2826240) {
 				t.Fatalf("Incorrect value parsed from procfs data %v", v)
 			}
 


### PR DESCRIPTION
ZFS metrics can also be unsigned 64-bit integers that won't fit in int64 and causes the whole collector to fail.

#### Example

`time="2017-10-25T17:28:16Z" level=error msg="ERROR: zfs collector failed after 0.000335s: could not parse expected integer value for \"kstat.zfs.misc.zil.zil_itx_needcopy_bytes\"" source="collector.go:123"`

```
# grep zil_itx_needcopy_bytes /proc/spl/kstat/zfs/zil 
zil_itx_needcopy_bytes          4    18446744073709037523
```

The internal ZFS datatype `kstat_named_t` can have an uint64 value: https://github.com/zfsonlinux/zfs/blob/master/lib/libspl/include/sys/kstat.h#L472