### PR TITLE
Remove -race test flag to build on OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ else
 endif
 
 ifeq ($(GOHOSTARCH),amd64)
-        ifneq ($(OS_detected),SunOS)
+	ifeq ($(OS_detected),$(filter $(OS_detected),Linux FreeBSD Darwin Windows))
                 # Only supported on amd64
                 test-flags := -race
         endif


### PR DESCRIPTION
Without this change, running 'gmake' as the documentation does not finish the
build process to produce the binary.

Fixes: https://github.com/prometheus/node_exporter/issues/880