### PR TITLE
Fix error output in nfsd collector.

### DIFF
--- a/collector/nfsd_linux.go
+++ b/collector/nfsd_linux.go
@@ -15,8 +15,10 @@ package collector
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 	"github.com/prometheus/procfs"
 	"github.com/prometheus/procfs/nfs"
 )
@@ -57,6 +59,10 @@ func NewNFSdCollector() (Collector, error) {
 func (c *nfsdCollector) Update(ch chan<- prometheus.Metric) error {
 	stats, err := c.fs.NFSdServerRPCStats()
 	if err != nil {
+		if os.IsNotExist(err) {
+			log.Debugf("Not collecting NFSd metrics: %s", err)
+			return nil
+		}
 		return fmt.Errorf("failed to retrieve nfsd stats: %v", err)
 	}
 


### PR DESCRIPTION
Fixes:
```
ERRO[0007] ERROR: nfsd collector failed after 0.000041s: failed to retrieve nfsd stats: open /proc/net/rpc/nfsd: no such file or directory source="collector.go:136"
```

Now debug level only:
```
DEBU[0014] Not collecting NFSd metrics: open /proc/net/rpc/nfsd: no such file or directory  source="nfsd_linux.go:63"
```