### PR TITLE
cpu: Support processor-less (memory-only) NUMA nodes

### DIFF
--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -111,7 +111,7 @@ func (c *cpuCollector) updateCPUfreq(ch chan<- prometheus.Metric) error {
 		_, cpuname := filepath.Split(cpu)
 
 		if _, err := os.Stat(filepath.Join(cpu, "cpufreq")); os.IsNotExist(err) {
-			log.Debugf("CPU %q is missing cpufreq", cpu)
+			log.Debugf("CPU %v is missing cpufreq", cpu)
 		} else {
 			// sysfs cpufreq values are kHz, thus multiply by 1000 to export base units (hz).
 			// See https://www.kernel.org/doc/Documentation/cpu-freq/user-guide.txt
@@ -132,7 +132,7 @@ func (c *cpuCollector) updateCPUfreq(ch chan<- prometheus.Metric) error {
 		}
 
 		if _, err := os.Stat(filepath.Join(cpu, "thermal_throttle")); os.IsNotExist(err) {
-			log.Debugf("CPU %q is missing thermal_throttle", cpu)
+			log.Debugf("CPU %v is missing thermal_throttle", cpu)
 			continue
 		}
 		if value, err = readUintFromFile(filepath.Join(cpu, "thermal_throttle", "core_throttle_count")); err != nil {
@@ -149,12 +149,12 @@ func (c *cpuCollector) updateCPUfreq(ch chan<- prometheus.Metric) error {
 	// package / NUMA node loop
 	for _, node := range nodes {
 		if _, err := os.Stat(filepath.Join(node, "cpulist")); os.IsNotExist(err) {
-			log.Debugf("NUMA node %q is missing cpulist", node)
+			log.Debugf("NUMA node %v is missing cpulist", node)
 			continue
 		}
 		cpulist, err := ioutil.ReadFile(filepath.Join(node, "cpulist"))
 		if err != nil {
-			log.Debugf("could not read cpulist of NUMA node %q", node)
+			log.Debugf("could not read cpulist of NUMA node %v", node)
 			return err
 		}
 		// cpulist example of one package/node with HT: "0-11,24-35"
@@ -163,14 +163,14 @@ func (c *cpuCollector) updateCPUfreq(ch chan<- prometheus.Metric) error {
 			// Skip processor-less (memory-only) NUMA nodes.
 			// E.g. RAM expansion with Intel Optane Drive(s) using
 			// Intel Memory Drive Technology (IMDT).
-			log.Debugf("skipping processor-less (memory-only) NUMA node %q", node)
+			log.Debugf("skipping processor-less (memory-only) NUMA node %v", node)
 			continue
 		}
 		firstCPU := strings.FieldsFunc(line, func(r rune) bool {
 			return r == '-' || r == ','
 		})[0]
 		if _, err := os.Stat(filepath.Join(node, "cpu"+firstCPU, "thermal_throttle", "package_throttle_count")); os.IsNotExist(err) {
-			log.Debugf("Node %q CPU %q is missing package_throttle", node, firstCPU)
+			log.Debugf("Node %v CPU %v is missing package_throttle", node, firstCPU)
 			continue
 		}
 		if value, err = readUintFromFile(filepath.Join(node, "cpu"+firstCPU, "thermal_throttle", "package_throttle_count")); err != nil {

--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -159,6 +159,13 @@ func (c *cpuCollector) updateCPUfreq(ch chan<- prometheus.Metric) error {
 		}
 		// cpulist example of one package/node with HT: "0-11,24-35"
 		line := strings.Split(string(cpulist), "\n")[0]
+		if line == "" {
+			// Skip processor-less (memory-only) NUMA nodes.
+			// E.g. RAM expansion with Intel Optane Drive(s) using
+			// Intel Memory Drive Technology (IMDT).
+			log.Debugf("skipping processor-less (memory-only) package %q", pkg)
+			continue
+		}
 		firstCPU := strings.FieldsFunc(line, func(r rune) bool {
 			return r == '-' || r == ','
 		})[0]

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -152,6 +152,14 @@ Lines: 1
 0-3
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/node/devices/node1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/node/devices/node1/cpulist
+Lines: 1
+
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/class
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This PR fixes the following crash on systems with **processor-less (memory-only) NUMA node(s)**:
```
panic: runtime error: index out of range
goroutine 40 [running]:
github.com/prometheus/node_exporter/collector.(*cpuCollector).updateCPUfreq(0xc420214690, 0xc4202f0900, 0x0, 0x0)
.../go/packages/src/github.com/prometheus/node_exporter/collector/cpu_linux.go:164 +0x13ad
github.com/prometheus/node_exporter/collector.(*cpuCollector).Update(0xc420214690, 0xc4202f0900, 0x106da40, 0x0)
.../go/packages/src/github.com/prometheus/node_exporter/collector/cpu_linux.go:94 +0x60
github.com/prometheus/node_exporter/collector.execute(0xad6ab8, 0x3, 0x1035e40, 0xc420214690, 0xc4202f0900)
.../go/packages/src/github.com/prometheus/node_exporter/collector/collector.go:131 +0x7e
github.com/prometheus/node_exporter/collector.nodeCollector.Collect.func1(0xc4202f0900, 0xc4202f2190, 0xad6ab8, 0x3, 0x1035e40, 0xc420214690)
.../go/packages/src/github.com/prometheus/node_exporter/collector/collector.go:122 +0x53
created by github.com/prometheus/node_exporter/collector.nodeCollector.Collect
.../go/packages/src/github.com/prometheus/node_exporter/collector/collector.go:121 +0x109
```
There are also two additional cleanup commits.

Processor-less (memory-only) NUMA nodes exist e.g. in systems that use Intel Optane drives for RAM expansion using Intel Memory Drive Technology (IMDT).

IMDT RAM expansion supports two modes:

- **Unify Remote Memory domains** : present a processor-less (memory-only)
  NUMA domain, which is the default
- **Expand local memory domains** : to expand each processor’s memory domain with a portion of the memory made available by Optane and IMDT

This commit fixes a crash in the first case (when `cpulist` is empty).

Here's an example of such a system:

```
$ numastat -m|head -n5

Per-node system memory usage (in MBs):
                          Node 0          Node 1          Node 2           Total
                 --------------- --------------- --------------- ---------------
MemTotal               118239.56       130816.00       464384.00       713439.56

$ for i in {0..2}; do echo -n "$i: " ; cat /sys/bus/node/devices/node$i/cpulist ; done
0: 0-7,16-23
1: 8-15,24-31
2:

$ /opt/vsmp/bin/vsmpversion -vvv
Memory Drive Technology: 8.2.1455.74 (Sep 28 2017 13:09:59)
System configuration:
    Boards:      3
       1 x Proc. + I/O + Memory
       2 x NVM devices (Intel SSDPED1K375GAQ)
    Processors:  2, Cores: 16, Threads: 32
        Intel(R) Xeon(R) CPU E5-2667 v4 @ 3.20GHz Stepping 01
    Memory (MB): 713472 (of 977450), Cache: 251416, Private: 12562
       1 x 249088MB   [262036/   678/12270]
       1 x 232192MB   [357707/125369/  146]  82:00.0#1
       1 x 232192MB   [357707/125369/  146]  83:00.0#1
```