### PR TITLE
Add Prometheus 2.0 compatible example rules file - new YAML format

### DIFF
--- a/example-rules.yml
+++ b/example-rules.yml
@@ -1,0 +1,14 @@
+groups:
+- name: example-node-exporter-rules
+  rules:
+  # The count of CPUs per node, useful for getting CPU time as a percent of total.
+  - record: instance:node_cpus:count
+    expr: count(node_cpu{mode="idle"}) without (cpu,mode)
+
+  # CPU in use by CPU.
+  - record: instance_cpu:node_cpu_not_idle:rate5m
+    expr: sum(rate(node_cpu{mode!="idle"}[5m])) without (mode)
+
+  # CPU in use by mode.
+  - record: instance_mode:node_cpu:rate5m
+    expr: sum(rate(node_cpu[5m])) without (cpu)


### PR DESCRIPTION
This pull request adds a new example rules file, which is compatible with Prometheus 2.0. The examples are copied from the original example file.

I tested it with the beta2 release, though the format should be the same in the final release.

@discordianfish @SuperQ 