### PR TITLE
[FIX] Exclude Linux proc from filesystem type regexp

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	defIgnoredMountPoints = "^/(sys|proc|dev)($|/)"
-	defIgnoredFSTypes     = "^(sysfs|proc|autofs|procfs)$"
+	defIgnoredFSTypes     = "^(sysfs|autofs|procfs|proc)$"
 	readOnly              = 0x1 // ST_RDONLY
 )
 

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	defIgnoredMountPoints = "^/(sys|proc|dev)($|/)"
-	defIgnoredFSTypes     = "^(sys|proc|auto)fs$"
+	defIgnoredFSTypes     = "^(sysfs|proc|autofs|procfs)$"
 	readOnly              = 0x1 // ST_RDONLY
 )
 


### PR DESCRIPTION
Closes: https://github.com/prometheus/node_exporter/issues/773