### PR TITLE
fix netdev collector for linux

### DIFF
--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -1745,6 +1745,24 @@ node_network_transmit_bytes_total{device="lxcbr0"} 2.630299e+06
 node_network_transmit_bytes_total{device="tun0"} 67120
 node_network_transmit_bytes_total{device="veth4B09XN"} 1.943284e+06
 node_network_transmit_bytes_total{device="wlan0"} 2.85164936e+09
+# HELP node_network_transmit_carrier_total Network device statistic transmit_carrier.
+# TYPE node_network_transmit_carrier_total counter
+node_network_transmit_carrier_total{device="docker0"} 0
+node_network_transmit_carrier_total{device="eth0"} 0
+node_network_transmit_carrier_total{device="lo"} 0
+node_network_transmit_carrier_total{device="lxcbr0"} 0
+node_network_transmit_carrier_total{device="tun0"} 0
+node_network_transmit_carrier_total{device="veth4B09XN"} 0
+node_network_transmit_carrier_total{device="wlan0"} 0
+# HELP node_network_transmit_colls_total Network device statistic transmit_colls.
+# TYPE node_network_transmit_colls_total counter
+node_network_transmit_colls_total{device="docker0"} 0
+node_network_transmit_colls_total{device="eth0"} 0
+node_network_transmit_colls_total{device="lo"} 0
+node_network_transmit_colls_total{device="lxcbr0"} 0
+node_network_transmit_colls_total{device="tun0"} 0
+node_network_transmit_colls_total{device="veth4B09XN"} 0
+node_network_transmit_colls_total{device="wlan0"} 0
 # HELP node_network_transmit_compressed_total Network device statistic transmit_compressed.
 # TYPE node_network_transmit_compressed_total counter
 node_network_transmit_compressed_total{device="docker0"} 0
@@ -1781,24 +1799,6 @@ node_network_transmit_fifo_total{device="lxcbr0"} 0
 node_network_transmit_fifo_total{device="tun0"} 0
 node_network_transmit_fifo_total{device="veth4B09XN"} 0
 node_network_transmit_fifo_total{device="wlan0"} 0
-# HELP node_network_transmit_frame_total Network device statistic transmit_frame.
-# TYPE node_network_transmit_frame_total counter
-node_network_transmit_frame_total{device="docker0"} 0
-node_network_transmit_frame_total{device="eth0"} 0
-node_network_transmit_frame_total{device="lo"} 0
-node_network_transmit_frame_total{device="lxcbr0"} 0
-node_network_transmit_frame_total{device="tun0"} 0
-node_network_transmit_frame_total{device="veth4B09XN"} 0
-node_network_transmit_frame_total{device="wlan0"} 0
-# HELP node_network_transmit_multicast_total Network device statistic transmit_multicast.
-# TYPE node_network_transmit_multicast_total counter
-node_network_transmit_multicast_total{device="docker0"} 0
-node_network_transmit_multicast_total{device="eth0"} 0
-node_network_transmit_multicast_total{device="lo"} 0
-node_network_transmit_multicast_total{device="lxcbr0"} 0
-node_network_transmit_multicast_total{device="tun0"} 0
-node_network_transmit_multicast_total{device="veth4B09XN"} 0
-node_network_transmit_multicast_total{device="wlan0"} 0
 # HELP node_network_transmit_packets_total Network device statistic transmit_packets.
 # TYPE node_network_transmit_packets_total counter
 node_network_transmit_packets_total{device="docker0"} 1.929779e+06

--- a/collector/netdev_linux.go
+++ b/collector/netdev_linux.go
@@ -50,12 +50,15 @@ func parseNetDevStats(r io.Reader, ignore *regexp.Regexp) (map[string]map[string
 			scanner.Text())
 	}
 
-	header := strings.Fields(parts[1])
+	receiveHeader := strings.Fields(parts[1])
+	transmitHeader := strings.Fields(parts[2])
+	headerLength := len(receiveHeader)+len(transmitHeader)+1
+
 	netDev := map[string]map[string]string{}
 	for scanner.Scan() {
 		line := strings.TrimLeft(scanner.Text(), " ")
 		parts := procNetDevFieldSep.Split(line, -1)
-		if len(parts) != 2*len(header)+1 {
+		if len(parts) != headerLength {
 			return nil, fmt.Errorf("invalid line in net/dev: %s", scanner.Text())
 		}
 
@@ -65,10 +68,13 @@ func parseNetDevStats(r io.Reader, ignore *regexp.Regexp) (map[string]map[string
 			continue
 		}
 		netDev[dev] = map[string]string{}
-		for i, v := range header {
-			netDev[dev]["receive_"+v] = parts[i+1]
-			netDev[dev]["transmit_"+v] = parts[i+1+len(header)]
-		}
+                for i := 0; i < len(receiveHeader); i++ {
+                        netDev[dev]["receive_"+receiveHeader[i]] = parts[i+1]
+                }
+
+                for i := 0; i < len(transmitHeader); i++ {
+                        netDev[dev]["transmit_"+transmitHeader[i]] = parts[i+1+len(receiveHeader)]
+                }
 	}
 	return netDev, scanner.Err()
 }


### PR DESCRIPTION
header for transmit traffic is differs from recieve, so we cannot use recieve header as transmit, now we can see carier and colls metrics in prometheus

```
root@dimon-note:~# cat /proc/net/dev
Inter-|   Receive                                                |  Transmit
 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
wlp3s0:  615351    3633    0    0    0     0          0         0   139984     968    0    0    0     0       0          0
    lo:  626743    3507    0    0    0     0          0         0   626743    3507    0    0    0     0       0          0
enp2s0: 137449283  136651    0    0    0     0          0      1718 32085642   98565    0    0    0     0       0          0
  tun0: 8585664   20643    0    0    0     0          0         0 14582735   24569    0    0    0     0       0          0
docker0:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0

```