### PR TITLE
Use swpginuse instead of swpgonly in meminfo_openbsd

### DIFF
--- a/collector/meminfo_openbsd.go
+++ b/collector/meminfo_openbsd.go
@@ -57,7 +57,7 @@ func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 		"inactive_bytes":                ps * float64(uvmexp.inactive),
 		"size_bytes":                    ps * float64(uvmexp.npages),
 		"swap_size_bytes":               ps * float64(uvmexp.swpages),
-		"swap_used_bytes":               ps * float64(uvmexp.swpgonly),
+		"swap_used_bytes":               ps * float64(uvmexp.swpginuse),
 		"swapped_in_pages_bytes_total":  ps * float64(uvmexp.pgswapin),
 		"swapped_out_pages_bytes_total": ps * float64(uvmexp.pgswapout),
 		"wired_bytes":                   ps * float64(uvmexp.wired),


### PR DESCRIPTION
All tools in OpenBSD base system use swpginuse instead of swpgonly
for reporting swap usage (snmpd, swapctl, top, vmstat), so let
memory collector use that as well for consistency.