### PR TITLE
Greatly reduce the metrics vmstat returns by default.

### DIFF
--- a/collector/vmstat_linux.go
+++ b/collector/vmstat_linux.go
@@ -19,17 +19,25 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 const (
 	vmStatSubsystem = "vmstat"
 )
 
-type vmStatCollector struct{}
+var (
+	vmStatFields = kingpin.Flag("collector.vmstat.fields", "Regexp of fields to return for vmstat collector.").Default("^(pgpg|pswp|pg.*fault).*").String()
+)
+
+type vmStatCollector struct {
+	fieldPattern *regexp.Regexp
+}
 
 func init() {
 	registerCollector("vmstat", defaultEnabled, NewvmStatCollector)
@@ -37,7 +45,10 @@ func init() {
 
 // NewvmStatCollector returns a new Collector exposing vmstat stats.
 func NewvmStatCollector() (Collector, error) {
-	return &vmStatCollector{}, nil
+	pattern := regexp.MustCompile(*vmStatFields)
+	return &vmStatCollector{
+		fieldPattern: pattern,
+	}, nil
 }
 
 func (c *vmStatCollector) Update(ch chan<- prometheus.Metric) error {
@@ -53,6 +64,9 @@ func (c *vmStatCollector) Update(ch chan<- prometheus.Metric) error {
 		value, err := strconv.ParseFloat(parts[1], 64)
 		if err != nil {
 			return err
+		}
+		if !c.fieldPattern.MatchString(parts[0]) {
+			continue
 		}
 
 		ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
Vmstat has over 100 fields, most of which are highly
detailed debug information. Trim this down to only
essential fields by default, configurable by flag.

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>

@SuperQ This knocks 112 metrics or 14% off a node exporter on my laptop. I think bar a few keys ones, these are too detailed to keep given how many there are.