### PR TITLE
Fix some golint issues

### DIFF
--- a/collector/cpu_common.go
+++ b/collector/cpu_common.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	nodeCpuSecondsDesc = prometheus.NewDesc(
+	nodeCPUSecondsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "seconds_total"),
 		"Seconds the cpus spent in each mode.",
 		[]string{"cpu", "mode"}, nil,

--- a/collector/cpu_darwin.go
+++ b/collector/cpu_darwin.go
@@ -59,7 +59,7 @@ func init() {
 // NewCPUCollector returns a new Collector exposing CPU stats.
 func NewCPUCollector() (Collector, error) {
 	return &statCollector{
-		cpu: nodeCpuSecondsDesc,
+		cpu: nodeCPUSecondsDesc,
 	}, nil
 }
 

--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -94,7 +94,7 @@ func init() {
 // NewStatCollector returns a new Collector exposing CPU stats.
 func NewStatCollector() (Collector, error) {
 	return &statCollector{
-		cpu: nodeCpuSecondsDesc,
+		cpu: nodeCPUSecondsDesc,
 	}, nil
 }
 

--- a/collector/cpu_freebsd.go
+++ b/collector/cpu_freebsd.go
@@ -92,7 +92,7 @@ func init() {
 // NewStatCollector returns a new Collector exposing CPU stats.
 func NewStatCollector() (Collector, error) {
 	return &statCollector{
-		cpu: typedDesc{nodeCpuSecondsDesc, prometheus.CounterValue},
+		cpu: typedDesc{nodeCPUSecondsDesc, prometheus.CounterValue},
 		temp: typedDesc{prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "temperature_celsius"),
 			"CPU temperature",

--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -185,8 +185,8 @@ func (c *cpuCollector) updateCPUfreq(ch chan<- prometheus.Metric) error {
 			strconv.FormatUint(physicalPackageID, 10))
 	}
 
-	for physicalPackageID, core_map := range packageCoreThrottles {
-		for coreID, coreThrottleCount := range core_map {
+	for physicalPackageID, coreMap := range packageCoreThrottles {
+		for coreID, coreThrottleCount := range coreMap {
 			ch <- prometheus.MustNewConstMetric(c.cpuCoreThrottle,
 				prometheus.CounterValue,
 				float64(coreThrottleCount),

--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -49,7 +49,7 @@ func init() {
 // NewCPUCollector returns a new Collector exposing kernel/system statistics.
 func NewCPUCollector() (Collector, error) {
 	return &cpuCollector{
-		cpu: nodeCpuSecondsDesc,
+		cpu: nodeCPUSecondsDesc,
 		cpuGuest: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "guest_seconds_total"),
 			"Seconds the cpus spent in guests (VMs) for each mode.",

--- a/collector/cpu_openbsd.go
+++ b/collector/cpu_openbsd.go
@@ -39,7 +39,7 @@ func init() {
 
 func NewCpuCollector() (Collector, error) {
 	return &cpuCollector{
-		cpu: typedDesc{nodeCpuSecondsDesc, prometheus.CounterValue},
+		cpu: typedDesc{nodeCPUSecondsDesc, prometheus.CounterValue},
 	}, nil
 }
 

--- a/collector/qdisc_linux.go
+++ b/collector/qdisc_linux.go
@@ -41,6 +41,7 @@ func init() {
 	registerCollector("qdisc", defaultDisabled, NewQdiscStatCollector)
 }
 
+// NewQdiscStatCollector returns a new Collector exposing queuing discipline statistics.
 func NewQdiscStatCollector() (Collector, error) {
 	return &qdiscStatCollector{
 		bytes: typedDesc{prometheus.NewDesc(


### PR DESCRIPTION
Hi @SuperQ,

I fixed some trivial [golint](https://github.com/golang/lint) issues. See,

```
collector/cpu_common.go:27:2:warning: var nodeCpuSecondsDesc should be nodeCPUSecondsDesc (golint)
collector/cpu_linux.go:188:25:warning: don't use underscores in Go names; range var core_map should be coreMap (golint)
collector/qdisc_linux.go:44:1:warning: exported function NewQdiscStatCollector should have comment or be unexported (golint)
```