### PR TITLE
update text_collector_examples/smartmon.sh

### DIFF
--- a/text_collector_examples/smartmon.sh
+++ b/text_collector_examples/smartmon.sh
@@ -189,7 +189,7 @@ for device in ${device_list}; do
 # shellcheck disable=SC2086
   type="$(echo ${device} | cut -f2 -d'|')"
 # shellcheck disable=SC2030
-  TS="$(TZ=UTC date +%s%3N)"
+  TS="$(TZ=UTC date +%s.%N)"
   echo "smartctl_run{disk=\"${disk}\",type=\"${type}\"} $TS"
   # Get the SMART information and health
   TS="$(TZ=UTC date +%s%3N)"

--- a/text_collector_examples/smartmon.sh
+++ b/text_collector_examples/smartmon.sh
@@ -7,63 +7,107 @@
 #       data in them than you'd think.
 #       http://arstechnica.com/civis/viewtopic.php?p=22062211
 
+#
+# 2017-11-07 extended by Jan Walzer
+#  - fixed some minor bugs
+#  - extended the list of smart-fields with the ones I found in my DC
+#  - implemented 'exact' timestamps for delivery of the metric
+#
+
+START_TS="$(TZ=UTC date +%s.%3N)"
+
 parse_smartctl_attributes_awk="$(cat << 'SMARTCTLAWK'
-$1 ~ /^[0-9]+$/ && $2 ~ /^[a-zA-Z0-9_-]+$/ {
+$1 ~ /^ *[0-9]+$/ && $2 ~ /^[a-zA-Z0-9_-]+$/ {
   gsub(/-/, "_");
-  printf "%s_value{%s,smart_id=\"%s\"} %d\n", $2, labels, $1, $4
-  printf "%s_worst{%s,smart_id=\"%s\"} %d\n", $2, labels, $1, $5
-  printf "%s_threshold{%s,smart_id=\"%s\"} %d\n", $2, labels, $1, $6
-  printf "%s_raw_value{%s,smart_id=\"%s\"} %e\n", $2, labels, $1, $10
+  printf "%s_value{%s,smart_id=\"%s\"} %d %s\n", $2, labels, $1, $4, ts
+  printf "%s_worst{%s,smart_id=\"%s\"} %d %s\n", $2, labels, $1, $5, ts
+  printf "%s_threshold{%s,smart_id=\"%s\"} %d %s\n", $2, labels, $1, $6, ts
+  printf "%s_raw_value{%s,smart_id=\"%s\"} %e %s\n", $2, labels, $1, $10, ts
 }
 SMARTCTLAWK
 )"
 
 smartmon_attrs="$(cat << 'SMARTMONATTRS'
 airflow_temperature_cel
+available_reservd_space
+ave_block-erase_count
+bckgnd_program_page_cnt
 command_timeout
+crc_error_count
+cumulativ_corrected_ecc
 current_pending_sector
+end-to-end_error
 end_to_end_error
 erase_fail_count
+error_correction_count
 g_sense_error_rate
 hardware_ecc_recovered
-host_reads_mib
+host_program_page_count
 host_reads_32mib
-host_writes_mib
+host_reads_mib
 host_writes_32mib
+host_writes_mib
 load_cycle_count
 media_wearout_indicator
-wear_leveling_count
 nand_writes_1gib
+nand_writes_32mib
 offline_uncorrectable
+percent_lifetime_used
+power-off_retract_count
 power_cycle_count
+power_loss_cap_test
 power_on_hours
+program_fail_cnt_total
 program_fail_count
+program_fail_count_chip
 raw_read_error_rate
+reallocate_nand_blk_cnt
+reallocated_event_count
 reallocated_sector_ct
 reported_uncorrect
+reserved_block_count
+runtime_bad_block
 sata_downshift_count
+sata_interfac_downshift
+seek_error_rate
+seek_time_performance
 spin_retry_count
 spin_up_time
 start_stop_count
+success_rain_recov_cnt
+temperature_case
 temperature_celsius
+temperature_internal
+thermal_throttle
+throughput_performance
+total_host_sector_write
 total_lbas_read
 total_lbas_written
 udma_crc_error_count
+unexpect_power_loss_ct
+unknown_attribute
+unknown_ssd_attribute
 unsafe_shutdown_count
+unused_reserve_nand_blk
+unused_rsvd_blk_cnt_tot
+wear_leveling_count
 workld_host_reads_perc
 workld_media_wear_indic
 workload_minutes
+write_error_rate
 SMARTMONATTRS
 )"
+# shellcheck disable=SC2086
 smartmon_attrs="$(echo ${smartmon_attrs} | xargs | tr ' ' '|')"
 
 parse_smartctl_attributes() {
   local disk="$1"
   local disk_type="$2"
   local labels="disk=\"${disk}\",type=\"${disk_type}\""
-  local vars="$(echo "${smartmon_attrs}" | xargs | tr ' ' '|')"
+# shellcheck disable=SC2018
+# shellcheck disable=SC2019
   sed 's/^ \+//g' \
-    | awk -v labels="${labels}" "${parse_smartctl_attributes_awk}" 2>/dev/null \
+    | awk -v labels="${labels}" -v ts="$TS" "${parse_smartctl_attributes_awk}" 2>/dev/null \
     | tr A-Z a-z \
     | grep -E "(${smartmon_attrs})"
 }
@@ -71,6 +115,7 @@ parse_smartctl_attributes() {
 parse_smartctl_info() {
   local -i smart_available=0 smart_enabled=0 smart_healthy=0
   local disk="$1" disk_type="$2"
+# shellcheck disable=SC2162
   while read line ; do
     info_type="$(echo "${line}" | cut -f1 -d: | tr ' ' '_')"
     info_value="$(echo "${line}" | cut -f2- -d: | sed 's/^ \+//g')"
@@ -102,13 +147,13 @@ parse_smartctl_info() {
     fi
   done
   if [[ -n "${vendor}" ]] ; then
-    echo "device_info{disk=\"${disk}\",type=\"${disk_type}\",vendor=\"${vendor}\",product=\"${product}\",revision=\"${revision}\",lun_id=\"${lun_id}\"} 1"
+    echo "device_info{disk=\"${disk}\",type=\"${disk_type}\",vendor=\"${vendor}\",product=\"${product}\",revision=\"${revision}\",lun_id=\"${lun_id}\"} 1 $TS"
   else
-    echo "device_info{disk=\"${disk}\",type=\"${disk_type}\",model_family=\"${model_family}\",device_model=\"${device_model}\",serial_number=\"${serial_number}\",firmware_version=\"${fw_version}\"} 1"
+    echo "device_info{disk=\"${disk}\",type=\"${disk_type}\",model_family=\"${model_family}\",device_model=\"${device_model}\",serial_number=\"${serial_number}\",firmware_version=\"${fw_version}\"} 1 $TS"
   fi
-  echo "device_smart_available{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_available}"
-  echo "device_smart_enabled{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_enabled}"
-  echo "device_smart_healthy{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_healthy}"
+  echo "device_smart_available{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_available} $TS"
+  echo "device_smart_enabled{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_enabled} $TS"
+  echo "device_smart_healthy{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_healthy} $TS"
 }
 
 output_format_awk="$(cat << 'OUTPUTAWK'
@@ -127,9 +172,10 @@ format_output() {
   | awk -F'{' "${output_format_awk}"
 }
 
+TS="$(TZ=UTC date +%s%3N)"
 smartctl_version="$(/usr/sbin/smartctl -V | head -n1  | awk '$1 == "smartctl" {print $2}')"
 
-echo "smartctl_version{version=\"${smartctl_version}\"} 1" | format_output
+echo "smartctl_version{version=\"${smartctl_version}\"} 1 $TS" | format_output
 
 if [[ "$(expr "${smartctl_version}" : '\([0-9]*\)\..*')" -lt 6 ]] ; then
   exit
@@ -138,11 +184,22 @@ fi
 device_list="$(/usr/sbin/smartctl --scan-open | awk '/^\/dev/{print $1 "|" $3}')"
 
 for device in ${device_list}; do
+# shellcheck disable=SC2086
   disk="$(echo ${device} | cut -f1 -d'|')"
+# shellcheck disable=SC2086
   type="$(echo ${device} | cut -f2 -d'|')"
-  echo "smartctl_run{disk=\"${disk}\",type=\"${type}\"}" $(TZ=UTC date '+%s')
+# shellcheck disable=SC2030
+  TS="$(TZ=UTC date +%s%3N)"
+  echo "smartctl_run{disk=\"${disk}\",type=\"${type}\"} $TS"
   # Get the SMART information and health
+  TS="$(TZ=UTC date +%s%3N)"
   /usr/sbin/smartctl -i -H -d "${type}" "${disk}" | parse_smartctl_info "${disk}" "${type}"
   # Get the SMART attributes
+  TS="$(TZ=UTC date +%s%3N)"
   /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}"
 done | format_output
+
+DURATION="$(TZ=UTC date -u -d "-${START_TS}seconds" +%s.%3N)"
+
+# shellcheck disable=SC2031
+echo "smartctl_run_duration{} $DURATION $TS" | format_output


### PR DESCRIPTION
- fixed some minor bugs:
  Because of Line#20 only Attributes with SMART-ID greater 99 got exported - fixed

- extended the list of smart-attributes
   I just grepped over all the discs available to me in the DC:
  Yes, there are even faulty ones exported by some discs like 'end-to-end_error' (written with dashes instead of underscores)

- implemented 'exact' timestamps for delivery of the metric:
  because the textfile-collector reads the file more often, than we write into it, its IMHO better, to specify the timestamp of every metric, when it got aquired. So prometheus can associate values that are gathered by the same run together and not produce artificial stairsteps, that aren't there in reality.

- annotated for the shellcheck
  because we're using shellcheck as linter in our CI-Pipeline I tried to fix most of the warnings and annotated the remaining ones, where the use of the idioms are intended.