### PR TITLE
Fix smartmon.sh bugs

### DIFF
--- a/text_collector_examples/smartmon.sh
+++ b/text_collector_examples/smartmon.sh
@@ -71,6 +71,7 @@ parse_smartctl_attributes() {
 parse_smartctl_info() {
   local -i smart_available=0 smart_enabled=0 smart_healthy=0
   local disk="$1" disk_type="$2"
+  local model_family='' device_model='' serial_number='' fw_version='' vendor='' product='' revision='' lun_id=''
   while read line ; do
     info_type="$(echo "${line}" | cut -f1 -d: | tr ' ' '_')"
     info_value="$(echo "${line}" | cut -f2- -d: | sed 's/^ \+//g')"
@@ -101,11 +102,7 @@ parse_smartctl_info() {
       esac
     fi
   done
-  if [[ -n "${vendor}" ]] ; then
-    echo "device_info{disk=\"${disk}\",type=\"${disk_type}\",vendor=\"${vendor}\",product=\"${product}\",revision=\"${revision}\",lun_id=\"${lun_id}\"} 1"
-  else
-    echo "device_info{disk=\"${disk}\",type=\"${disk_type}\",model_family=\"${model_family}\",device_model=\"${device_model}\",serial_number=\"${serial_number}\",firmware_version=\"${fw_version}\"} 1"
-  fi
+  echo "device_info{disk=\"${disk}\",type=\"${disk_type}\",vendor=\"${vendor}\",product=\"${product}\",revision=\"${revision}\",lun_id=\"${lun_id}\",model_family=\"${model_family}\",device_model=\"${device_model}\",serial_number=\"${serial_number}\",firmware_version=\"${fw_version}\"} 1"
   echo "device_smart_available{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_available}"
   echo "device_smart_enabled{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_enabled}"
   echo "device_smart_healthy{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_healthy}"

--- a/text_collector_examples/smartmon.sh
+++ b/text_collector_examples/smartmon.sh
@@ -8,7 +8,7 @@
 #       http://arstechnica.com/civis/viewtopic.php?p=22062211
 
 parse_smartctl_attributes_awk="$(cat << 'SMARTCTLAWK'
-$1 ~ /^[0-9]+$/ && $2 ~ /^[a-zA-Z0-9_-]+$/ {
+$1 ~ /^ *[0-9]+$/ && $2 ~ /^[a-zA-Z0-9_-]+$/ {
   gsub(/-/, "_");
   printf "%s_value{%s,smart_id=\"%s\"} %d\n", $2, labels, $1, $4
   printf "%s_worst{%s,smart_id=\"%s\"} %d\n", $2, labels, $1, $5


### PR DESCRIPTION
* Fix parsing of SMART-ID attributes <= 99. (See https://github.com/prometheus/node_exporter/pull/731)
* Fix smartmon.sh info label consistency.

Closes: https://github.com/prometheus/node_exporter/issues/791