### PR TITLE
textfile: fix duplicate metrics error

### DIFF
--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -34,6 +35,7 @@ import (
 
 var (
 	textFileDirectory = kingpin.Flag("collector.textfile.directory", "Directory to read text files with metrics from.").Default("").String()
+	textFileAddOnce   sync.Once
 )
 
 type textFileCollector struct {
@@ -56,10 +58,12 @@ func NewTextFileCollector() (Collector, error) {
 		// the flag is not passed.
 		log.Infof("No directory specified, see --collector.textfile.directory")
 	} else {
-		prometheus.DefaultGatherer = prometheus.Gatherers{
-			prometheus.DefaultGatherer,
-			prometheus.GathererFunc(func() ([]*dto.MetricFamily, error) { return c.parseTextFiles(), nil }),
-		}
+		textFileAddOnce.Do(func() {
+			prometheus.DefaultGatherer = prometheus.Gatherers{
+				prometheus.DefaultGatherer,
+				prometheus.GathererFunc(func() ([]*dto.MetricFamily, error) { return c.parseTextFiles(), nil }),
+			}
+		})
 	}
 
 	return c, nil


### PR DESCRIPTION
The textfile gatherer should only be added to gatherer list once.

Closes #704