### PR TITLE
add sample directory size exporter

### DIFF
--- a/text_collector_examples/directory-size.sh
+++ b/text_collector_examples/directory-size.sh
@@ -12,4 +12,4 @@
 echo "# HELP anarcat_dir_space_bytes Disk space used by some directories"
 echo "# TYPE anarcat_dir_space_bytes gauge"
 du --block-size=1 --summarize "$@" \
-  | sed -ne 's/^\([0-9]\+\)\t\(.*\)$/node_directory_size_bytes{directory="\2"} \1/p'
+  | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/node_directory_size_bytes{directory="\2"} \1/p'

--- a/text_collector_examples/directory-size.sh
+++ b/text_collector_examples/directory-size.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Expose directory usage metrics, passed as an argument.
+#
+# Usage: add this to crontab:
+#
+# */5 * * * * prometheus directory-size.sh /var/lib/prometheus | sponge /var/lib/node_exporter/directory_size.prom
+#
+# sed pattern taken from https://www.robustperception.io/monitoring-directory-sizes-with-the-textfile-collector/
+#
+# Author: Antoine Beaupré <anarcat@debian.org>
+echo "# HELP anarcat_dir_space_bytes Disk space used by some directories"
+echo "# TYPE anarcat_dir_space_bytes gauge"
+du --block-size=1 --summarize "$@" \
+  | sed -ne 's/^\([0-9]\+\)\t\(.*\)$/node_directory_size_bytes{directory="\2"} \1/p'


### PR DESCRIPTION
This is a possible workaround for the lack of metrics in the new
storage backend, as documented in:

https://github.com/prometheus/prometheus/issues/3684

Partly inspired by this post as well:

https://www.robustperception.io/monitoring-directory-sizes-with-the-textfile-collector/