### PR TITLE
Correct the ClocksPerSec scaling factor on Darwin

### DIFF
--- a/collector/cpu_darwin.go
+++ b/collector/cpu_darwin.go
@@ -31,6 +31,7 @@ import (
 /*
 #cgo LDFLAGS:
 #include <stdlib.h>
+#include <limits.h>
 #include <sys/sysctl.h>
 #include <sys/mount.h>
 #include <mach/mach_init.h>
@@ -45,7 +46,7 @@ import (
 import "C"
 
 // ClocksPerSec default value. from time.h
-const ClocksPerSec = float64(128)
+const ClocksPerSec = C.CLK_TCK
 
 type statCollector struct {
 	cpu *prometheus.Desc

--- a/collector/cpu_darwin.go
+++ b/collector/cpu_darwin.go
@@ -46,7 +46,7 @@ import (
 import "C"
 
 // ClocksPerSec default value. from time.h
-const ClocksPerSec = C.CLK_TCK
+const ClocksPerSec = float64(C.CLK_TCK)
 
 type statCollector struct {
 	cpu *prometheus.Desc


### PR DESCRIPTION
Change the definition of ClocksPerSec to read from limits.h

Per #845, CPU counters are scaled by an incorrect factor (128 was assumed, which is the FreeBSD default [?]). Correct value on Darwin is given by the C macro CLK_TCK in limits.h