### PR TITLE
Feat/systemd summary

### DIFF
--- a/collector/systemd_linux_test.go
+++ b/collector/systemd_linux_test.go
@@ -121,3 +121,24 @@ func TestSystemdIgnoreFilterDefaultKeepsAll(t *testing.T) {
 		t.Error("Default filters removed units")
 	}
 }
+
+func TestSystemdSummary(t *testing.T) {
+	fixtures := getUnitListFixtures()
+	summary := summarizeUnits(fixtures[0])
+
+	for _, state := range unitStatesName {
+		if state == "inactive" {
+			testSummaryHelper(t, state, summary[state], 3.0)
+		} else if state == "active" {
+			testSummaryHelper(t, state, summary[state], 1.0)
+		} else {
+			testSummaryHelper(t, state, summary[state], 0.0)
+		}
+	}
+}
+
+func testSummaryHelper(t *testing.T, state string, actual float64, expected float64) {
+	if actual != expected {
+		t.Errorf("Summary mode didn't count %s jobs correctly. Actual: %f, expected: %f", state, actual, expected)
+	}
+}


### PR DESCRIPTION
Here's the topic in the Google Groups to discuss this: https://groups.google.com/forum/?fromgroups#!topic/prometheus-developers/uhpXqdS0r8A

By using `./node_exporter --collector.systemd --collector.systemd.summary`, you can get simplified/summarized systemd stats:

```
# HELP node_systemd_unit_state_summary Summary of systemd unit states
# TYPE node_systemd_unit_state_summary gauge
node_systemd_unit_state_summary{state="activating"} 0
node_systemd_unit_state_summary{state="active"} 275
node_systemd_unit_state_summary{state="deactivating"} 0
node_systemd_unit_state_summary{state="failed"} 0
node_systemd_unit_state_summary{state="inactive"} 70
node_systemd_unit_state_summary{state="total"} 345
```