### PR TITLE
Treat custom textfile metric timestamps as errors

### DIFF
--- a/collector/fixtures/textfile/client_side_timestamp.out
+++ b/collector/fixtures/textfile/client_side_timestamp.out
@@ -1,0 +1,3 @@
+# HELP node_textfile_scrape_error 1 if there was an error opening or reading a file, 0 otherwise
+# TYPE node_textfile_scrape_error gauge
+node_textfile_scrape_error 1

--- a/collector/fixtures/textfile/client_side_timestamp/metrics.prom
+++ b/collector/fixtures/textfile/client_side_timestamp/metrics.prom
@@ -1,0 +1,2 @@
+metric_with_custom_timestamp 1 1441205977284
+normal_metric 2

--- a/collector/fixtures/textfile/two_metric_files/metrics2.prom
+++ b/collector/fixtures/textfile/two_metric_files/metrics2.prom
@@ -1,2 +1,2 @@
-testmetric2_1{foo="bar"} 30 1441205977284
-testmetric2_2{foo="baz"} 40 1441205977284
+testmetric2_1{foo="bar"} 30
+testmetric2_2{foo="baz"} 40

--- a/collector/textfile_test.go
+++ b/collector/textfile_test.go
@@ -63,6 +63,10 @@ func TestTextfileCollector(t *testing.T) {
 			out:  "fixtures/textfile/nonexistent_path.out",
 		},
 		{
+			path: "fixtures/textfile/client_side_timestamp",
+			out:  "fixtures/textfile/client_side_timestamp.out",
+		},
+		{
 			path: "fixtures/textfile/different_metric_types",
 			out:  "fixtures/textfile/different_metric_types.out",
 		},


### PR DESCRIPTION
This is clearer behavior and users will notice and fix their textfiles faster
than if we just output a warning.