### PR TITLE
Cleanup sys fixtures before unpacking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ skip-test-32bit:
 
 collector/fixtures/sys/.unpacked: collector/fixtures/sys.ttar
 	@echo ">> extracting sysfs fixtures"
+	if [ -d collector/fixtures/sys ] ; then rm -r collector/fixtures/sys ; fi
 	./ttar -C collector/fixtures -x -f collector/fixtures/sys.ttar
 	touch $@
 


### PR DESCRIPTION
Make sure we cleanup the sys fixtures before unpacking to avoid obsolete
files and conflicts from sticking around.

Closes: https://github.com/prometheus/node_exporter/issues/892