### PR TITLE
text_collector_examples/apt.sh: add missing backslash 

### DIFF
--- a/text_collector_examples/apt.sh
+++ b/text_collector_examples/apt.sh
@@ -7,7 +7,7 @@
 upgrades="$(/usr/bin/apt-get --just-print upgrade \
   | /usr/bin/awk -F'[()]' \
       '/^Inst/ { sub("^[^ ]+ ", "", $2); sub("\\[", " ", $2);
-                 sub(" ", "", $2); sub("\\]", "", $2); print $2 }'
+                 sub(" ", "", $2); sub("\\]", "", $2); print $2 }' \
   | /usr/bin/sort \
   | /usr/bin/uniq -c \
   | awk '{ gsub(/\\\\/, "\\\\", $2); gsub(/\"/, "\\\"", $2);


### PR DESCRIPTION
This patch fixes:

./apt.test: command substitution: line 19: syntax error near unexpected token `|'
./apt.test: command substitution: line 19: `  | /usr/bin/sort   | /usr/bin/uniq -c   | awk '{ gsub(/\\\\/,