### PR TITLE
Exclude only subdirectories of /var/lib/docker

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	defIgnoredMountPoints = "^/(dev|proc|sys|var/lib/docker)($|/)"
+	defIgnoredMountPoints = "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
 	defIgnoredFSTypes     = "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
 	readOnly              = 0x1 // ST_RDONLY
 	mountTimeout          = 30 * time.Second


### PR DESCRIPTION
It is quite common to put /var/lib/docker itself on a separate partition and that should be monitored as well.

This would resolve #1000.