### PR TITLE
Added text collector conversion for ipmitool output.

### DIFF
--- a/text_collector_examples/ipmitool
+++ b/text_collector_examples/ipmitool
@@ -10,22 +10,20 @@
 #   ipmitool sensor | awk -f ./ipmitool > ipmitool.prom
 #
 
-function discrete2float(hex_value) {
-	return hex_value + 0;
-}
-
-function exportArray(a, name) {
-	if (a["metric_count"] < 1) {
+function export(values, name) {
+	if (values["metric_count"] < 1) {
 		return
 	}
-	delete a["metric_count"]
+	delete values["metric_count"]
+
+	printf("# HELP %s%s %s sensor reading from ipmitool\n", namespace, name, friendly[name]);
 
 	if (name != "status") {
 		printf("# TYPE %s%s gauge\n", namespace, name);
 	}
 
-	for (sensor in a) {
-		printf("%s%s{sensor=\"%s\"} %f\n", namespace, name, sensor, a[sensor]);
+	for (sensor in values) {
+		printf("%s%s{sensor=\"%s\"} %f\n", namespace, name, sensor, values[sensor]);
 	}
 }
 
@@ -33,6 +31,13 @@ function exportArray(a, name) {
 BEGIN {
 	FS = "[ ]*[|][ ]*";
 	namespace = "node_ipmi_";
+
+	# Friendly description of the type of sensor for HELP.
+	friendly["temperature_celcius"] = "Temperature";
+	friendly["volts"] = "Voltage";
+	friendly["power_watts"] = "Power";
+	friendly["speed_rpm"] = "Fan";
+	friendly["status"] = "Chassis status";
 
 	temperature_celcius["metric_count"] = 0;
 	volts["metric_count"] = 0;
@@ -80,9 +85,9 @@ $3 ~ /discrete/ {
 }
 
 END {
-	exportArray(temperature_celcius, "temperature_celcius");
-	exportArray(volts, "volts");
-	exportArray(power_watts, "power_watts");
-	exportArray(speed_rpm, "speed_rpm");
-	exportArray(status, "status");
+	export(temperature_celcius, "temperature_celcius");
+	export(volts, "volts");
+	export(power_watts, "power_watts");
+	export(speed_rpm, "speed_rpm");
+	export(status, "status");
 }

--- a/text_collector_examples/ipmitool
+++ b/text_collector_examples/ipmitool
@@ -1,50 +1,88 @@
-#!/usr/bin/awk -f
+#!/usr/bin/awk -nf
 
 #
 # Converts output of `ipmitool sensor` to prometheus format.
 #
-# e.g.:
+# With GNU awk:
 #   ipmitool sensor | ./ipmitool > ipmitool.prom
+#
+# With BSD awk:
+#   ipmitool sensor | awk -f ./ipmitool > ipmitool.prom
 #
 
 function discrete2float(hex_value) {
 	return hex_value + 0;
 }
 
-# Fields are Bar separated, with space padding
-BEGIN {
-	FS = "[ ]*[|][ ]*";
+function exportArray(a, name) {
+	if (a["metric_count"] < 1) {
+		return
+	}
+	delete a["metric_count"]
+
+	if (name != "status") {
+		printf("# TYPE %s%s gauge\n", namespace, name);
+	}
+
+	for (sensor in a) {
+		printf("%s%s{sensor=\"%s\"} %f\n", namespace, name, sensor, a[sensor]);
+	}
 }
 
-# Not a valid line
+# Fields are Bar separated, with space padding.
+BEGIN {
+	FS = "[ ]*[|][ ]*";
+	namespace = "node_ipmi_";
+
+	temperature_celcius["metric_count"] = 0;
+	volts["metric_count"] = 0;
+	power_watts["metric_count"] = 0;
+	speed_rpm["metric_count"] = 0;
+	status["metric_count"] = 0;
+}
+
+# Not a valid line.
 {
 	if (NF < 3) {
 		next
 	}
 }
 
-# $2 is value field
+# $2 is value field.
 $2 ~ /na/ {
 	next
 }
 
-# $3 is type field
+# $3 is type field.
 $3 ~ /degrees C/ {
-	printf("node_physical_temperature_celcius{sensor=\"%s\"} %f\n", $1, $2);
+	temperature_celcius[$1] = $2;
+	temperature_celcius["metric_count"]++;
 }
 
 $3 ~ /Volts/ {
-	printf("node_physical_volts{sensor=\"%s\"} %f\n", $1, $2);
+	volts[$1] = $2;
+	volts["metric_count"]++;
 }
 
 $3 ~ /Watts/ {
-	printf("node_physical_watts{sensor=\"%s\"} %f\n", $1, $2);
+	power_watts[$1] = $2;
+	power_watts["metric_count"]++;
 }
 
 $3 ~ /RPM/ {
-	printf("node_physical_speed_rpm{sensor=\"%s\"} %f\n", $1, $2);
+	speed_rpm[$1] = $2;
+	speed_rpm["metric_count"]++;
 }
 
 $3 ~ /discrete/ {
-	printf("node_physical_status{sensor=\"%s\"} %f\n", $1, discrete2float($2));
+	status[$1] = $2;
+	status["metric_count"]++;
+}
+
+END {
+	exportArray(temperature_celcius, "temperature_celcius");
+	exportArray(volts, "volts");
+	exportArray(power_watts, "power_watts");
+	exportArray(speed_rpm, "speed_rpm");
+	exportArray(status, "status");
 }

--- a/text_collector_examples/ipmitool
+++ b/text_collector_examples/ipmitool
@@ -1,0 +1,50 @@
+#!/usr/bin/awk -f
+
+#
+# Converts output of `ipmitool sensor` to prometheus format.
+#
+# e.g.:
+#   ipmitool sensor | ./ipmitool > ipmitool.prom
+#
+
+function discrete2float(hex_value) {
+	return hex_value + 0;
+}
+
+# Fields are Bar separated, with space padding
+BEGIN {
+	FS = "[ ]*[|][ ]*";
+}
+
+# Not a valid line
+{
+	if (NF < 3) {
+		next
+	}
+}
+
+# $2 is value field
+$2 ~ /na/ {
+	next
+}
+
+# $3 is type field
+$3 ~ /degrees C/ {
+	printf("node_physical_temperature_celcius{sensor=\"%s\"} %f\n", $1, $2);
+}
+
+$3 ~ /Volts/ {
+	printf("node_physical_volts{sensor=\"%s\"} %f\n", $1, $2);
+}
+
+$3 ~ /Watts/ {
+	printf("node_physical_watts{sensor=\"%s\"} %f\n", $1, $2);
+}
+
+$3 ~ /RPM/ {
+	printf("node_physical_speed_rpm{sensor=\"%s\"} %f\n", $1, $2);
+}
+
+$3 ~ /discrete/ {
+	printf("node_physical_status{sensor=\"%s\"} %f\n", $1, discrete2float($2));
+}

--- a/text_collector_examples/ipmitool
+++ b/text_collector_examples/ipmitool
@@ -16,12 +16,8 @@ function export(values, name) {
 	}
 	delete values["metric_count"]
 
-	printf("# HELP %s%s %s sensor reading from ipmitool\n", namespace, name, friendly[name]);
-
-	if (name != "status") {
-		printf("# TYPE %s%s gauge\n", namespace, name);
-	}
-
+	printf("# HELP %s%s %s sensor reading from ipmitool\n", namespace, name, help[name]);
+	printf("# TYPE %s%s gauge\n", namespace, name);
 	for (sensor in values) {
 		printf("%s%s{sensor=\"%s\"} %f\n", namespace, name, sensor, values[sensor]);
 	}
@@ -33,11 +29,11 @@ BEGIN {
 	namespace = "node_ipmi_";
 
 	# Friendly description of the type of sensor for HELP.
-	friendly["temperature_celcius"] = "Temperature";
-	friendly["volts"] = "Voltage";
-	friendly["power_watts"] = "Power";
-	friendly["speed_rpm"] = "Fan";
-	friendly["status"] = "Chassis status";
+	help["temperature_celcius"] = "Temperature";
+	help["volts"] = "Voltage";
+	help["power_watts"] = "Power";
+	help["speed_rpm"] = "Fan";
+	help["status"] = "Chassis status";
 
 	temperature_celcius["metric_count"] = 0;
 	volts["metric_count"] = 0;


### PR DESCRIPTION
Converts output of `ipmitool sensor` to prometheus format.

e.g.: `ipmitool sensor | ./ipmitool > ipmitool.prom`