### PR TITLE
apt.sh: handle multiple origins in apt-get output

### DIFF
--- a/text_collector_examples/apt.sh
+++ b/text_collector_examples/apt.sh
@@ -5,7 +5,9 @@
 # Author: Ben Kochie <superq@gmail.com>
 
 upgrades="$(/usr/bin/apt-get --just-print upgrade \
-  | /usr/bin/awk '/^Inst/ {print $5, $6}' \
+  | /usr/bin/awk -F'[()]' \
+      '/^Inst/ { sub("^[^ ]+ ", "", $2); sub("\\[", " ", $2);
+                 sub(" ", "", $2); sub("\\]", "", $2); print $2 }'
   | /usr/bin/sort \
   | /usr/bin/uniq -c \
   | awk '{ gsub(/\\\\/, "\\\\", $2); gsub(/\"/, "\\\"", $2);


### PR DESCRIPTION
I found this case mostly on machines with "point release" upgrades pending, e.g. like the recent jessie and stretch updates. What do you think @SuperQ ?