### PR TITLE
Use Go 1.9 for build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     - checkout
     - run: make promu
-    - run: promu crossbuild -v
+    - run: promu crossbuild -v --go 1.9
     - persist_to_workspace:
         root: .
         paths:


### PR DESCRIPTION
Workaround CGO bugs in 1.10.1.