### PR TITLE
Use /proc/mounts instead of statfs(2) for ro state

### DIFF
--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -51,7 +51,7 @@ type filesystemCollector struct {
 }
 
 type filesystemLabels struct {
-	device, mountPoint, fsType string
+	device, mountPoint, fsType, options string
 }
 
 type filesystemStats struct {

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -59,8 +59,11 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 		}
 
 		var ro float64
-		if (buf.Flags & readOnly) != 0 {
-			ro = 1
+		for _, option := range strings.Split(labels.options, ",") {
+			if option == "ro" {
+				ro = 1
+				break
+			}
 		}
 
 		stats = append(stats, filesystemStats{
@@ -97,6 +100,7 @@ func mountPointDetails() ([]filesystemLabels, error) {
 			device:     parts[0],
 			mountPoint: parts[1],
 			fsType:     parts[2],
+			options:    parts[3],
 		})
 	}
 	return filesystems, scanner.Err()


### PR DESCRIPTION
Fixes #591 with the approach discussed by @SuperQ and @discordianfish

I verified that this exports correctly on a very troubled test machine.