### PR TITLE
Add example launchctl-file for MacOS

### DIFF
--- a/examples/launchctl/README.md
+++ b/examples/launchctl/README.md
@@ -13,6 +13,9 @@ Ex. install globally by
     sudo cp -n examples/launchctl/io.prometheus.node_exporter.plist /Library/LaunchAgents/
     sudo launchctl bootstrap system/ /Library/LaunchAgents/io.prometheus.node_exporter.plist
 
+    # Optionally configure by dropping CLI arguments in a file
+    echo -- '--web.listen-address=:9101' | sudo tee /usr/local/etc/node_exporter.args
+
     # Check it's running
     sudo launchctl list | grep node_exporter
 

--- a/examples/launchctl/README.md
+++ b/examples/launchctl/README.md
@@ -1,0 +1,24 @@
+# MacOS LaunchAgent
+
+If you're installing through a package manager, you probably don't need to deal
+with this file.
+
+The `plist` file should be put in `~/Library/LaunchAgents/` (user-install) or
+`/Library/LaunchAgents/` (global install), and the binary installed at
+`/usr/local/bin/node_exporter`.
+
+Ex. install globally by
+
+    sudo cp -n node_exporter /usr/local/bin/
+    sudo cp -n examples/launchctl/node_exporter.plist /Library/LaunchAgents/
+    sudo launchctl bootstrap system/ /Library/LaunchAgents/node_exporter.plist
+    sudo launchctl start node_exporter
+
+    # Check it's running
+    sudo launchctl list | grep node_exporter
+
+    # See full process state
+    sudo launchctl print system/node_exporter
+
+    # View logs
+    sudo tail /usr/local/var/logs/node_exporter/output.log

--- a/examples/launchctl/README.md
+++ b/examples/launchctl/README.md
@@ -21,4 +21,4 @@ Ex. install globally by
     sudo launchctl print system/node_exporter
 
     # View logs
-    sudo tail /usr/local/var/logs/node_exporter/output.log
+    sudo tail /tmp/node_exporter.log

--- a/examples/launchctl/README.md
+++ b/examples/launchctl/README.md
@@ -10,15 +10,14 @@ The `plist` file should be put in `~/Library/LaunchAgents/` (user-install) or
 Ex. install globally by
 
     sudo cp -n node_exporter /usr/local/bin/
-    sudo cp -n examples/launchctl/node_exporter.plist /Library/LaunchAgents/
-    sudo launchctl bootstrap system/ /Library/LaunchAgents/node_exporter.plist
-    sudo launchctl start node_exporter
+    sudo cp -n examples/launchctl/io.prometheus.node_exporter.plist /Library/LaunchAgents/
+    sudo launchctl bootstrap system/ /Library/LaunchAgents/io.prometheus.node_exporter.plist
 
     # Check it's running
     sudo launchctl list | grep node_exporter
 
     # See full process state
-    sudo launchctl print system/node_exporter
+    sudo launchctl print system/io.prometheus.node_exporter
 
     # View logs
     sudo tail /tmp/node_exporter.log

--- a/examples/launchctl/io.prometheus.node_exporter.plist
+++ b/examples/launchctl/io.prometheus.node_exporter.plist
@@ -8,6 +8,10 @@
   <array>
     <string>/usr/local/bin/node_exporter</string>
   </array>
+  <key>UserName</key>
+  <string>nobody</string>
+  <key>GroupName</key>
+  <string>nobody</string>
   <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>
@@ -15,9 +19,9 @@
   <key>WorkingDirectory</key>
   <string>/usr/local</string>
   <key>StandardErrorPath</key>
-  <string>/usr/local/var/log/node_exporter/output.log</string>
+  <string>/tmp/node_exporter.log</string>
   <key>StandardOutPath</key>
-  <string>/usr/local/var/log/node_exporter/output.log</string>
+  <string>/tmp/node_exporter.log</string>
   <key>HardResourceLimits</key>
   <dict>
     <key>NumberOfFiles</key>

--- a/examples/launchctl/io.prometheus.node_exporter.plist
+++ b/examples/launchctl/io.prometheus.node_exporter.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>node_exporter</string>
+  <string>io.prometheus.node_exporter</string>
   <key>ProgramArguments</key>
   <array>
     <string>/usr/local/bin/node_exporter</string>

--- a/examples/launchctl/io.prometheus.node_exporter.plist
+++ b/examples/launchctl/io.prometheus.node_exporter.plist
@@ -6,7 +6,9 @@
   <string>io.prometheus.node_exporter</string>
   <key>ProgramArguments</key>
   <array>
-    <string>/usr/local/bin/node_exporter</string>
+    <string>sh</string>
+    <string>-c</string>
+    <string>/usr/local/bin/node_exporter $(&lt; /usr/local/etc/node_exporter.args)</string>
   </array>
   <key>UserName</key>
   <string>nobody</string>

--- a/examples/launchctl/node_exporter.plist
+++ b/examples/launchctl/node_exporter.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>node_exporter</string>
+  <key>Program</key>
+  <string>/usr/local/bin/node_exporter</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <false/>
+  <key>WorkingDirectory</key>
+  <string>/usr/local</string>
+  <key>StandardErrorPath</key>
+  <string>/usr/local/var/log/node_exporter/output.log</string>
+  <key>StandardOutPath</key>
+  <string>/usr/local/var/log/node_exporter/output.log</string>
+  <key>HardResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>4096</integer>
+  </dict>
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>4096</integer>
+  </dict>
+</dict>
+</plist>

--- a/examples/launchctl/node_exporter.plist
+++ b/examples/launchctl/node_exporter.plist
@@ -4,8 +4,10 @@
 <dict>
   <key>Label</key>
   <string>node_exporter</string>
-  <key>Program</key>
-  <string>/usr/local/bin/node_exporter</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/node_exporter</string>
+  </array>
   <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>


### PR DESCRIPTION
There doesn't quite seem to be a handy way to get node_exporter running on MacOS, so I've brewed up the appropriate files and a README to get started, analogue to the way it's done for systemd.