### PR TITLE
Fix for #945, cpu temperature is signed.

### DIFF
--- a/collector/cpu_freebsd.go
+++ b/collector/cpu_freebsd.go
@@ -140,7 +140,7 @@ func (c *statCollector) Update(ch chan<- prometheus.Metric) error {
 		}
 
 		// Temp is a signed integer in deci-degrees Kelvin.
-		// Cast uint32 to int32 and convert to float64 degrees Celcius.
+		// Cast uint32 to int32 and convert to float64 degrees Celsius.
 		//
 		// 2732 is used as the conversion constant for deci-degrees
 		// Kelvin, in multiple places in the kernel that feed into this

--- a/collector/cpu_freebsd.go
+++ b/collector/cpu_freebsd.go
@@ -139,10 +139,10 @@ func (c *statCollector) Update(ch chan<- prometheus.Metric) error {
 			continue
 		}
 
-		// Temp is a signed integer in centi-degrees Kelvin.
+		// Temp is a signed integer in deci-degrees Kelvin.
 		// Cast uint32 to int32 and convert to float64 degrees Celcius.
 		//
-		// 2732 is used as the conversion constant in for centi-degrees
+		// 2732 is used as the conversion constant for deci-degrees
 		// Kelvin, in multiple places in the kernel that feed into this
 		// sysctl, so we want to maintain consistency:
 		//

--- a/collector/cpu_freebsd.go
+++ b/collector/cpu_freebsd.go
@@ -138,7 +138,22 @@ func (c *statCollector) Update(ch chan<- prometheus.Metric) error {
 			}
 			continue
 		}
-		// Sysctl temp is an signed integer, so we do the conversion.
+
+		// Temp is a signed integer in centi-degrees Kelvin.
+		// Cast uint32 to int32 and convert to float64 degrees Celcius.
+		//
+		// 2732 is used as the conversion constant in for centi-degrees
+		// Kelvin, in multiple places in the kernel that feed into this
+		// sysctl, so we want to maintain consistency:
+		//
+		// sys/dev/amdtemp/amdtemp.c
+		//   #define AMDTEMP_ZERO_C_TO_K 2732
+		//
+		// sys/dev/acpica/acpi_thermal.c
+		//   #define TZ_ZEROC            2732
+		//
+		// sys/dev/coretemp/coretemp.c
+		//   #define TZ_ZEROC            2732
 		ch <- c.temp.mustNewConstMetric(float64(int32(temp)-2732)/10, lcpu)
 	}
 	return err

--- a/collector/cpu_freebsd.go
+++ b/collector/cpu_freebsd.go
@@ -138,7 +138,8 @@ func (c *statCollector) Update(ch chan<- prometheus.Metric) error {
 			}
 			continue
 		}
-		ch <- c.temp.mustNewConstMetric(float64(temp-2732)/10, lcpu)
+		// Sysctl temp is an signed integer, so we do the conversion.
+		ch <- c.temp.mustNewConstMetric(float64(int32(temp)-2732)/10, lcpu)
 	}
 	return err
 }


### PR DESCRIPTION
Added a type conversion to cpu temperature sysctl.  Will still collect/report -1 when the value is -1, this is because it should be up to interpretation whether this is the correct value for the system or not.

Some drivers will report -1 for cpu temperature.  Other sensors will report "an input into the fan control algorithm", i.e. not the actual temperature, but how much fan it wants.  Some people cool their machines
with liquid nitrogen.

Closes: https://github.com/prometheus/node_exporter/issues/945