### PR TITLE
Add support for NRestarts counter introduced in systemd 235

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Breaking changes**
 
-* [CHANGE]
+* [CHANGE] Collect NRestarts property for systemd service units
 * [FEATURE]
 * [ENHANCEMENT]
 * [BUGFIX]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 **Breaking changes**
 
-* [CHANGE] Collect NRestarts property for systemd service units
-* [FEATURE]
+* [CHANGE]
+* [FEATURE] Collect NRestarts property for systemd service units
 * [ENHANCEMENT]
 * [BUGFIX]
 


### PR DESCRIPTION
`.service` units increment this counter any time the Restart= condition is
triggered.