### PR TITLE
Add overlay to defIgnoredFSTypes

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	defIgnoredMountPoints = "^/(dev|proc|sys|var/lib/docker)($|/)"
-	defIgnoredFSTypes     = "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
+	defIgnoredFSTypes     = "^(overlay|autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
 	readOnly              = 0x1 // ST_RDONLY
 )
 

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	defIgnoredMountPoints = "^/(dev|proc|sys|var/lib/docker)($|/)"
-	defIgnoredFSTypes     = "^(overlay|autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
+	defIgnoredFSTypes     = "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
 	readOnly              = 0x1 // ST_RDONLY
 )
 


### PR DESCRIPTION
To avoid statfs() errors if node_exporter is running as non privileged user in docker host.