### PR TITLE
Fix metric name in directory size text collector example

### DIFF
--- a/text_collector_examples/directory-size.sh
+++ b/text_collector_examples/directory-size.sh
@@ -9,7 +9,7 @@
 # sed pattern taken from https://www.robustperception.io/monitoring-directory-sizes-with-the-textfile-collector/
 #
 # Author: Antoine Beaupré <anarcat@debian.org>
-echo "# HELP anarcat_dir_space_bytes Disk space used by some directories"
-echo "# TYPE anarcat_dir_space_bytes gauge"
+echo "# HELP node_directory_size_bytes Disk space used by some directories"
+echo "# TYPE node_directory_size_bytes gauge"
 du --block-size=1 --summarize "$@" \
   | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/node_directory_size_bytes{directory="\2"} \1/p'


### PR DESCRIPTION
The directory size text collector example uses the wrong metric name in the HELP and TYPE lines rendering the comments unusable.

This fixes that by using the same metric name.

@SuperQ 