### PR TITLE
Ignore /var/lib/docker by default.

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	defIgnoredMountPoints = "^/(dev|proc|sys)($|/)"
+	defIgnoredMountPoints = "^/(dev|proc|sys|var/lib/docker)($|/)"
 	defIgnoredFSTypes     = "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
 	readOnly              = 0x1 // ST_RDONLY
 )


### PR DESCRIPTION
The node exporter runs unprivileged, so it cannot statfs any filesystems
under this directory causing log spam.  In addition there tends to be
high churn in the filesystems here (as it's basically application
monitoring) which can cause high cardinaltiy and in one case caused
Prometheus's index symbol table to get very large.
Accordingly this should be ignored to reduce log spam and avoid
performance issues. The filesystems themselves can in principle be
monitored via container oriented exporters, and the underlying
filesystems will still be monitored.

@SuperQ 