### PR TITLE
On SunOS/ solaris/ SmartOS the go test flag of -rance isn't supported.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,15 +31,17 @@ DOCKERFILE              ?= Dockerfile
 STATICCHECK_IGNORE = \
   github.com/prometheus/node_exporter/node_exporter.go:SA1019
 
-ifeq ($(GOHOSTARCH),amd64)
-	# Only supported on amd64
-	test-flags := -race
-endif
-
 ifeq ($(OS),Windows_NT)
     OS_detected := Windows
 else
     OS_detected := $(shell uname -s)
+endif
+
+ifeq ($(GOHOSTARCH),amd64)
+        ifneq ($(OS_detected),SunOS)
+                # Only supported on amd64
+                test-flags := -race
+        endif
 endif
 
 ifeq ($(OS_detected), Linux)


### PR DESCRIPTION
I was trying to build node_exporter on SmartOS and ran into this issue. It fixes #698, but also needs https://github.com/prometheus/promu/pull/88 

Install setup from smartos image: base-64-lts 16.4.1

>   pkgin in scmgit-base gcc49
>   pkgin in go-1.9
>   pkgin in git-2.14.1
>   go get github.com/prometheus/node_exporter
>   cd go/src/github.com/prometheus/node_exporter/
>   pkgin in gmake
>   make

Before my change
>[root@fry ~/go/src/github.com/prometheus/node_exporter]# make
>> formatting code
>> vetting code
>> running staticcheck
>> building binaries
 >   node_exporter
./ttar -C collector/fixtures -x -f collector/fixtures/sys.ttar
touch collector/fixtures/sys/.unpacked
>> running tests
GO15VENDOREXPERIMENT=1 go test -short -race github.com/prometheus/node_exporter github.com/prometheus/node_exporter/collector github.com/prometheus/node_exporter/collector/ganglia
go test: -race and -msan are only supported on linux/amd64, freebsd/amd64, darwin/amd64 and windows/amd64
Makefile:75: recipe for target 'test' failed
make: *** [test] Error 2


Env
>[root@fry ~/go/src/github.com/prometheus/node_exporter]# go env
GOARCH="amd64"
GOBIN=""
GOEXE=""
GOHOSTARCH="amd64"
GOHOSTOS="solaris"
GOOS="solaris"
GOPATH="/root/go"
GORACE=""
.....
