### PR TITLE
added scsi smart data to prometheus exporter

### DIFF
--- a/text_collector_examples/smartmon.sh
+++ b/text_collector_examples/smartmon.sh
@@ -68,6 +68,26 @@ parse_smartctl_attributes() {
     | grep -E "(${smartmon_attrs})"
 }
 
+parse_smartctl_scsi_attributes() {
+    local disk="$1"
+    local disk_type="$2"
+    local labels="disk=\"${disk}\",type=\"${disk_type}\""
+    while read line ; do
+      attr_type="$(echo "${line}" | tr '=' ':' | cut -f1 -d: | sed 's/^ \+//g' | tr ' ' '_')"
+      attr_value="$(echo "${line}" | tr '=' ':' | cut -f2 -d: | sed 's/^ \+//g')"
+      case "${attr_type}" in
+        number_of_hours_powered_up_) power_on="$( echo "${attr_value}" | awk '{ printf "%e\n", $1 }')" ;;
+        Current_Drive_Temperature) temp_cel="$(echo ${attr_value} | cut -f1 -d' ' | awk '{ printf "%e\n", $1 }')" ;;
+        Blocks_read_from_cache_and_sent_to_initiator_) lbas_read="$(echo ${attr_value} | awk '{ printf "%e\n", $1 }')" ;;
+        Accumulated_start-stop_cycles) power_cycle="$(echo ${attr_value} | awk '{ printf "%e\n", $1 }')" ;;
+      esac
+    done
+    echo "power_on_hours_raw_value{"${labels}",smart_id=\"9\"} ${power_on}"
+    echo "temperature_celsius_raw_value{"${labels}",smart_id=\"194\"} ${temp_cel}"
+    echo "total_lbas_read_raw_value{"${labels}",smart_id=\"242\"} ${lbas_read}"
+    echo "power_cycle_count_raw_value{"${labels}",smart_id=\"12\"} ${power_cycle}"
+}
+
 parse_smartctl_info() {
   local -i smart_available=0 smart_enabled=0 smart_healthy=0
   local disk="$1" disk_type="$2"
@@ -141,5 +161,9 @@ for device in ${device_list}; do
   # Get the SMART information and health
   /usr/sbin/smartctl -i -H -d "${type}" "${disk}" | parse_smartctl_info "${disk}" "${type}"
   # Get the SMART attributes
-  /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}"
+  if [[ "${type}" == 'sat' ]] ; then
+    /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}"
+  else
+    /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}"
+  fi
 done | format_output

--- a/text_collector_examples/smartmon.sh
+++ b/text_collector_examples/smartmon.sh
@@ -161,9 +161,9 @@ for device in ${device_list}; do
   # Get the SMART information and health
   /usr/sbin/smartctl -i -H -d "${type}" "${disk}" | parse_smartctl_info "${disk}" "${type}"
   # Get the SMART attributes
-  if [[ "${type}" == 'sat' ]] ; then
-    /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}"
-  else
-    /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}"
-  fi
+  case ${type} in
+    sat) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}" ;;
+    scsi) /usr/sbin/smartctl -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
+    *) echo "disk type is not sat or scsi, ${type}"; exit ;;
+  esac
 done | format_output


### PR DESCRIPTION
output for scsi disk

$ /usr/sbin/smartctl -A -d scsi /dev/sdc
smartctl 6.5 2016-01-24 r4214 [x86_64-linux-4.4.0-92-generic] (local build)
Copyright (C) 2002-16, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF READ SMART DATA SECTION ===
Current Drive Temperature: 37 C
Drive Trip Temperature: 60 C

Manufactured in week 06 of year 2017
Specified cycle count over device lifetime: 10000
Accumulated start-stop cycles: 47
Specified load-unload count over device lifetime: 300000
Accumulated load-unload cycles: 177
Elements in grown defect list: 0

Vendor (Seagate) cache information
Blocks sent to initiator = 2400162880
Blocks received from initiator = 3175550757
Blocks read from cache and sent to initiator = 41978586
Number of read and write commands whose size <= segment size = 66660671
Number of read and write commands whose size > segment size = 1721079

Vendor (Seagate/Hitachi) factory information
number of hours powered up = 2831.72
number of minutes until next internal SMART test = 35

modify some values for exporting
Accumulated start-stop cycles -> power_cycle_count_raw_value
Blocks read from cache and sent to initiator -> total_lbas_read_raw_value
number of hours powered up -> power_on_hours_raw_value
Current Drive Temperature -> temperature_celsius_raw_value