### PR TITLE
Fix code style check in "all" make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ $(eval $(call goarch_pair,arm64,arm))
 $(eval $(call goarch_pair,mips64,mips))
 $(eval $(call goarch_pair,mips64el,mipsel))
 
-all: format vet staticcheck checkmetrics build test $(cross-test) $(test-e2e)
+all: style vet staticcheck checkmetrics build test $(cross-test) $(test-e2e)
 
 style:
 	@echo ">> checking code style"


### PR DESCRIPTION
The all target should abort on incorrectly formatted code, instead of
formatting it. The CI pipeline should fail and not silently accept
wrong code.

Signed-off-by: Tobias Schmidt <tobidt@gmail.com>

This regression was introduced in 158200f.