### PR TITLE
Fix e2e tests after textfile custom timestamp removal

### DIFF
--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -3307,7 +3307,7 @@ testmetric1_1{foo="bar"} 10
 testmetric1_2{foo="baz"} 20
 # HELP testmetric2_1 Metric read from collector/fixtures/textfile/two_metric_files/metrics2.prom
 # TYPE testmetric2_1 untyped
-testmetric2_1{foo="bar"} 30 1441205977284
+testmetric2_1{foo="bar"} 30
 # HELP testmetric2_2 Metric read from collector/fixtures/textfile/two_metric_files/metrics2.prom
 # TYPE testmetric2_2 untyped
-testmetric2_2{foo="baz"} 40 1441205977284
+testmetric2_2{foo="baz"} 40

--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -77,6 +77,10 @@ func convertMetricFamily(metricFamily *dto.MetricFamily, ch chan<- prometheus.Me
 	}
 
 	for _, metric := range metricFamily.Metric {
+		if metric.TimestampMs != nil {
+			log.Warnf("Ignoring unsupported custom timestamp on textfile collector metric %v", metric)
+		}
+
 		labels := metric.GetLabel()
 		var names []string
 		var values []string


### PR DESCRIPTION
The textfile collector does not support client-side timestamps anymore after https://github.com/prometheus/node_exporter/pull/763. Only the e2e tests caught this, which only seem to run once something is merged into master?

@brian-brazil is this ok, or do we still need to support client-side timestamps for user-supplied textfile metrics?