### PR TITLE
Lio node_exporter module 

### DIFF
--- a/collector/lio.go
+++ b/collector/lio.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Alex Lau (AvengerMoJo) <alau@suse.com>
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,300 +15,299 @@
 package collector
 
 import (
-    "fmt"
-    "strings"
+	"fmt"
+	"strings"
 
-    "github.com/prometheus/client_golang/prometheus"
-    "github.com/prometheus/common/log"
-    "github.com/prometheus/procfs/iscsi"
-    "github.com/prometheus/procfs/sysfs"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+	"github.com/prometheus/procfs/iscsi"
+	"github.com/prometheus/procfs/sysfs"
 )
 
 const (
-    lio_fileio_Subsystem = "lio_fileio"
-    lio_iblock_Subsystem = "lio_iblock"
-    lio_rbd_Subsystem    = "lio_rbd"
-    lio_rdmcp_Subsystem  = "lio_rd_mcp"
+	lioFileioSubsystem = "lio_fileio"
+	lioIblockSubsystem = "lio_iblock"
+	lioRbdSubsystem    = "lio_rbd"
+	lioRdmcpSubsystem  = "lio_rdmcp"
 )
 
 // An lioCollector is a Collector which gathers iscsi RBD
-// iops (iscsi commands) , Read in byte and Write in byte. 
+// iops (iscsi commands) , Read in byte and Write in byte.
 // ( original reading sysfs is in MB )
 
 type lioCollector struct {
-    fs      sysfs.FS
-    metrics *lioMetric
+	fs      sysfs.FS
+	metrics *lioMetric
 }
 
 type lioMetric struct {
-    lio_file_iops   *prometheus.Desc
-    lio_file_read   *prometheus.Desc
-    lio_file_write  *prometheus.Desc
+	lioFileIops  *prometheus.Desc
+	lioFileRead  *prometheus.Desc
+	lioFileWrite *prometheus.Desc
 
-    lio_block_iops  *prometheus.Desc
-    lio_block_read  *prometheus.Desc
-    lio_block_write *prometheus.Desc
+	lioBlockIops  *prometheus.Desc
+	lioBlockRead  *prometheus.Desc
+	lioBlockWrite *prometheus.Desc
 
-    lio_rbd_iops    *prometheus.Desc
-    lio_rbd_read    *prometheus.Desc
-    lio_rbd_write   *prometheus.Desc
+	lioRbdIops  *prometheus.Desc
+	lioRbdRead  *prometheus.Desc
+	lioRbdWrite *prometheus.Desc
 
-    lio_rdmcp_iops  *prometheus.Desc
-    lio_rdmcp_read  *prometheus.Desc
-    lio_rdmcp_write *prometheus.Desc
+	lioRdmcpIops  *prometheus.Desc
+	lioRdmcpRead  *prometheus.Desc
+	lioRdmcpWrite *prometheus.Desc
 }
 
-type graph_label struct {
-    iqn     string
-    tpgt    string
-    lun     string
-    store   string
-    pool    string
-    image   string
+type graphLabel struct {
+	iqn   string
+	tpgt  string
+	lun   string
+	store string
+	pool  string
+	image string
 }
-
 
 func init() {
-    registerCollector("iscsi", defaultEnabled, NewLioCollector)
+	registerCollector("iscsi", defaultEnabled, NewLioCollector)
 }
 
 // NewLioCollector returns a new Collector with iscsi statistics.
 func NewLioCollector() (Collector, error) {
-    fs, err := sysfs.NewFS(*sysPath)
-    if err != nil {
-        return nil, fmt.Errorf("failed to open sysfs: %v", err)
-    }
+	fs, err := sysfs.NewFS(*sysPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open sysfs: %v", err)
+	}
 
-    metrics, _ := NewLioMetric()
-    
-    return &lioCollector{
-        fs: fs,
-        metrics: metrics }, nil
-}   
+	metrics, _ := newLioMetric()
+
+	return &lioCollector{
+		fs:      fs,
+		metrics: metrics}, nil
+}
 
 // Update implement the lioCollector.
 func (c *lioCollector) Update(ch chan<- prometheus.Metric) error {
 
-    stats, err := c.fs.ISCSIStats()
-    log.Debugf("lio: Update lioCollector")
-    if err != nil { 
-        return fmt.Errorf("lio: failed to update iscsi stat : %v", err)
-    }
-    for _, s := range stats {
-        c.updateStat(ch, s)
-    }
-    return nil
+	stats, err := c.fs.ISCSIStats()
+	log.Debugf("lio: Update lioCollector")
+	if err != nil {
+		return fmt.Errorf("lio: failed to update iscsi stat : %v", err)
+	}
+	for _, s := range stats {
+		c.updateStat(ch, s)
+	}
+	return nil
 }
 
-func NewLioMetric() (*lioMetric, error) {
+//newLioMetric create the LIO metric data structure to return for node_exporter
+func newLioMetric() (*lioMetric, error) {
 
-    return &lioMetric{
-        lio_file_iops: prometheus.NewDesc(
-            prometheus.BuildFQName(namespace, lio_fileio_Subsystem, "iops"),
-            "iSCSI FileIO backstore transport operations.",
-            []string{"iqn", "tpgt", "lun", "fileio", "object", "filename"}, nil,
-        ),
-        lio_file_read: prometheus.NewDesc(
-            prometheus.BuildFQName(namespace, lio_fileio_Subsystem, "read"),
-            "iSCSI FileIO backstore Read in byte.",
-            []string{"iqn", "tpgt", "lun", "fileio", "object", "filename"}, nil,
-        ),
-        lio_file_write: prometheus.NewDesc(
-            prometheus.BuildFQName(namespace, lio_fileio_Subsystem, "write"),
-            "iSCSI FileIO backstore Write in byte.",
-            []string{"iqn", "tpgt", "lun", "fileio", "object", "filename"}, nil,
-        ),
+	return &lioMetric{
+		lioFileIops: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, lioFileioSubsystem, "iops"),
+			"iSCSI FileIO backstore transport operations.",
+			[]string{"iqn", "tpgt", "lun", "fileio", "object", "filename"}, nil,
+		),
+		lioFileRead: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, lioFileioSubsystem, "read"),
+			"iSCSI FileIO backstore Read in byte.",
+			[]string{"iqn", "tpgt", "lun", "fileio", "object", "filename"}, nil,
+		),
+		lioFileWrite: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, lioFileioSubsystem, "write"),
+			"iSCSI FileIO backstore Write in byte.",
+			[]string{"iqn", "tpgt", "lun", "fileio", "object", "filename"}, nil,
+		),
 
-        lio_block_iops: prometheus.NewDesc(
-            prometheus.BuildFQName(namespace, lio_iblock_Subsystem, "iops"),
-            "iSCSI IBlock backstore transport operations.",
-            []string{"iqn", "tpgt", "lun", "iblock", "object", "blockname"}, nil,
-        ),
-        lio_block_read: prometheus.NewDesc(
-            prometheus.BuildFQName(namespace, lio_iblock_Subsystem, "read"),
-            "iSCSI IBlock backstore Read in byte.",
-            []string{"iqn", "tpgt", "lun", "iblock", "object", "blockname"}, nil,
-        ),
-        lio_block_write: prometheus.NewDesc(
-            prometheus.BuildFQName(namespace, lio_iblock_Subsystem, "write"),
-            "iSCSI IBlock backstore Write in byte.",
-            []string{"iqn", "tpgt", "lun", "iblock", "object", "blockname"}, nil,
-        ),
+		lioBlockIops: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, lioIblockSubsystem, "iops"),
+			"iSCSI IBlock backstore transport operations.",
+			[]string{"iqn", "tpgt", "lun", "iblock", "object", "blockname"}, nil,
+		),
+		lioBlockRead: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, lioIblockSubsystem, "read"),
+			"iSCSI IBlock backstore Read in byte.",
+			[]string{"iqn", "tpgt", "lun", "iblock", "object", "blockname"}, nil,
+		),
+		lioBlockWrite: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, lioIblockSubsystem, "write"),
+			"iSCSI IBlock backstore Write in byte.",
+			[]string{"iqn", "tpgt", "lun", "iblock", "object", "blockname"}, nil,
+		),
 
-        lio_rbd_iops: prometheus.NewDesc(
-            prometheus.BuildFQName(namespace, lio_rbd_Subsystem, "iops"),
-            "iSCSI RBD backstore transport operations.",
-            []string{"iqn", "tpgt", "lun", "rbd", "pool", "image"}, nil,
-        ),
-        lio_rbd_read: prometheus.NewDesc(
-            prometheus.BuildFQName(namespace, lio_rbd_Subsystem, "read"),
-            "iSCSI RBD backstore Read in byte.",
-            []string{"iqn", "tpgt", "lun", "rbd", "pool", "image"}, nil,
-        ),
-        lio_rbd_write: prometheus.NewDesc(
-            prometheus.BuildFQName(namespace, lio_rbd_Subsystem, "write"),
-            "iSCSI RBD backstore Write in byte.",
-            []string{"iqn", "tpgt", "lun", "rbd", "pool", "image"}, nil,
-        ),
+		lioRbdIops: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, lioRbdSubsystem, "iops"),
+			"iSCSI RBD backstore transport operations.",
+			[]string{"iqn", "tpgt", "lun", "rbd", "pool", "image"}, nil,
+		),
+		lioRbdRead: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, lioRbdSubsystem, "read"),
+			"iSCSI RBD backstore Read in byte.",
+			[]string{"iqn", "tpgt", "lun", "rbd", "pool", "image"}, nil,
+		),
+		lioRbdWrite: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, lioRbdSubsystem, "write"),
+			"iSCSI RBD backstore Write in byte.",
+			[]string{"iqn", "tpgt", "lun", "rbd", "pool", "image"}, nil,
+		),
 
-        lio_rdmcp_iops: prometheus.NewDesc(
-            prometheus.BuildFQName(namespace, lio_rdmcp_Subsystem, "iops"),
-            "iSCSI Memory Copy RAMDisk backstore transport operations.",
-            []string{"iqn", "tpgt", "lun", "rd_mcp", "object"}, nil,
-        ),
-        lio_rdmcp_read: prometheus.NewDesc(
-            prometheus.BuildFQName(namespace, lio_rdmcp_Subsystem, "read"),
-            "iSCSI Memory Copy RAMDisk backstore Read in byte.",
-            []string{"iqn", "tpgt", "lun", "rd_mcp", "object" }, nil,
-        ),
-        lio_rdmcp_write: prometheus.NewDesc(
-            prometheus.BuildFQName(namespace, lio_rdmcp_Subsystem, "write"),
-            "iSCSI Memory Copy RAMDisk backstore Write in byte.",
-            []string{"iqn", "tpgt", "lun", "rd_mcp", "object" }, nil,
-        ),
-    }, nil
+		lioRdmcpIops: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, lioRdmcpSubsystem, "iops"),
+			"iSCSI Memory Copy RAMDisk backstore transport operations.",
+			[]string{"iqn", "tpgt", "lun", "rdmcp", "object"}, nil,
+		),
+		lioRdmcpRead: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, lioRdmcpSubsystem, "read"),
+			"iSCSI Memory Copy RAMDisk backstore Read in byte.",
+			[]string{"iqn", "tpgt", "lun", "rdmcp", "object"}, nil,
+		),
+		lioRdmcpWrite: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, lioRdmcpSubsystem, "write"),
+			"iSCSI Memory Copy RAMDisk backstore Write in byte.",
+			[]string{"iqn", "tpgt", "lun", "rdmcp", "object"}, nil,
+		),
+	}, nil
 }
 
 // /sys/kernel/config/target/iscsi/iqn*/tpgt_*/lun/lun_*/ which link
-// back to the following 
-// /sys/kernel/config/target/core/{backstore_type}_{number}/{object_name}/
+// back to the following
+// /sys/kernel/config/target/core/{backstoreType}_{number}/{objectName}/
 
 func (c *lioCollector) updateStat(ch chan<- prometheus.Metric, s *iscsi.Stats) error {
 
-    log.Debugf("lio updateStat iscsi %s path", s.Name)
-    tpgt_s := s.Tpgt
-    for _, tpgt := range tpgt_s {
-        tpgt_path := tpgt.TpgtPath
-        iscsi_enable := tpgt.IsEnable
+	log.Debugf("lio updateStat iscsi %s path", s.Name)
+	tpgtS := s.Tpgt
+	for _, tpgt := range tpgtS {
+		tpgtPath := tpgt.TpgtPath
+		iscsiEnable := tpgt.IsEnable
 
-        log.Debugf("lio: iscsi %s isEnable=%t", tpgt_path, iscsi_enable)
-        // let's not putting more line into the graph with multiple
-        // disable lun, it may create problem for bigger cluster
-        if (iscsi_enable) {
+		log.Debugf("lio: iscsi %s isEnable=%t", tpgtPath, iscsiEnable)
+		// let's not putting more line into the graph with multiple
+		// disable lun, it may create problem for bigger cluster
+		if iscsiEnable {
 
-            lun_s := tpgt.Luns
-            for _, lun := range lun_s {
-                backstore_type  := lun.Backstore
-                object_name     := lun.ObjectName
-                type_number     := lun.TypeNumber
+			lunS := tpgt.Luns
+			for _, lun := range lunS {
+				backstoreType := lun.Backstore
+				objectName := lun.ObjectName
+				typeNumber := lun.TypeNumber
 
-                // struct type graph_label { iqn, tpgt, lun, store, pool,  image}
-                // label := graph_label {iqn, tpgt, lun, backstore_type, object_name, type_number}
-                label := graph_label { s.Name, tpgt.Name, lun.Name, backstore_type, object_name, type_number}
+				// struct type graphLabel { iqn, tpgt, lun, store, pool,  image}
+				// label := graphLabel {iqn, tpgt, lun, backstoreType, objectName, typeNumber}
+				label := graphLabel{s.Name, tpgt.Name, lun.Name, backstoreType, objectName, typeNumber}
 
-                log.Debugf("lio: iqn=%s, tpgt=%s, lun=%s, type=%s, object=%s, type_number=%s", 
-                s.Name, tpgt.Name, lun.Name, backstore_type, object_name, type_number) 
+				log.Debugf("lio: iqn=%s, tpgt=%s, lun=%s, type=%s, object=%s, typeNumber=%s",
+					s.Name, tpgt.Name, lun.Name, backstoreType, objectName, typeNumber)
 
-                switch { 
-                    case strings.Compare(backstore_type, "fileio") == 0:
-                        if err := c.updateFileIOStat(ch, label); err != nil {
-                            return fmt.Errorf("failed fileio stat : %v", err)
-                        }
-                        break;
-                    case strings.Compare(backstore_type, "iblock") == 0:
-                        if err := c.updateIBlockStat(ch, label); err != nil {
-                            return fmt.Errorf("failed iblock stat : %v", err)
-                        }
-                        break;
-                    case strings.Compare(backstore_type, "rbd") == 0:
-                        if err := c.updateRBDStat(ch, label); err != nil {
-                            return fmt.Errorf("failed rbd stat : %v", err)
-                        }
-                        break;
-                    case strings.Compare(backstore_type, "rd_mcp") == 0:
-                        if err := c.updateRDMCPStat(ch, label); err != nil {
-                            return fmt.Errorf("failed rdmcp stat : %v", err)
-                        }
-                        break;
-                    default:
-                        continue
-                }
-            }
-        }
-    }
-    return nil
+				switch {
+				case strings.Compare(backstoreType, "fileio") == 0:
+					if err := c.updateFileIOStat(ch, label); err != nil {
+						return fmt.Errorf("failed fileio stat : %v", err)
+					}
+					break
+				case strings.Compare(backstoreType, "iblock") == 0:
+					if err := c.updateIBlockStat(ch, label); err != nil {
+						return fmt.Errorf("failed iblock stat : %v", err)
+					}
+					break
+				case strings.Compare(backstoreType, "rbd") == 0:
+					if err := c.updateRBDStat(ch, label); err != nil {
+						return fmt.Errorf("failed rbd stat : %v", err)
+					}
+					break
+				case strings.Compare(backstoreType, "rdmcp") == 0:
+					if err := c.updateRDMCPStat(ch, label); err != nil {
+						return fmt.Errorf("failed rdmcp stat : %v", err)
+					}
+					break
+				default:
+					continue
+				}
+			}
+		}
+	}
+	return nil
 }
 
-// /sys/kernel/config/target/core/fileio_{type_number}/{object}/
-// udev_path has the file name 
-func (c *lioCollector) updateFileIOStat(ch chan<- prometheus.Metric, label graph_label) error {
+// /sys/kernel/config/target/core/fileio_{typeNumber}/{object}/
+// udev_path has the file name
+func (c *lioCollector) updateFileIOStat(ch chan<- prometheus.Metric, label graphLabel) error {
 
-    fileio := new(iscsi.FILEIO)
-    fileio, err := fileio.GetFileioUdev(label.image, label.pool)
-    if err != nil {
-        return err
-    } 
+	fileio := new(iscsi.FILEIO)
+	fileio, err := fileio.GetFileioUdev(label.image, label.pool)
+	if err != nil {
+		return err
+	}
 
-    read_mb, write_mb, iops, err:= iscsi.ReadWriteOPS(label.iqn, label.tpgt, label.lun)
-    if err != nil {
-        return err
-    }
-    log.Debugf("lio: Fileio Read int %d", read_mb) 
-    f_read_mb  := float64(read_mb<<20) 
-    log.Debugf("lio: Fileio Read float %f", f_read_mb) 
+	readMB, writeMB, iops, err := iscsi.ReadWriteOPS(label.iqn, label.tpgt, label.lun)
+	if err != nil {
+		return err
+	}
+	log.Debugf("lio: Fileio Read int %d", readMB)
+	fReadMB := float64(readMB << 20)
+	log.Debugf("lio: Fileio Read float %f", fReadMB)
 
-    log.Debugf("lio: Fileio Write int %d", write_mb) 
-    f_write_mb := float64(write_mb<<20)
-    log.Debugf("lio: Fileio Write int %f", f_write_mb) 
+	log.Debugf("lio: Fileio Write int %d", writeMB)
+	fWriteMB := float64(writeMB << 20)
+	log.Debugf("lio: Fileio Write int %f", fWriteMB)
 
-    log.Debugf("lio: Fileio OPS int %d", iops) 
-    f_iops := float64(iops)
-    log.Debugf("lio: Fileio OPS float %f", f_iops) 
+	log.Debugf("lio: Fileio OPS int %d", iops)
+	fIops := float64(iops)
+	log.Debugf("lio: Fileio OPS float %f", fIops)
 
-    ch <- prometheus.MustNewConstMetric(c.metrics.lio_file_read,
-    prometheus.CounterValue, f_read_mb, label.iqn, label.tpgt, label.lun, 
-    fileio.Name, fileio.ObjectName, fileio.Filename)
+	ch <- prometheus.MustNewConstMetric(c.metrics.lioFileRead,
+		prometheus.CounterValue, fReadMB, label.iqn, label.tpgt, label.lun,
+		fileio.Name, fileio.ObjectName, fileio.Filename)
 
-    ch <- prometheus.MustNewConstMetric(c.metrics.lio_file_write,
-    prometheus.CounterValue, f_write_mb, label.iqn, label.tpgt, label.lun,
-    fileio.Name, fileio.ObjectName, fileio.Filename)
+	ch <- prometheus.MustNewConstMetric(c.metrics.lioFileWrite,
+		prometheus.CounterValue, fWriteMB, label.iqn, label.tpgt, label.lun,
+		fileio.Name, fileio.ObjectName, fileio.Filename)
 
-    ch <- prometheus.MustNewConstMetric(c.metrics.lio_file_iops,
-    prometheus.CounterValue, f_iops, label.iqn, label.tpgt, label.lun,
-    fileio.Name, fileio.ObjectName, fileio.Filename)
+	ch <- prometheus.MustNewConstMetric(c.metrics.lioFileIops,
+		prometheus.CounterValue, fIops, label.iqn, label.tpgt, label.lun,
+		fileio.Name, fileio.ObjectName, fileio.Filename)
 
-    return nil
+	return nil
 }
 
-// /sys/kernel/config/target/core/iblock_{type_number}/{object}/
-// udev_path has the file name 
-func (c *lioCollector) updateIBlockStat(ch chan<- prometheus.Metric, label graph_label) error {
+// /sys/kernel/config/target/core/iblock_{typeNumber}/{object}/
+// udev_path has the file name
+func (c *lioCollector) updateIBlockStat(ch chan<- prometheus.Metric, label graphLabel) error {
 
-    iblock := new(iscsi.IBLOCK)
-    iblock, err := iblock.GetIblockUdev(label.image, label.pool)
-    if err != nil {
-        return err
-    }
-    read_mb, write_mb, iops, err:= iscsi.ReadWriteOPS(label.iqn, label.tpgt, label.lun)
-    if err != nil {
-        return err
-    }
-    log.Debugf("lio: IBlock Read int %d", read_mb) 
-    f_read_mb  := float64(read_mb<<20) 
-    log.Debugf("lio: IBlock Read float %f", f_read_mb) 
+	iblock := new(iscsi.IBLOCK)
+	iblock, err := iblock.GetIblockUdev(label.image, label.pool)
+	if err != nil {
+		return err
+	}
+	readMB, writeMB, iops, err := iscsi.ReadWriteOPS(label.iqn, label.tpgt, label.lun)
+	if err != nil {
+		return err
+	}
+	log.Debugf("lio: IBlock Read int %d", readMB)
+	fReadMB := float64(readMB << 20)
+	log.Debugf("lio: IBlock Read float %f", fReadMB)
 
-    log.Debugf("lio: IBlock Write int %d", write_mb) 
-    f_write_mb := float64(write_mb<<20)
-    log.Debugf("lio: IBlock Write int %f", f_write_mb) 
+	log.Debugf("lio: IBlock Write int %d", writeMB)
+	fWriteMB := float64(writeMB << 20)
+	log.Debugf("lio: IBlock Write int %f", fWriteMB)
 
-    log.Debugf("lio: IBlock OPS int %d", iops) 
-    f_iops := float64(iops)
-    log.Debugf("lio: IBlock OPS float %f", f_iops) 
+	log.Debugf("lio: IBlock OPS int %d", iops)
+	fIops := float64(iops)
+	log.Debugf("lio: IBlock OPS float %f", fIops)
 
+	ch <- prometheus.MustNewConstMetric(c.metrics.lioBlockRead,
+		prometheus.CounterValue, fReadMB, label.iqn, label.tpgt, label.lun,
+		iblock.Name, iblock.ObjectName, iblock.Iblock)
 
-    ch <- prometheus.MustNewConstMetric(c.metrics.lio_block_read,
-    prometheus.CounterValue, f_read_mb, label.iqn, label.tpgt, label.lun, 
-    iblock.Name, iblock.ObjectName, iblock.Iblock)
+	ch <- prometheus.MustNewConstMetric(c.metrics.lioBlockWrite,
+		prometheus.CounterValue, fWriteMB, label.iqn, label.tpgt, label.lun,
+		iblock.Name, iblock.ObjectName, iblock.Iblock)
 
-    ch <- prometheus.MustNewConstMetric(c.metrics.lio_block_write,
-    prometheus.CounterValue, f_write_mb, label.iqn, label.tpgt, label.lun,
-    iblock.Name, iblock.ObjectName, iblock.Iblock)
+	ch <- prometheus.MustNewConstMetric(c.metrics.lioBlockIops,
+		prometheus.CounterValue, fIops, label.iqn, label.tpgt, label.lun,
+		iblock.Name, iblock.ObjectName, iblock.Iblock)
 
-    ch <- prometheus.MustNewConstMetric(c.metrics.lio_block_iops,
-    prometheus.CounterValue, f_iops, label.iqn, label.tpgt, label.lun,
-    iblock.Name, iblock.ObjectName, iblock.Iblock)
-
-    return nil
+	return nil
 }
 
 // First using the rbd device label to create all the state place holder,
@@ -316,91 +315,90 @@ func (c *lioCollector) updateIBlockStat(ch chan<- prometheus.Metric, label graph
 // /sys/devices/rbd/{} [0-9]* as rbd{X}
 // pool  = '/sys/devices/rbd/{X}/pool'
 // image = '/sys/devices/rbd/{X}/name'
-// 
+//
 // Then we loop though the iscsi target and match the link with the above
-// rbd info /sys/kernel/config/target/iscsi/iqn*/tpgt_*/lun/lun_*/{symblink} 
-// 
-// The link location look something like as following 
+// rbd info /sys/kernel/config/target/iscsi/iqn*/tpgt_*/lun/lun_*/{symblink}
+//
+// The link location look something like as following
 // /sys/kernel/config/target/core/rbd_{X}/{pool}-{images}/
-// 
-// the rbd_{X} / {pool}-{image} should match the following 
+//
+// the rbd_{X} / {pool}-{image} should match the following
 
-func (c *lioCollector) updateRBDStat(ch chan<- prometheus.Metric, label graph_label) error {
+func (c *lioCollector) updateRBDStat(ch chan<- prometheus.Metric, label graphLabel) error {
 
-    rbd := new(iscsi.RBD)
-    rbd, err := rbd.GetRBDMatch(label.image, label.pool)
-    if err != nil {
-        return err
-    }
-    if rbd != nil { 
-        read_mb, write_mb, iops, err:= iscsi.ReadWriteOPS(label.iqn, label.tpgt, label.lun)
-        if err != nil {
-            return err
-        }
-        log.Debugf("lio: RBD Read int %d", read_mb) 
-        f_read_mb  := float64(read_mb<<20) 
-        log.Debugf("lio: RBD Read float %f", f_read_mb) 
+	rbd := new(iscsi.RBD)
+	rbd, err := rbd.GetRBDMatch(label.image, label.pool)
+	if err != nil {
+		return err
+	}
+	if rbd != nil {
+		readMB, writeMB, iops, err := iscsi.ReadWriteOPS(label.iqn, label.tpgt, label.lun)
+		if err != nil {
+			return err
+		}
+		log.Debugf("lio: RBD Read int %d", readMB)
+		fReadMB := float64(readMB << 20)
+		log.Debugf("lio: RBD Read float %f", fReadMB)
 
-        log.Debugf("lio: RBD Write int %d", write_mb) 
-        f_write_mb := float64(write_mb<<20)
-        log.Debugf("lio: RBD Write int %f", f_write_mb) 
+		log.Debugf("lio: RBD Write int %d", writeMB)
+		fWriteMB := float64(writeMB << 20)
+		log.Debugf("lio: RBD Write int %f", fWriteMB)
 
-        log.Debugf("lio: RBD OPS int %d", iops) 
-        f_iops := float64(iops)
-        log.Debugf("lio: RBD OPS float %f", f_iops) 
+		log.Debugf("lio: RBD OPS int %d", iops)
+		fIops := float64(iops)
+		log.Debugf("lio: RBD OPS float %f", fIops)
 
-        ch <- prometheus.MustNewConstMetric(c.metrics.lio_rbd_read,
-        prometheus.CounterValue, f_read_mb, label.iqn, label.tpgt, label.lun,
-        rbd.Name, rbd.Pool, rbd.Image)
+		ch <- prometheus.MustNewConstMetric(c.metrics.lioRbdRead,
+			prometheus.CounterValue, fReadMB, label.iqn, label.tpgt, label.lun,
+			rbd.Name, rbd.Pool, rbd.Image)
 
-        ch <- prometheus.MustNewConstMetric(c.metrics.lio_rbd_write,
-        prometheus.CounterValue, f_write_mb, label.iqn, label.tpgt, label.lun,
-        rbd.Name, rbd.Pool, rbd.Image)
+		ch <- prometheus.MustNewConstMetric(c.metrics.lioRbdWrite,
+			prometheus.CounterValue, fWriteMB, label.iqn, label.tpgt, label.lun,
+			rbd.Name, rbd.Pool, rbd.Image)
 
-        ch <- prometheus.MustNewConstMetric(c.metrics.lio_rbd_iops,
-        prometheus.CounterValue, f_iops, label.iqn, label.tpgt, label.lun,
-        rbd.Name, rbd.Pool, rbd.Image)
-    }
-    return nil
+		ch <- prometheus.MustNewConstMetric(c.metrics.lioRbdIops,
+			prometheus.CounterValue, fIops, label.iqn, label.tpgt, label.lun,
+			rbd.Name, rbd.Pool, rbd.Image)
+	}
+	return nil
 }
 
-// /sys/kernel/config/target/core/rd_mcp_{type_number}/{object}/
-// there won't be udev_path for ramdisk so not image name either 
-func (c *lioCollector) updateRDMCPStat(ch chan<- prometheus.Metric, label graph_label) error {
-    rd_mcp := new(iscsi.RDMCP)
-    rd_mcp, err := rd_mcp.GetRDMCPPath(label.image, label.pool)
-    if err != nil {
-        return err
-    }
-    if rd_mcp != nil { 
-        read_mb, write_mb, iops, err:= iscsi.ReadWriteOPS(label.iqn, label.tpgt, label.lun)
-        if err != nil {
-            return err
-        }
-        log.Debugf("lio: RDMCP Read int %d", read_mb) 
-        f_read_mb  := float64(read_mb<<20) 
-        log.Debugf("lio: RDMCP Read float %f", f_read_mb) 
+// /sys/kernel/config/target/core/rdmcp_{typeNumber}/{object}/
+// there won't be udev_path for ramdisk so not image name either
+func (c *lioCollector) updateRDMCPStat(ch chan<- prometheus.Metric, label graphLabel) error {
+	rdmcp := new(iscsi.RDMCP)
+	rdmcp, err := rdmcp.GetRDMCPPath(label.image, label.pool)
+	if err != nil {
+		return err
+	}
+	if rdmcp != nil {
+		readMB, writeMB, iops, err := iscsi.ReadWriteOPS(label.iqn, label.tpgt, label.lun)
+		if err != nil {
+			return err
+		}
+		log.Debugf("lio: RDMCP Read int %d", readMB)
+		fReadMB := float64(readMB << 20)
+		log.Debugf("lio: RDMCP Read float %f", fReadMB)
 
-        log.Debugf("lio: RDMCP Write int %d", write_mb) 
-        f_write_mb := float64(write_mb<<20)
-        log.Debugf("lio: RDMCP Write int %f", f_write_mb) 
+		log.Debugf("lio: RDMCP Write int %d", writeMB)
+		fWriteMB := float64(writeMB << 20)
+		log.Debugf("lio: RDMCP Write int %f", fWriteMB)
 
-        log.Debugf("lio: RDMCP OPS int %d", iops) 
-        f_iops := float64(iops)
-        log.Debugf("lio: RDMCP OPS float %f", f_iops) 
+		log.Debugf("lio: RDMCP OPS int %d", iops)
+		fIops := float64(iops)
+		log.Debugf("lio: RDMCP OPS float %f", fIops)
 
-        ch <- prometheus.MustNewConstMetric(c.metrics.lio_rdmcp_read,
-        prometheus.CounterValue, f_read_mb, label.iqn, label.tpgt, label.lun,
-        rd_mcp.Name, rd_mcp.ObjectName)
+		ch <- prometheus.MustNewConstMetric(c.metrics.lioRdmcpRead,
+			prometheus.CounterValue, fReadMB, label.iqn, label.tpgt, label.lun,
+			rdmcp.Name, rdmcp.ObjectName)
 
-        ch <- prometheus.MustNewConstMetric(c.metrics.lio_rdmcp_write,
-        prometheus.CounterValue, f_write_mb, label.iqn, label.tpgt, label.lun,
-        rd_mcp.Name, rd_mcp.ObjectName)
+		ch <- prometheus.MustNewConstMetric(c.metrics.lioRdmcpWrite,
+			prometheus.CounterValue, fWriteMB, label.iqn, label.tpgt, label.lun,
+			rdmcp.Name, rdmcp.ObjectName)
 
-        ch <- prometheus.MustNewConstMetric(c.metrics.lio_rdmcp_iops,
-        prometheus.CounterValue, f_iops, label.iqn, label.tpgt, label.lun,
-        rd_mcp.Name, rd_mcp.ObjectName)
-    }
-    return nil
+		ch <- prometheus.MustNewConstMetric(c.metrics.lioRdmcpIops,
+			prometheus.CounterValue, fIops, label.iqn, label.tpgt, label.lun,
+			rdmcp.Name, rdmcp.ObjectName)
+	}
+	return nil
 }
-

--- a/collector/lio.go
+++ b/collector/lio.go
@@ -178,8 +178,8 @@ func (c *lioCollector) updateStat(ch chan<- prometheus.Metric, s *iscsi.Stats) e
     log.Debugf("lio updateStat iscsi %s path", s.Name)
     tpgt_s := s.Tpgt
     for _, tpgt := range tpgt_s {
-        tpgt_path := tpgt.Tpgt_path
-        iscsi_enable := tpgt.Is_enable
+        tpgt_path := tpgt.TpgtPath
+        iscsi_enable := tpgt.IsEnable
 
         log.Debugf("lio: iscsi %s isEnable=%t", tpgt_path, iscsi_enable)
         // let's not putting more line into the graph with multiple
@@ -189,8 +189,8 @@ func (c *lioCollector) updateStat(ch chan<- prometheus.Metric, s *iscsi.Stats) e
             lun_s := tpgt.Luns
             for _, lun := range lun_s {
                 backstore_type  := lun.Backstore
-                object_name     := lun.Object_name
-                type_number     := lun.Type_number
+                object_name     := lun.ObjectName
+                type_number     := lun.TypeNumber
 
                 // struct type graph_label { iqn, tpgt, lun, store, pool,  image}
                 // label := graph_label {iqn, tpgt, lun, backstore_type, object_name, type_number}
@@ -257,15 +257,15 @@ func (c *lioCollector) updateFileIOStat(ch chan<- prometheus.Metric, label graph
 
     ch <- prometheus.MustNewConstMetric(c.metrics.lio_file_read,
     prometheus.CounterValue, f_read_mb, label.iqn, label.tpgt, label.lun, 
-    fileio.Name, fileio.Object_name, fileio.Filename)
+    fileio.Name, fileio.ObjectName, fileio.Filename)
 
     ch <- prometheus.MustNewConstMetric(c.metrics.lio_file_write,
     prometheus.CounterValue, f_write_mb, label.iqn, label.tpgt, label.lun,
-    fileio.Name, fileio.Object_name, fileio.Filename)
+    fileio.Name, fileio.ObjectName, fileio.Filename)
 
     ch <- prometheus.MustNewConstMetric(c.metrics.lio_file_iops,
     prometheus.CounterValue, f_iops, label.iqn, label.tpgt, label.lun,
-    fileio.Name, fileio.Object_name, fileio.Filename)
+    fileio.Name, fileio.ObjectName, fileio.Filename)
 
     return nil
 }
@@ -298,15 +298,15 @@ func (c *lioCollector) updateIBlockStat(ch chan<- prometheus.Metric, label graph
 
     ch <- prometheus.MustNewConstMetric(c.metrics.lio_block_read,
     prometheus.CounterValue, f_read_mb, label.iqn, label.tpgt, label.lun, 
-    iblock.Name, iblock.Object_name, iblock.Iblock)
+    iblock.Name, iblock.ObjectName, iblock.Iblock)
 
     ch <- prometheus.MustNewConstMetric(c.metrics.lio_block_write,
     prometheus.CounterValue, f_write_mb, label.iqn, label.tpgt, label.lun,
-    iblock.Name, iblock.Object_name, iblock.Iblock)
+    iblock.Name, iblock.ObjectName, iblock.Iblock)
 
     ch <- prometheus.MustNewConstMetric(c.metrics.lio_block_iops,
     prometheus.CounterValue, f_iops, label.iqn, label.tpgt, label.lun,
-    iblock.Name, iblock.Object_name, iblock.Iblock)
+    iblock.Name, iblock.ObjectName, iblock.Iblock)
 
     return nil
 }
@@ -377,29 +377,29 @@ func (c *lioCollector) updateRDMCPStat(ch chan<- prometheus.Metric, label graph_
         if err != nil {
             return err
         }
-        log.Debugf("lio: RBD Read int %d", read_mb) 
+        log.Debugf("lio: RDMCP Read int %d", read_mb) 
         f_read_mb  := float64(read_mb<<20) 
-        log.Debugf("lio: RBD Read float %f", f_read_mb) 
+        log.Debugf("lio: RDMCP Read float %f", f_read_mb) 
 
-        log.Debugf("lio: RBD Write int %d", write_mb) 
+        log.Debugf("lio: RDMCP Write int %d", write_mb) 
         f_write_mb := float64(write_mb<<20)
-        log.Debugf("lio: RBD Write int %f", f_write_mb) 
+        log.Debugf("lio: RDMCP Write int %f", f_write_mb) 
 
-        log.Debugf("lio: RBD OPS int %d", iops) 
+        log.Debugf("lio: RDMCP OPS int %d", iops) 
         f_iops := float64(iops)
-        log.Debugf("lio: RBD OPS float %f", f_iops) 
+        log.Debugf("lio: RDMCP OPS float %f", f_iops) 
 
         ch <- prometheus.MustNewConstMetric(c.metrics.lio_rdmcp_read,
         prometheus.CounterValue, f_read_mb, label.iqn, label.tpgt, label.lun,
-        rd_mcp.Name, rd_mcp.Object_name)
+        rd_mcp.Name, rd_mcp.ObjectName)
 
         ch <- prometheus.MustNewConstMetric(c.metrics.lio_rdmcp_write,
         prometheus.CounterValue, f_write_mb, label.iqn, label.tpgt, label.lun,
-        rd_mcp.Name, rd_mcp.Object_name)
+        rd_mcp.Name, rd_mcp.ObjectName)
 
         ch <- prometheus.MustNewConstMetric(c.metrics.lio_rdmcp_iops,
         prometheus.CounterValue, f_iops, label.iqn, label.tpgt, label.lun,
-        rd_mcp.Name, rd_mcp.Object_name)
+        rd_mcp.Name, rd_mcp.ObjectName)
     }
     return nil
 }

--- a/collector/lio.go
+++ b/collector/lio.go
@@ -1,0 +1,582 @@
+// Copyright 2017 Alex Lau (AvengerMoJo) <alau@suse.com>
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+    "errors"
+    "fmt"
+    "io/ioutil"
+    "os"
+    "path/filepath"
+    "strings"
+    "strconv"
+
+    "github.com/prometheus/client_golang/prometheus"
+    "github.com/prometheus/common/log"
+)
+
+const (
+    lio_fileio_Subsystem = "lio_fileio"
+    lio_iblock_Subsystem = "lio_iblock"
+    lio_rbd_Subsystem    = "lio_rbd"
+    lio_rdmcp_Subsystem  = "lio_rd_mcp"
+)
+
+// An lioCollector is a Collector which gathers iscsi RBD
+// iops (iscsi commands) , Read in byte and Write in byte. 
+// ( original reading sysfs is in MB )
+
+type lioCollector struct {
+    lio_file_iops   *prometheus.Desc
+    lio_file_read   *prometheus.Desc
+    lio_file_write  *prometheus.Desc
+
+    lio_block_iops  *prometheus.Desc
+    lio_block_read  *prometheus.Desc
+    lio_block_write *prometheus.Desc
+
+    lio_rbd_iops    *prometheus.Desc
+    lio_rbd_read    *prometheus.Desc
+    lio_rbd_write   *prometheus.Desc
+
+    lio_rdmcp_iops  *prometheus.Desc
+    lio_rdmcp_read  *prometheus.Desc
+    lio_rdmcp_write *prometheus.Desc
+}
+
+type graph_label struct {
+    iqn     string
+    tpgt    string
+    lun     string
+    active  string
+    store   string
+    pool    string
+    image   string
+}
+
+func init() {
+    registerCollector("iscsi", defaultEnabled, NewLioCollector)
+}
+
+// NewLioCollector returns a new Collector with iscsi statistics.
+func NewLioCollector() (Collector, error) {
+    return &lioCollector{
+        lio_file_iops: prometheus.NewDesc(
+            prometheus.BuildFQName(namespace, lio_fileio_Subsystem, "iops"),
+            "iSCSI FileIO backstore transport operations.",
+            []string{"iqn", "tpgt", "lun", "active", "fileio", "object", "filename"}, nil,
+        ),
+        lio_file_read: prometheus.NewDesc(
+            prometheus.BuildFQName(namespace, lio_fileio_Subsystem, "read"),
+            "iSCSI FileIO backstore Read in byte.",
+            []string{"iqn", "tpgt", "lun", "active", "fileio", "object", "filename"}, nil,
+        ),
+        lio_file_write: prometheus.NewDesc(
+            prometheus.BuildFQName(namespace, lio_fileio_Subsystem, "write"),
+            "iSCSI FileIO backstore Write in byte.",
+            []string{"iqn", "tpgt", "lun", "active", "fileio", "object", "filename"}, nil,
+        ),
+
+        lio_block_iops: prometheus.NewDesc(
+            prometheus.BuildFQName(namespace, lio_iblock_Subsystem, "iops"),
+            "iSCSI IBlock backstore transport operations.",
+            []string{"iqn", "tpgt", "lun", "active", "iblock", "object", "blockname"}, nil,
+        ),
+        lio_block_read: prometheus.NewDesc(
+            prometheus.BuildFQName(namespace, lio_iblock_Subsystem, "read"),
+            "iSCSI IBlock backstore Read in byte.",
+            []string{"iqn", "tpgt", "lun", "active", "iblock", "object", "blockname"}, nil,
+        ),
+        lio_block_write: prometheus.NewDesc(
+            prometheus.BuildFQName(namespace, lio_iblock_Subsystem, "write"),
+            "iSCSI IBlock backstore Write in byte.",
+            []string{"iqn", "tpgt", "lun", "active", "iblock", "object", "blockname"}, nil,
+        ),
+
+        lio_rbd_iops: prometheus.NewDesc(
+            prometheus.BuildFQName(namespace, lio_rbd_Subsystem, "iops"),
+            "iSCSI RBD backstore transport operations.",
+            []string{"iqn", "tpgt", "lun", "active", "rbd", "pool", "image"}, nil,
+        ),
+        lio_rbd_read: prometheus.NewDesc(
+            prometheus.BuildFQName(namespace, lio_rbd_Subsystem, "read"),
+            "iSCSI RBD backstore Read in byte.",
+            []string{"iqn", "tpgt", "lun", "active", "rbd", "pool", "image"}, nil,
+        ),
+        lio_rbd_write: prometheus.NewDesc(
+            prometheus.BuildFQName(namespace, lio_rbd_Subsystem, "write"),
+            "iSCSI RBD backstore Write in byte.",
+            []string{"iqn", "tpgt", "lun", "active", "rbd", "pool", "image"}, nil,
+        ),
+
+        lio_rdmcp_iops: prometheus.NewDesc(
+            prometheus.BuildFQName(namespace, lio_rdmcp_Subsystem, "iops"),
+            "iSCSI Memory Copy RAMDisk backstore transport operations.",
+            []string{"iqn", "tpgt", "lun", "active", "rd_mcp", "object", "size"}, nil,
+        ),
+        lio_rdmcp_read: prometheus.NewDesc(
+            prometheus.BuildFQName(namespace, lio_rdmcp_Subsystem, "read"),
+            "iSCSI Memory Copy RAMDisk backstore Read in byte.",
+            []string{"iqn", "tpgt", "lun", "active", "rd_mcp", "object", "size"}, nil,
+        ),
+        lio_rdmcp_write: prometheus.NewDesc(
+            prometheus.BuildFQName(namespace, lio_rdmcp_Subsystem, "write"),
+            "iSCSI Memory Copy RAMDisk backstore Write in byte.",
+            []string{"iqn", "tpgt", "lun", "active", "rd_mcp", "object", "size"}, nil,
+        ),
+    }, nil
+}
+
+// Update implement the lioCollector.
+func (c *lioCollector) Update(ch chan<- prometheus.Metric) error {
+
+    log.Debugf("lioCollector updateStat\n")
+    if err := c.updateStat(ch); err != nil {
+        return fmt.Errorf("failed to update iscsi stat : %v", err)
+    }
+    return nil
+}
+
+// /sys/kernel/config/target/iscsi/iqn*/tpgt_*/lun/lun_*/ which link
+// back to the following 
+// /sys/kernel/config/target/core/{backstore_type}_{number}/{object_name}/
+
+func (c *lioCollector) updateStat(ch chan<- prometheus.Metric) error {
+    iqn_s, _:=  getIQN() 
+
+    for _, iqn_path :=range iqn_s {
+        tpgt_s, _:= getTpgt(iqn_path) 
+
+        for _, tpgt_path:= range tpgt_s { 
+            iscsi_enable := isTpgtEnable(tpgt_path)
+
+            log.Debugf("iscsi %s isEnable=%t\n", tpgt_path, iscsi_enable)
+
+            // let's not putting more line into the graph with multiple
+            // disable lun, it may create problem for bigger cluster
+
+            if (iscsi_enable) {
+                lun_s, _:= getLun(tpgt_path) 
+                for _, lun_path := range lun_s {
+                    backstore_type, object_name, type_number, err := getLunLinkTarget(lun_path)
+
+                    if err != nil {
+                        continue 
+                    }
+                    _, iqn := filepath.Split(iqn_path) 
+                    _, tpgt:= filepath.Split(tpgt_path) 
+                    _, lun := filepath.Split(lun_path) 
+
+                    // struct type graph_label { iqn, tpgt, lun, active, store, pool,  image}
+                    label := graph_label {iqn, tpgt, lun, "enable", backstore_type, object_name, type_number}
+
+                    log.Debugf("iqn=%s, tpgt=%s, lun=%s, type=%s, object=%s, type_number=%s\n", 
+                    iqn, tpgt, lun, backstore_type, object_name, type_number) 
+
+                    switch { 
+                        case strings.Compare(backstore_type, "fileio") == 0:
+                            if err := c.updateFileIOStat(ch, label); err != nil {
+                                return fmt.Errorf("failed fileio stat : %v", err)
+                            }
+                            break;
+                        case strings.Compare(backstore_type, "iblock") == 0:
+                            if err := c.updateIBlockStat(ch, label); err != nil {
+                                return fmt.Errorf("failed iblock stat : %v", err)
+                            }
+                            break;
+                        case strings.Compare(backstore_type, "rbd") == 0:
+                            if err := c.updateRBDStat(ch, label); err != nil {
+                                return fmt.Errorf("failed rbd stat : %v", err)
+                            }
+                            break;
+                        case strings.Compare(backstore_type, "rd_mcp") == 0:
+                            if err := c.updateRDMCPStat(ch, label); err != nil {
+                                return fmt.Errorf("failed rbd stat : %v", err)
+                            }
+                            break;
+                        default:
+                            continue
+                    }
+                }
+            }
+        }
+    }
+    return nil
+}
+
+// /sys/kernel/config/target/core/fileio_{type_number}/{object}/
+// udev_path has the file name 
+func (c *lioCollector) updateFileIOStat(ch chan<- prometheus.Metric, label graph_label) error {
+    fileio_with_number := "fileio_" + label.image
+    udev_path := filepath.Join("/sys/kernel/config/target/core/",
+    fileio_with_number, label.pool, "udev_path")
+
+    if _, err := os.Stat(udev_path); os.IsNotExist(err) {
+        return fmt.Errorf("fileio_%s is missing file name ...!", label.image)
+    } else {
+        file_name, err := ioutil.ReadFile(udev_path)
+        if err != nil {
+            return fmt.Errorf("Cannot read file name from %s!", udev_path)
+        } else { 
+            label.image = strings.TrimSpace(string(file_name))
+            log.Debugf("%s file name is using ->%s<- !",
+            fileio_with_number, label.image)
+
+            //  /sys/kernel/config/target/iscsi/iqn*/tpgt_*/lun/lun_*
+
+            log.Debugf("File %s\n", filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn, label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
+            read_mb, _:=readUintFromFile(
+            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
+            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
+
+            log.Debugf("Read %f\n", read_mb) 
+
+            ch <- prometheus.MustNewConstMetric(c.lio_file_read,
+            prometheus.CounterValue, float64(read_mb<<10),
+            label.iqn, label.tpgt, label.lun, "enable",
+            fileio_with_number, label.pool, label.image)
+
+            write_mb, _:=readUintFromFile( 
+            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
+            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/write_mbytes"))
+
+            log.Debugf("Write %f\n", write_mb) 
+
+            ch <- prometheus.MustNewConstMetric(c.lio_file_write,
+            prometheus.CounterValue, float64(write_mb<<10),
+            label.iqn, label.tpgt, label.lun, "enable",
+            fileio_with_number, label.pool, label.image)
+
+            iops, _:=readUintFromFile( 
+            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
+            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/in_cmds"))
+
+            log.Debugf("iops %f\n", iops) 
+
+            ch <- prometheus.MustNewConstMetric(c.lio_file_iops,
+            prometheus.CounterValue, float64(iops),
+            label.iqn, label.tpgt, label.lun, "enable",
+            fileio_with_number, label.pool, label.image)
+        }
+    }
+    return nil
+}
+
+// /sys/kernel/config/target/core/iblock_{type_number}/{object}/
+// udev_path has the file name 
+func (c *lioCollector) updateIBlockStat(ch chan<- prometheus.Metric, label graph_label) error {
+    iblock_with_number := "iblock_" + label.image
+    udev_path := filepath.Join("/sys/kernel/config/target/core/",
+    iblock_with_number, label.pool, "udev_path")
+
+    if _, err := os.Stat(udev_path); os.IsNotExist(err) {
+        return fmt.Errorf("iblock_%s is missing file name ...!", label.image)
+    } else {
+        block_name, err := ioutil.ReadFile(udev_path)
+        if err != nil {
+            return fmt.Errorf("Cannot read block name from %s!", udev_path)
+        } else { 
+            label.image = strings.TrimSpace(string(block_name))
+            log.Debugf("%s block name is using ->%s<- !",
+            iblock_with_number, label.image)
+
+            //  /sys/kernel/config/target/iscsi/iqn*/tpgt_*/lun/lun_*
+
+            log.Debugf("File %s\n", filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn, label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
+            read_mb, _:=readUintFromFile(
+            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
+            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
+
+            log.Debugf("Read %f\n", read_mb) 
+
+            ch <- prometheus.MustNewConstMetric(c.lio_block_read,
+            prometheus.CounterValue, float64(read_mb<<10),
+            label.iqn, label.tpgt, label.lun, "enable",
+            iblock_with_number, label.pool, label.image)
+
+            write_mb, _:=readUintFromFile( 
+            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
+            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/write_mbytes"))
+
+            log.Debugf("Write %f\n", write_mb) 
+
+            ch <- prometheus.MustNewConstMetric(c.lio_block_write,
+            prometheus.CounterValue, float64(write_mb<<10),
+            label.iqn, label.tpgt, label.lun, "enable",
+            iblock_with_number, label.pool, label.image)
+
+            iops, _:=readUintFromFile( 
+            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
+            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/in_cmds"))
+
+            log.Debugf("iops %f\n", iops) 
+
+            ch <- prometheus.MustNewConstMetric(c.lio_block_iops,
+            prometheus.CounterValue, float64(iops),
+            label.iqn, label.tpgt, label.lun, "enable",
+            iblock_with_number, label.pool, label.image)
+        }
+    }
+    return nil
+}
+
+// First using the rbd device label to create all the state place holder,
+// Base on the following:
+// /sys/devices/rbd/{} [0-9]* as rbd{X}
+// pool  = '/sys/devices/rbd/{X}/pool'
+// image = '/sys/devices/rbd/{X}/name'
+// 
+// Then we loop though the iscsi target and match the link with the above
+// rbd info /sys/kernel/config/target/iscsi/iqn*/tpgt_*/lun/lun_*/{symblink} 
+// 
+// The link location look something like as following 
+// /sys/kernel/config/target/core/rbd_{X}/{pool}-{images}/
+// 
+// the rbd_{X} / {pool}-{image} should match the following 
+
+func (c *lioCollector) updateRBDStat(ch chan<- prometheus.Metric, label graph_label) error {
+
+    rbds, err := filepath.Glob(sysFilePath("devices/rbd/[0-9]*"))
+    if err != nil {
+        return err
+    }
+
+    // looping all rbd{X} with image and pool
+    for rbd_number , rbd_path := range rbds {
+
+        log.Debugf("RBD path %s, device rbd%d", rbd_path, rbd_number)
+        var pool string = ""
+        var image string = ""
+
+        log.Debugf("rbd_%d\n pool --->%s<--- \nimage --->%s<---", rbd_number, pool, image)
+
+        if _, err := os.Stat(filepath.Join(rbd_path, "pool")); os.IsNotExist(err) {
+            fmt.Errorf("rbd%d is missing pool name ...!", rbd_number)
+            continue 
+        } else {
+            p_name , err := ioutil.ReadFile(filepath.Join(rbd_path, "pool"))
+            if err != nil {
+                fmt.Errorf("Cannot read pool name from rbd%d!", rbd_number)
+                continue 
+            } else {
+                log.Debugf("rbd%d pool name is ->%s<- !", rbd_number, p_name)
+                pool = strings.TrimSpace(string(p_name))
+            }
+        }
+        if _, err := os.Stat(filepath.Join(rbd_path, "name")); os.IsNotExist(err) {
+            fmt.Errorf("rbd%d is missing image name ...!", rbd_number)
+            continue 
+        } else {
+            i_name, err := ioutil.ReadFile(filepath.Join(rbd_path, "name"))
+            if err != nil {
+                fmt.Errorf("Cannot read image name from rbd%d!", rbd_number)
+                continue 
+            } else { 
+                log.Debugf("rbd%d image name is ->%s<- !", rbd_number, image)
+                image = strings.TrimSpace(string(i_name))
+            }
+        }
+        log.Debugf("rbd_%d\n pool --->%s<--- \nimage --->%s<---", rbd_number, pool, image)
+
+        // find a match 
+        // reminding label 
+        // []string{"iqn", "tpgt", "lun", "active", "rbd", "pool", "image"}, nil,
+
+        log.Debugf("Matching rbd%d, label->rbd%s", rbd_number, label.image )
+        log.Debugf("Matching pool->%s, image->%s, label->%s", pool, image, label.pool)
+
+        if matchRBD(fmt.Sprintf("%d", rbd_number), label.image) &&
+        matchPoolImage(pool, image, label.pool) {
+            log.Debugf("Match! rbd%d, pool->%s, image->%s", rbd_number, pool, image)
+
+            //  /sys/kernel/config/target/iscsi/iqn*/tpgt_*/lun/lun_*
+
+            log.Debugf("File %s\n", filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn, label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
+            read_mb, _:=readUintFromFile(
+            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
+            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
+
+            log.Debugf("Read %f\n", read_mb) 
+
+            ch <- prometheus.MustNewConstMetric(c.lio_rbd_read,
+            prometheus.CounterValue, float64(read_mb<<10),
+            label.iqn, label.tpgt, label.lun, "enable",
+            "rbd" + label.image , pool, image)
+
+            write_mb, _:=readUintFromFile( 
+            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
+            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/write_mbytes"))
+
+            log.Debugf("Write %f\n", write_mb) 
+
+            ch <- prometheus.MustNewConstMetric(c.lio_rbd_write,
+            prometheus.CounterValue, float64(write_mb<<10),
+            label.iqn, label.tpgt, label.lun, "enable",
+            "rbd" + label.image, pool, image)
+
+            iops, _:=readUintFromFile( 
+            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
+            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/in_cmds"))
+
+            log.Debugf("iops %f\n", iops) 
+
+            ch <- prometheus.MustNewConstMetric(c.lio_rbd_iops,
+            prometheus.CounterValue, float64(iops),
+            label.iqn, label.tpgt, label.lun, "enable",
+            "rbd" + label.image, pool, image)
+        }
+    }
+    return nil
+}
+
+// /sys/kernel/config/target/core/rd_mcp_{type_number}/{object}/
+// there won't be udev_path for ramdisk so not image name either 
+func (c *lioCollector) updateRDMCPStat(ch chan<- prometheus.Metric, label graph_label) error {
+    rd_mcp_with_number := "rd_mcp_" + label.image
+
+    //  /sys/kernel/config/target/iscsi/iqn*/tpgt_*/lun/lun_*
+
+    log.Debugf("File %s\n", filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn, label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
+    read_mb, _:=readUintFromFile(
+    filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
+    label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
+
+    log.Debugf("Read %f\n", read_mb) 
+
+    ch <- prometheus.MustNewConstMetric(c.lio_rdmcp_read,
+    prometheus.CounterValue, float64(read_mb<<10),
+    label.iqn, label.tpgt, label.lun, "enable",
+    rd_mcp_with_number, label.pool, "")
+
+    write_mb, _:=readUintFromFile( 
+    filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
+    label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/write_mbytes"))
+
+    log.Debugf("Write %f\n", write_mb) 
+
+    ch <- prometheus.MustNewConstMetric(c.lio_rdmcp_write,
+    prometheus.CounterValue, float64(write_mb<<10),
+    label.iqn, label.tpgt, label.lun, "enable",
+    rd_mcp_with_number, label.pool, "")
+
+    iops, _:=readUintFromFile( 
+    filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
+    label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/in_cmds"))
+
+    log.Debugf("iops %f\n", iops) 
+
+    ch <- prometheus.MustNewConstMetric(c.lio_rdmcp_iops,
+    prometheus.CounterValue, float64(iops),
+    label.iqn, label.tpgt, label.lun, "enable",
+    rd_mcp_with_number, label.pool, "")
+
+    return nil
+}
+
+func getIQN() (m []string, err error) { 
+    matches, err := filepath.Glob(sysFilePath("kernel/config/target/iscsi/iqn*"))
+    if err != nil {
+        fmt.Errorf("getIQN error %v\n", err)
+        return nil, nil
+    }
+    return matches, nil
+}
+
+func getTpgt(iqn_path string) (m []string, err error) {
+    log.Debugf("getTpgt path %s\n", iqn_path)
+    matches, err := filepath.Glob(filepath.Join(iqn_path, "tpgt*"))
+    if err != nil {
+        fmt.Errorf("getTPGT error %v\n", err )                                                                                                                           
+        return nil, nil
+    } 
+    return matches, nil
+}
+
+func isTpgtEnable(tpgt_path string) (isEnable bool) { 
+    isEnable = false
+    tmp, err := ioutil.ReadFile(filepath.Join(tpgt_path, "enable"))
+    log.Debugf("getTpgt enable %s\n", tmp)
+    if err != nil {
+        fmt.Errorf("isTpgtEnable error %v\n", err )                                                                                                                           
+        return false
+    } 
+    tmp_num, err := strconv.Atoi(strings.TrimSpace(string(tmp)))
+    log.Debugf("getTpgt enable number %d\n", tmp_num)
+    if (tmp_num > 0) {
+        isEnable = true
+    }
+    return isEnable
+}
+
+func getLun(tpgt_path string) (m []string, err error) { 
+    log.Debugf("getLun path %s\n", tpgt_path)
+    matches, err := filepath.Glob(filepath.Join(tpgt_path, "lun/lun*"))
+    if err != nil {
+        fmt.Errorf("getLun error  %v\n", err )
+        return nil, nil
+    } 
+    return matches, nil
+}
+
+func getLunLinkTarget(lun_path string) ( backstore_type string, object_name string, type_number string, err error) { 
+    files, err := ioutil.ReadDir(lun_path)
+    if err != nil { 
+        fmt.Errorf("getLunLinkTarget error  %v\n", err )
+        return "", "", "", nil
+    }
+    for _, file := range files {
+        log.Debugf("lun dir list file ->%s<-\n",file.Name())
+        fileInfo, _:= os.Lstat(lun_path +  "/" + file.Name())
+        if fileInfo.Mode() & os.ModeSymlink != 0 {
+            target, err := os.Readlink( lun_path +  "/" + fileInfo.Name()) 
+            if err != nil {
+                fmt.Errorf("Readlink err %v\n", err)
+                return "", "", "", nil
+            }
+            p1, object_name := filepath.Split(target)
+            _, type_with_number := filepath.Split(filepath.Clean(p1))
+
+            tmp := strings.Split(type_with_number, "_")
+            backstore_type, type_number := tmp[0], tmp[1]
+            if len(tmp) == 3 {
+                backstore_type = fmt.Sprintf("%s_%s", tmp[0], tmp[1])
+                type_number = tmp[2] 
+            }
+            log.Debugf("object_name->%s-<, type->%s, type_number->%s<- \n", object_name, backstore_type, type_number)
+            return backstore_type, object_name, type_number, nil
+        }
+    }
+    return "", "", "", errors.New("getLunLinkTarget: Lun Link does not exist")
+}
+
+func matchRBD(rbd_number string, rbd_name string) (isEqual bool) { 
+    isEqual = false
+    log.Debugf("compare rbd->%s<- with rbd->%s<- \n", rbd_number, rbd_name)
+    if strings.Compare(rbd_name, rbd_number) == 0 { 
+        isEqual = true
+    }
+    return isEqual 
+}
+
+func matchPoolImage(pool string, image string, match_pool_image string) (isEqual bool) { 
+    isEqual = false
+    var pool_image = fmt.Sprintf("%s-%s", pool, image)
+    log.Debugf("compare pool_image->%s<- with pool_image->%s<- \n", pool_image, match_pool_image)
+    if strings.Compare(pool_image, match_pool_image) == 0 { 
+        isEqual = true
+    }
+    return isEqual 
+}
+

--- a/collector/lio.go
+++ b/collector/lio.go
@@ -15,16 +15,13 @@
 package collector
 
 import (
-    "errors"
     "fmt"
-    "io/ioutil"
-    "os"
-    "path/filepath"
     "strings"
-    "strconv"
 
     "github.com/prometheus/client_golang/prometheus"
     "github.com/prometheus/common/log"
+    "github.com/prometheus/procfs/iscsi"
+    "github.com/prometheus/procfs/sysfs"
 )
 
 const (
@@ -39,6 +36,11 @@ const (
 // ( original reading sysfs is in MB )
 
 type lioCollector struct {
+    fs      sysfs.FS
+    metrics *lioMetric
+}
+
+type lioMetric struct {
     lio_file_iops   *prometheus.Desc
     lio_file_read   *prometheus.Desc
     lio_file_write  *prometheus.Desc
@@ -60,11 +62,11 @@ type graph_label struct {
     iqn     string
     tpgt    string
     lun     string
-    active  string
     store   string
     pool    string
     image   string
 }
+
 
 func init() {
     registerCollector("iscsi", defaultEnabled, NewLioCollector)
@@ -72,143 +74,154 @@ func init() {
 
 // NewLioCollector returns a new Collector with iscsi statistics.
 func NewLioCollector() (Collector, error) {
+    fs, err := sysfs.NewFS(*sysPath)
+    if err != nil {
+        return nil, fmt.Errorf("failed to open sysfs: %v", err)
+    }
+
+    metrics, _ := NewLioMetric()
+    
     return &lioCollector{
+        fs: fs,
+        metrics: metrics }, nil
+}   
+
+// Update implement the lioCollector.
+func (c *lioCollector) Update(ch chan<- prometheus.Metric) error {
+
+    stats, err := c.fs.ISCSIStats()
+    log.Debugf("lio: Update lioCollector")
+    if err != nil { 
+        return fmt.Errorf("lio: failed to update iscsi stat : %v", err)
+    }
+    for _, s := range stats {
+        c.updateStat(ch, s)
+    }
+    return nil
+}
+
+func NewLioMetric() (*lioMetric, error) {
+
+    return &lioMetric{
         lio_file_iops: prometheus.NewDesc(
             prometheus.BuildFQName(namespace, lio_fileio_Subsystem, "iops"),
             "iSCSI FileIO backstore transport operations.",
-            []string{"iqn", "tpgt", "lun", "active", "fileio", "object", "filename"}, nil,
+            []string{"iqn", "tpgt", "lun", "fileio", "object", "filename"}, nil,
         ),
         lio_file_read: prometheus.NewDesc(
             prometheus.BuildFQName(namespace, lio_fileio_Subsystem, "read"),
             "iSCSI FileIO backstore Read in byte.",
-            []string{"iqn", "tpgt", "lun", "active", "fileio", "object", "filename"}, nil,
+            []string{"iqn", "tpgt", "lun", "fileio", "object", "filename"}, nil,
         ),
         lio_file_write: prometheus.NewDesc(
             prometheus.BuildFQName(namespace, lio_fileio_Subsystem, "write"),
             "iSCSI FileIO backstore Write in byte.",
-            []string{"iqn", "tpgt", "lun", "active", "fileio", "object", "filename"}, nil,
+            []string{"iqn", "tpgt", "lun", "fileio", "object", "filename"}, nil,
         ),
 
         lio_block_iops: prometheus.NewDesc(
             prometheus.BuildFQName(namespace, lio_iblock_Subsystem, "iops"),
             "iSCSI IBlock backstore transport operations.",
-            []string{"iqn", "tpgt", "lun", "active", "iblock", "object", "blockname"}, nil,
+            []string{"iqn", "tpgt", "lun", "iblock", "object", "blockname"}, nil,
         ),
         lio_block_read: prometheus.NewDesc(
             prometheus.BuildFQName(namespace, lio_iblock_Subsystem, "read"),
             "iSCSI IBlock backstore Read in byte.",
-            []string{"iqn", "tpgt", "lun", "active", "iblock", "object", "blockname"}, nil,
+            []string{"iqn", "tpgt", "lun", "iblock", "object", "blockname"}, nil,
         ),
         lio_block_write: prometheus.NewDesc(
             prometheus.BuildFQName(namespace, lio_iblock_Subsystem, "write"),
             "iSCSI IBlock backstore Write in byte.",
-            []string{"iqn", "tpgt", "lun", "active", "iblock", "object", "blockname"}, nil,
+            []string{"iqn", "tpgt", "lun", "iblock", "object", "blockname"}, nil,
         ),
 
         lio_rbd_iops: prometheus.NewDesc(
             prometheus.BuildFQName(namespace, lio_rbd_Subsystem, "iops"),
             "iSCSI RBD backstore transport operations.",
-            []string{"iqn", "tpgt", "lun", "active", "rbd", "pool", "image"}, nil,
+            []string{"iqn", "tpgt", "lun", "rbd", "pool", "image"}, nil,
         ),
         lio_rbd_read: prometheus.NewDesc(
             prometheus.BuildFQName(namespace, lio_rbd_Subsystem, "read"),
             "iSCSI RBD backstore Read in byte.",
-            []string{"iqn", "tpgt", "lun", "active", "rbd", "pool", "image"}, nil,
+            []string{"iqn", "tpgt", "lun", "rbd", "pool", "image"}, nil,
         ),
         lio_rbd_write: prometheus.NewDesc(
             prometheus.BuildFQName(namespace, lio_rbd_Subsystem, "write"),
             "iSCSI RBD backstore Write in byte.",
-            []string{"iqn", "tpgt", "lun", "active", "rbd", "pool", "image"}, nil,
+            []string{"iqn", "tpgt", "lun", "rbd", "pool", "image"}, nil,
         ),
 
         lio_rdmcp_iops: prometheus.NewDesc(
             prometheus.BuildFQName(namespace, lio_rdmcp_Subsystem, "iops"),
             "iSCSI Memory Copy RAMDisk backstore transport operations.",
-            []string{"iqn", "tpgt", "lun", "active", "rd_mcp", "object", "size"}, nil,
+            []string{"iqn", "tpgt", "lun", "rd_mcp", "object"}, nil,
         ),
         lio_rdmcp_read: prometheus.NewDesc(
             prometheus.BuildFQName(namespace, lio_rdmcp_Subsystem, "read"),
             "iSCSI Memory Copy RAMDisk backstore Read in byte.",
-            []string{"iqn", "tpgt", "lun", "active", "rd_mcp", "object", "size"}, nil,
+            []string{"iqn", "tpgt", "lun", "rd_mcp", "object" }, nil,
         ),
         lio_rdmcp_write: prometheus.NewDesc(
             prometheus.BuildFQName(namespace, lio_rdmcp_Subsystem, "write"),
             "iSCSI Memory Copy RAMDisk backstore Write in byte.",
-            []string{"iqn", "tpgt", "lun", "active", "rd_mcp", "object", "size"}, nil,
+            []string{"iqn", "tpgt", "lun", "rd_mcp", "object" }, nil,
         ),
     }, nil
-}
-
-// Update implement the lioCollector.
-func (c *lioCollector) Update(ch chan<- prometheus.Metric) error {
-
-    log.Debugf("lioCollector updateStat\n")
-    if err := c.updateStat(ch); err != nil {
-        return fmt.Errorf("failed to update iscsi stat : %v", err)
-    }
-    return nil
 }
 
 // /sys/kernel/config/target/iscsi/iqn*/tpgt_*/lun/lun_*/ which link
 // back to the following 
 // /sys/kernel/config/target/core/{backstore_type}_{number}/{object_name}/
 
-func (c *lioCollector) updateStat(ch chan<- prometheus.Metric) error {
-    iqn_s, _:=  getIQN() 
+func (c *lioCollector) updateStat(ch chan<- prometheus.Metric, s *iscsi.Stats) error {
 
-    for _, iqn_path :=range iqn_s {
-        tpgt_s, _:= getTpgt(iqn_path) 
+    log.Debugf("lio updateStat iscsi %s path", s.Name)
+    tpgt_s := s.Tpgt
+    for _, tpgt := range tpgt_s {
+        tpgt_path := tpgt.Tpgt_path
+        iscsi_enable := tpgt.Is_enable
 
-        for _, tpgt_path:= range tpgt_s { 
-            iscsi_enable := isTpgtEnable(tpgt_path)
+        log.Debugf("lio: iscsi %s isEnable=%t", tpgt_path, iscsi_enable)
+        // let's not putting more line into the graph with multiple
+        // disable lun, it may create problem for bigger cluster
+        if (iscsi_enable) {
 
-            log.Debugf("iscsi %s isEnable=%t\n", tpgt_path, iscsi_enable)
+            lun_s := tpgt.Luns
+            for _, lun := range lun_s {
+                backstore_type  := lun.Backstore
+                object_name     := lun.Object_name
+                type_number     := lun.Type_number
 
-            // let's not putting more line into the graph with multiple
-            // disable lun, it may create problem for bigger cluster
+                // struct type graph_label { iqn, tpgt, lun, store, pool,  image}
+                // label := graph_label {iqn, tpgt, lun, backstore_type, object_name, type_number}
+                label := graph_label { s.Name, tpgt.Name, lun.Name, backstore_type, object_name, type_number}
 
-            if (iscsi_enable) {
-                lun_s, _:= getLun(tpgt_path) 
-                for _, lun_path := range lun_s {
-                    backstore_type, object_name, type_number, err := getLunLinkTarget(lun_path)
+                log.Debugf("lio: iqn=%s, tpgt=%s, lun=%s, type=%s, object=%s, type_number=%s", 
+                s.Name, tpgt.Name, lun.Name, backstore_type, object_name, type_number) 
 
-                    if err != nil {
-                        continue 
-                    }
-                    _, iqn := filepath.Split(iqn_path) 
-                    _, tpgt:= filepath.Split(tpgt_path) 
-                    _, lun := filepath.Split(lun_path) 
-
-                    // struct type graph_label { iqn, tpgt, lun, active, store, pool,  image}
-                    label := graph_label {iqn, tpgt, lun, "enable", backstore_type, object_name, type_number}
-
-                    log.Debugf("iqn=%s, tpgt=%s, lun=%s, type=%s, object=%s, type_number=%s\n", 
-                    iqn, tpgt, lun, backstore_type, object_name, type_number) 
-
-                    switch { 
-                        case strings.Compare(backstore_type, "fileio") == 0:
-                            if err := c.updateFileIOStat(ch, label); err != nil {
-                                return fmt.Errorf("failed fileio stat : %v", err)
-                            }
-                            break;
-                        case strings.Compare(backstore_type, "iblock") == 0:
-                            if err := c.updateIBlockStat(ch, label); err != nil {
-                                return fmt.Errorf("failed iblock stat : %v", err)
-                            }
-                            break;
-                        case strings.Compare(backstore_type, "rbd") == 0:
-                            if err := c.updateRBDStat(ch, label); err != nil {
-                                return fmt.Errorf("failed rbd stat : %v", err)
-                            }
-                            break;
-                        case strings.Compare(backstore_type, "rd_mcp") == 0:
-                            if err := c.updateRDMCPStat(ch, label); err != nil {
-                                return fmt.Errorf("failed rbd stat : %v", err)
-                            }
-                            break;
-                        default:
-                            continue
-                    }
+                switch { 
+                    case strings.Compare(backstore_type, "fileio") == 0:
+                        if err := c.updateFileIOStat(ch, label); err != nil {
+                            return fmt.Errorf("failed fileio stat : %v", err)
+                        }
+                        break;
+                    case strings.Compare(backstore_type, "iblock") == 0:
+                        if err := c.updateIBlockStat(ch, label); err != nil {
+                            return fmt.Errorf("failed iblock stat : %v", err)
+                        }
+                        break;
+                    case strings.Compare(backstore_type, "rbd") == 0:
+                        if err := c.updateRBDStat(ch, label); err != nil {
+                            return fmt.Errorf("failed rbd stat : %v", err)
+                        }
+                        break;
+                    case strings.Compare(backstore_type, "rd_mcp") == 0:
+                        if err := c.updateRDMCPStat(ch, label); err != nil {
+                            return fmt.Errorf("failed rdmcp stat : %v", err)
+                        }
+                        break;
+                    default:
+                        continue
                 }
             }
         }
@@ -219,116 +232,82 @@ func (c *lioCollector) updateStat(ch chan<- prometheus.Metric) error {
 // /sys/kernel/config/target/core/fileio_{type_number}/{object}/
 // udev_path has the file name 
 func (c *lioCollector) updateFileIOStat(ch chan<- prometheus.Metric, label graph_label) error {
-    fileio_with_number := "fileio_" + label.image
-    udev_path := filepath.Join("/sys/kernel/config/target/core/",
-    fileio_with_number, label.pool, "udev_path")
 
-    if _, err := os.Stat(udev_path); os.IsNotExist(err) {
-        return fmt.Errorf("fileio_%s is missing file name ...!", label.image)
-    } else {
-        file_name, err := ioutil.ReadFile(udev_path)
-        if err != nil {
-            return fmt.Errorf("Cannot read file name from %s!", udev_path)
-        } else { 
-            label.image = strings.TrimSpace(string(file_name))
-            log.Debugf("%s file name is using ->%s<- !",
-            fileio_with_number, label.image)
+    fileio := new(iscsi.FILEIO)
+    fileio, err := fileio.GetFileioUdev(label.image, label.pool)
+    if err != nil {
+        return err
+    } 
 
-            //  /sys/kernel/config/target/iscsi/iqn*/tpgt_*/lun/lun_*
-
-            log.Debugf("File %s\n", filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn, label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
-            read_mb, _:=readUintFromFile(
-            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
-            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
-
-            log.Debugf("Read %f\n", read_mb) 
-
-            ch <- prometheus.MustNewConstMetric(c.lio_file_read,
-            prometheus.CounterValue, float64(read_mb<<10),
-            label.iqn, label.tpgt, label.lun, "enable",
-            fileio_with_number, label.pool, label.image)
-
-            write_mb, _:=readUintFromFile( 
-            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
-            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/write_mbytes"))
-
-            log.Debugf("Write %f\n", write_mb) 
-
-            ch <- prometheus.MustNewConstMetric(c.lio_file_write,
-            prometheus.CounterValue, float64(write_mb<<10),
-            label.iqn, label.tpgt, label.lun, "enable",
-            fileio_with_number, label.pool, label.image)
-
-            iops, _:=readUintFromFile( 
-            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
-            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/in_cmds"))
-
-            log.Debugf("iops %f\n", iops) 
-
-            ch <- prometheus.MustNewConstMetric(c.lio_file_iops,
-            prometheus.CounterValue, float64(iops),
-            label.iqn, label.tpgt, label.lun, "enable",
-            fileio_with_number, label.pool, label.image)
-        }
+    read_mb, write_mb, iops, err:= iscsi.ReadWriteOPS(label.iqn, label.tpgt, label.lun)
+    if err != nil {
+        return err
     }
+    log.Debugf("lio: Fileio Read int %d", read_mb) 
+    f_read_mb  := float64(read_mb<<20) 
+    log.Debugf("lio: Fileio Read float %f", f_read_mb) 
+
+    log.Debugf("lio: Fileio Write int %d", write_mb) 
+    f_write_mb := float64(write_mb<<20)
+    log.Debugf("lio: Fileio Write int %f", f_write_mb) 
+
+    log.Debugf("lio: Fileio OPS int %d", iops) 
+    f_iops := float64(iops)
+    log.Debugf("lio: Fileio OPS float %f", f_iops) 
+
+    ch <- prometheus.MustNewConstMetric(c.metrics.lio_file_read,
+    prometheus.CounterValue, f_read_mb, label.iqn, label.tpgt, label.lun, 
+    fileio.Name, fileio.Object_name, fileio.Filename)
+
+    ch <- prometheus.MustNewConstMetric(c.metrics.lio_file_write,
+    prometheus.CounterValue, f_write_mb, label.iqn, label.tpgt, label.lun,
+    fileio.Name, fileio.Object_name, fileio.Filename)
+
+    ch <- prometheus.MustNewConstMetric(c.metrics.lio_file_iops,
+    prometheus.CounterValue, f_iops, label.iqn, label.tpgt, label.lun,
+    fileio.Name, fileio.Object_name, fileio.Filename)
+
     return nil
 }
 
 // /sys/kernel/config/target/core/iblock_{type_number}/{object}/
 // udev_path has the file name 
 func (c *lioCollector) updateIBlockStat(ch chan<- prometheus.Metric, label graph_label) error {
-    iblock_with_number := "iblock_" + label.image
-    udev_path := filepath.Join("/sys/kernel/config/target/core/",
-    iblock_with_number, label.pool, "udev_path")
 
-    if _, err := os.Stat(udev_path); os.IsNotExist(err) {
-        return fmt.Errorf("iblock_%s is missing file name ...!", label.image)
-    } else {
-        block_name, err := ioutil.ReadFile(udev_path)
-        if err != nil {
-            return fmt.Errorf("Cannot read block name from %s!", udev_path)
-        } else { 
-            label.image = strings.TrimSpace(string(block_name))
-            log.Debugf("%s block name is using ->%s<- !",
-            iblock_with_number, label.image)
-
-            //  /sys/kernel/config/target/iscsi/iqn*/tpgt_*/lun/lun_*
-
-            log.Debugf("File %s\n", filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn, label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
-            read_mb, _:=readUintFromFile(
-            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
-            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
-
-            log.Debugf("Read %f\n", read_mb) 
-
-            ch <- prometheus.MustNewConstMetric(c.lio_block_read,
-            prometheus.CounterValue, float64(read_mb<<10),
-            label.iqn, label.tpgt, label.lun, "enable",
-            iblock_with_number, label.pool, label.image)
-
-            write_mb, _:=readUintFromFile( 
-            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
-            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/write_mbytes"))
-
-            log.Debugf("Write %f\n", write_mb) 
-
-            ch <- prometheus.MustNewConstMetric(c.lio_block_write,
-            prometheus.CounterValue, float64(write_mb<<10),
-            label.iqn, label.tpgt, label.lun, "enable",
-            iblock_with_number, label.pool, label.image)
-
-            iops, _:=readUintFromFile( 
-            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
-            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/in_cmds"))
-
-            log.Debugf("iops %f\n", iops) 
-
-            ch <- prometheus.MustNewConstMetric(c.lio_block_iops,
-            prometheus.CounterValue, float64(iops),
-            label.iqn, label.tpgt, label.lun, "enable",
-            iblock_with_number, label.pool, label.image)
-        }
+    iblock := new(iscsi.IBLOCK)
+    iblock, err := iblock.GetIblockUdev(label.image, label.pool)
+    if err != nil {
+        return err
     }
+    read_mb, write_mb, iops, err:= iscsi.ReadWriteOPS(label.iqn, label.tpgt, label.lun)
+    if err != nil {
+        return err
+    }
+    log.Debugf("lio: IBlock Read int %d", read_mb) 
+    f_read_mb  := float64(read_mb<<20) 
+    log.Debugf("lio: IBlock Read float %f", f_read_mb) 
+
+    log.Debugf("lio: IBlock Write int %d", write_mb) 
+    f_write_mb := float64(write_mb<<20)
+    log.Debugf("lio: IBlock Write int %f", f_write_mb) 
+
+    log.Debugf("lio: IBlock OPS int %d", iops) 
+    f_iops := float64(iops)
+    log.Debugf("lio: IBlock OPS float %f", f_iops) 
+
+
+    ch <- prometheus.MustNewConstMetric(c.metrics.lio_block_read,
+    prometheus.CounterValue, f_read_mb, label.iqn, label.tpgt, label.lun, 
+    iblock.Name, iblock.Object_name, iblock.Iblock)
+
+    ch <- prometheus.MustNewConstMetric(c.metrics.lio_block_write,
+    prometheus.CounterValue, f_write_mb, label.iqn, label.tpgt, label.lun,
+    iblock.Name, iblock.Object_name, iblock.Iblock)
+
+    ch <- prometheus.MustNewConstMetric(c.metrics.lio_block_iops,
+    prometheus.CounterValue, f_iops, label.iqn, label.tpgt, label.lun,
+    iblock.Name, iblock.Object_name, iblock.Iblock)
+
     return nil
 }
 
@@ -348,95 +327,39 @@ func (c *lioCollector) updateIBlockStat(ch chan<- prometheus.Metric, label graph
 
 func (c *lioCollector) updateRBDStat(ch chan<- prometheus.Metric, label graph_label) error {
 
-    rbds, err := filepath.Glob(sysFilePath("devices/rbd/[0-9]*"))
+    rbd := new(iscsi.RBD)
+    rbd, err := rbd.GetRBDMatch(label.image, label.pool)
     if err != nil {
         return err
     }
-
-    // looping all rbd{X} with image and pool
-    for rbd_number , rbd_path := range rbds {
-
-        log.Debugf("RBD path %s, device rbd%d", rbd_path, rbd_number)
-        var pool string = ""
-        var image string = ""
-
-        log.Debugf("rbd_%d\n pool --->%s<--- \nimage --->%s<---", rbd_number, pool, image)
-
-        if _, err := os.Stat(filepath.Join(rbd_path, "pool")); os.IsNotExist(err) {
-            fmt.Errorf("rbd%d is missing pool name ...!", rbd_number)
-            continue 
-        } else {
-            p_name , err := ioutil.ReadFile(filepath.Join(rbd_path, "pool"))
-            if err != nil {
-                fmt.Errorf("Cannot read pool name from rbd%d!", rbd_number)
-                continue 
-            } else {
-                log.Debugf("rbd%d pool name is ->%s<- !", rbd_number, p_name)
-                pool = strings.TrimSpace(string(p_name))
-            }
+    if rbd != nil { 
+        read_mb, write_mb, iops, err:= iscsi.ReadWriteOPS(label.iqn, label.tpgt, label.lun)
+        if err != nil {
+            return err
         }
-        if _, err := os.Stat(filepath.Join(rbd_path, "name")); os.IsNotExist(err) {
-            fmt.Errorf("rbd%d is missing image name ...!", rbd_number)
-            continue 
-        } else {
-            i_name, err := ioutil.ReadFile(filepath.Join(rbd_path, "name"))
-            if err != nil {
-                fmt.Errorf("Cannot read image name from rbd%d!", rbd_number)
-                continue 
-            } else { 
-                log.Debugf("rbd%d image name is ->%s<- !", rbd_number, image)
-                image = strings.TrimSpace(string(i_name))
-            }
-        }
-        log.Debugf("rbd_%d\n pool --->%s<--- \nimage --->%s<---", rbd_number, pool, image)
+        log.Debugf("lio: RBD Read int %d", read_mb) 
+        f_read_mb  := float64(read_mb<<20) 
+        log.Debugf("lio: RBD Read float %f", f_read_mb) 
 
-        // find a match 
-        // reminding label 
-        // []string{"iqn", "tpgt", "lun", "active", "rbd", "pool", "image"}, nil,
+        log.Debugf("lio: RBD Write int %d", write_mb) 
+        f_write_mb := float64(write_mb<<20)
+        log.Debugf("lio: RBD Write int %f", f_write_mb) 
 
-        log.Debugf("Matching rbd%d, label->rbd%s", rbd_number, label.image )
-        log.Debugf("Matching pool->%s, image->%s, label->%s", pool, image, label.pool)
+        log.Debugf("lio: RBD OPS int %d", iops) 
+        f_iops := float64(iops)
+        log.Debugf("lio: RBD OPS float %f", f_iops) 
 
-        if matchRBD(fmt.Sprintf("%d", rbd_number), label.image) &&
-        matchPoolImage(pool, image, label.pool) {
-            log.Debugf("Match! rbd%d, pool->%s, image->%s", rbd_number, pool, image)
+        ch <- prometheus.MustNewConstMetric(c.metrics.lio_rbd_read,
+        prometheus.CounterValue, f_read_mb, label.iqn, label.tpgt, label.lun,
+        rbd.Name, rbd.Pool, rbd.Image)
 
-            //  /sys/kernel/config/target/iscsi/iqn*/tpgt_*/lun/lun_*
+        ch <- prometheus.MustNewConstMetric(c.metrics.lio_rbd_write,
+        prometheus.CounterValue, f_write_mb, label.iqn, label.tpgt, label.lun,
+        rbd.Name, rbd.Pool, rbd.Image)
 
-            log.Debugf("File %s\n", filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn, label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
-            read_mb, _:=readUintFromFile(
-            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
-            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
-
-            log.Debugf("Read %f\n", read_mb) 
-
-            ch <- prometheus.MustNewConstMetric(c.lio_rbd_read,
-            prometheus.CounterValue, float64(read_mb<<10),
-            label.iqn, label.tpgt, label.lun, "enable",
-            "rbd" + label.image , pool, image)
-
-            write_mb, _:=readUintFromFile( 
-            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
-            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/write_mbytes"))
-
-            log.Debugf("Write %f\n", write_mb) 
-
-            ch <- prometheus.MustNewConstMetric(c.lio_rbd_write,
-            prometheus.CounterValue, float64(write_mb<<10),
-            label.iqn, label.tpgt, label.lun, "enable",
-            "rbd" + label.image, pool, image)
-
-            iops, _:=readUintFromFile( 
-            filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
-            label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/in_cmds"))
-
-            log.Debugf("iops %f\n", iops) 
-
-            ch <- prometheus.MustNewConstMetric(c.lio_rbd_iops,
-            prometheus.CounterValue, float64(iops),
-            label.iqn, label.tpgt, label.lun, "enable",
-            "rbd" + label.image, pool, image)
-        }
+        ch <- prometheus.MustNewConstMetric(c.metrics.lio_rbd_iops,
+        prometheus.CounterValue, f_iops, label.iqn, label.tpgt, label.lun,
+        rbd.Name, rbd.Pool, rbd.Image)
     }
     return nil
 }
@@ -444,139 +367,40 @@ func (c *lioCollector) updateRBDStat(ch chan<- prometheus.Metric, label graph_la
 // /sys/kernel/config/target/core/rd_mcp_{type_number}/{object}/
 // there won't be udev_path for ramdisk so not image name either 
 func (c *lioCollector) updateRDMCPStat(ch chan<- prometheus.Metric, label graph_label) error {
-    rd_mcp_with_number := "rd_mcp_" + label.image
-
-    //  /sys/kernel/config/target/iscsi/iqn*/tpgt_*/lun/lun_*
-
-    log.Debugf("File %s\n", filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn, label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
-    read_mb, _:=readUintFromFile(
-    filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
-    label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/read_mbytes"))
-
-    log.Debugf("Read %f\n", read_mb) 
-
-    ch <- prometheus.MustNewConstMetric(c.lio_rdmcp_read,
-    prometheus.CounterValue, float64(read_mb<<10),
-    label.iqn, label.tpgt, label.lun, "enable",
-    rd_mcp_with_number, label.pool, "")
-
-    write_mb, _:=readUintFromFile( 
-    filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
-    label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/write_mbytes"))
-
-    log.Debugf("Write %f\n", write_mb) 
-
-    ch <- prometheus.MustNewConstMetric(c.lio_rdmcp_write,
-    prometheus.CounterValue, float64(write_mb<<10),
-    label.iqn, label.tpgt, label.lun, "enable",
-    rd_mcp_with_number, label.pool, "")
-
-    iops, _:=readUintFromFile( 
-    filepath.Join("/sys/kernel/config/target/iscsi/", label.iqn,
-    label.tpgt, "lun", label.lun, "statistics/scsi_tgt_port/in_cmds"))
-
-    log.Debugf("iops %f\n", iops) 
-
-    ch <- prometheus.MustNewConstMetric(c.lio_rdmcp_iops,
-    prometheus.CounterValue, float64(iops),
-    label.iqn, label.tpgt, label.lun, "enable",
-    rd_mcp_with_number, label.pool, "")
-
-    return nil
-}
-
-func getIQN() (m []string, err error) { 
-    matches, err := filepath.Glob(sysFilePath("kernel/config/target/iscsi/iqn*"))
+    rd_mcp := new(iscsi.RDMCP)
+    rd_mcp, err := rd_mcp.GetRDMCPPath(label.image, label.pool)
     if err != nil {
-        fmt.Errorf("getIQN error %v\n", err)
-        return nil, nil
+        return err
     }
-    return matches, nil
-}
-
-func getTpgt(iqn_path string) (m []string, err error) {
-    log.Debugf("getTpgt path %s\n", iqn_path)
-    matches, err := filepath.Glob(filepath.Join(iqn_path, "tpgt*"))
-    if err != nil {
-        fmt.Errorf("getTPGT error %v\n", err )                                                                                                                           
-        return nil, nil
-    } 
-    return matches, nil
-}
-
-func isTpgtEnable(tpgt_path string) (isEnable bool) { 
-    isEnable = false
-    tmp, err := ioutil.ReadFile(filepath.Join(tpgt_path, "enable"))
-    log.Debugf("getTpgt enable %s\n", tmp)
-    if err != nil {
-        fmt.Errorf("isTpgtEnable error %v\n", err )                                                                                                                           
-        return false
-    } 
-    tmp_num, err := strconv.Atoi(strings.TrimSpace(string(tmp)))
-    log.Debugf("getTpgt enable number %d\n", tmp_num)
-    if (tmp_num > 0) {
-        isEnable = true
-    }
-    return isEnable
-}
-
-func getLun(tpgt_path string) (m []string, err error) { 
-    log.Debugf("getLun path %s\n", tpgt_path)
-    matches, err := filepath.Glob(filepath.Join(tpgt_path, "lun/lun*"))
-    if err != nil {
-        fmt.Errorf("getLun error  %v\n", err )
-        return nil, nil
-    } 
-    return matches, nil
-}
-
-func getLunLinkTarget(lun_path string) ( backstore_type string, object_name string, type_number string, err error) { 
-    files, err := ioutil.ReadDir(lun_path)
-    if err != nil { 
-        fmt.Errorf("getLunLinkTarget error  %v\n", err )
-        return "", "", "", nil
-    }
-    for _, file := range files {
-        log.Debugf("lun dir list file ->%s<-\n",file.Name())
-        fileInfo, _:= os.Lstat(lun_path +  "/" + file.Name())
-        if fileInfo.Mode() & os.ModeSymlink != 0 {
-            target, err := os.Readlink( lun_path +  "/" + fileInfo.Name()) 
-            if err != nil {
-                fmt.Errorf("Readlink err %v\n", err)
-                return "", "", "", nil
-            }
-            p1, object_name := filepath.Split(target)
-            _, type_with_number := filepath.Split(filepath.Clean(p1))
-
-            tmp := strings.Split(type_with_number, "_")
-            backstore_type, type_number := tmp[0], tmp[1]
-            if len(tmp) == 3 {
-                backstore_type = fmt.Sprintf("%s_%s", tmp[0], tmp[1])
-                type_number = tmp[2] 
-            }
-            log.Debugf("object_name->%s-<, type->%s, type_number->%s<- \n", object_name, backstore_type, type_number)
-            return backstore_type, object_name, type_number, nil
+    if rd_mcp != nil { 
+        read_mb, write_mb, iops, err:= iscsi.ReadWriteOPS(label.iqn, label.tpgt, label.lun)
+        if err != nil {
+            return err
         }
-    }
-    return "", "", "", errors.New("getLunLinkTarget: Lun Link does not exist")
-}
+        log.Debugf("lio: RBD Read int %d", read_mb) 
+        f_read_mb  := float64(read_mb<<20) 
+        log.Debugf("lio: RBD Read float %f", f_read_mb) 
 
-func matchRBD(rbd_number string, rbd_name string) (isEqual bool) { 
-    isEqual = false
-    log.Debugf("compare rbd->%s<- with rbd->%s<- \n", rbd_number, rbd_name)
-    if strings.Compare(rbd_name, rbd_number) == 0 { 
-        isEqual = true
-    }
-    return isEqual 
-}
+        log.Debugf("lio: RBD Write int %d", write_mb) 
+        f_write_mb := float64(write_mb<<20)
+        log.Debugf("lio: RBD Write int %f", f_write_mb) 
 
-func matchPoolImage(pool string, image string, match_pool_image string) (isEqual bool) { 
-    isEqual = false
-    var pool_image = fmt.Sprintf("%s-%s", pool, image)
-    log.Debugf("compare pool_image->%s<- with pool_image->%s<- \n", pool_image, match_pool_image)
-    if strings.Compare(pool_image, match_pool_image) == 0 { 
-        isEqual = true
+        log.Debugf("lio: RBD OPS int %d", iops) 
+        f_iops := float64(iops)
+        log.Debugf("lio: RBD OPS float %f", f_iops) 
+
+        ch <- prometheus.MustNewConstMetric(c.metrics.lio_rdmcp_read,
+        prometheus.CounterValue, f_read_mb, label.iqn, label.tpgt, label.lun,
+        rd_mcp.Name, rd_mcp.Object_name)
+
+        ch <- prometheus.MustNewConstMetric(c.metrics.lio_rdmcp_write,
+        prometheus.CounterValue, f_write_mb, label.iqn, label.tpgt, label.lun,
+        rd_mcp.Name, rd_mcp.Object_name)
+
+        ch <- prometheus.MustNewConstMetric(c.metrics.lio_rdmcp_iops,
+        prometheus.CounterValue, f_iops, label.iqn, label.tpgt, label.lun,
+        rd_mcp.Name, rd_mcp.Object_name)
     }
-    return isEqual 
+    return nil
 }
 


### PR DESCRIPTION
This module read 3 numbers, Read In Byte, Write in Byte and ISCSI OPS, 
form 4 different backstore, FileIO, IBlock, RBD and RD_MCP,  from lio target. 
The latest update use the procfs module in the following pull request
 https://github.com/prometheus/procfs/pull/69
That module need to be merge before this PR able to compile and work. 
