### PR TITLE
Escape double quotes in device model family

### DIFF
--- a/text_collector_examples/smartmon.sh
+++ b/text_collector_examples/smartmon.sh
@@ -73,7 +73,7 @@ parse_smartctl_info() {
   local disk="$1" disk_type="$2"
   while read line ; do
     info_type="$(echo "${line}" | cut -f1 -d: | tr ' ' '_')"
-    info_value="$(echo "${line}" | cut -f2- -d: | sed 's/^ \+//g')"
+    info_value="$(echo "${line}" | cut -f2- -d: | sed 's/^ \+//g' | sed 's/"/\\"/')"
     case "${info_type}" in
       Model_Family) model_family="${info_value}" ;;
       Device_Model) device_model="${info_value}" ;;


### PR DESCRIPTION
Some devices has double quotes in it's model family. Something like this:   
`Model Family:     Toshiba 3.5" DT01ACA... Desktop HDD`
It makes broken metric:  
`smartmon_device_info{disk="/dev/sdb",type="sat",model_family="Toshiba 3.5" DT01ACA... Desktop HDD",device_model="TOSHIBA DT01ACA300",serial_number="63QY1WTGS",firmware_version="MX6OABB0"} 1`
This PR is fixing this by escaping `"`.