### PR TITLE
remove or comment unused func, var, and const

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -42,10 +42,6 @@ var (
 	)
 )
 
-func warnDeprecated(collector string) {
-	log.Warnf("The %s collector is deprecated and will be removed in the future!", collector)
-}
-
 const (
 	defaultEnabled  = true
 	defaultDisabled = false

--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -19,17 +19,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/procfs"
-)
-
-var (
-	digitRegexp = regexp.MustCompile("[0-9]+")
 )
 
 type cpuCollector struct {

--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -34,7 +33,6 @@ import (
 
 var (
 	textFileDirectory = kingpin.Flag("collector.textfile.directory", "Directory to read text files with metrics from.").Default("").String()
-	textFileAddOnce   sync.Once
 	mtimeDesc         = prometheus.NewDesc(
 		"node_textfile_mtime_seconds",
 		"Unixtime mtime of textfiles successfully read.",


### PR DESCRIPTION
Hi @SuperQ,

I removed and commented out some **unused** functions, variables, and constants.

See,
```
$ gometalinter --enable-gc --vendor --deadline 10m --disable-all --enable=unused ./...
collector/collector.go:45:6:warning: func warnDeprecated is unused (U1000) (unused)
collector/cpu_linux.go:32:2:warning: var digitRegexp is unused (U1000) (unused)
collector/supervisord.go:84:3:warning: const STOPPED is unused (U1000) (unused)
collector/supervisord.go:87:3:warning: const BACKOFF is unused (U1000) (unused)
collector/supervisord.go:89:3:warning: const EXITED is unused (U1000) (unused)
collector/supervisord.go:90:3:warning: const FATAL is unused (U1000) (unused)
collector/supervisord.go:91:3:warning: const UNKNOWN is unused (U1000) (unused)
collector/textfile.go:37:2:warning: var textFileAddOnce is unused (U1000) (unused)
```