### PR TITLE
Add instance label

### DIFF
--- a/collector/arp_linux.go
+++ b/collector/arp_linux.go
@@ -36,7 +36,7 @@ func init() {
 // NewARPCollector returns a new Collector exposing ARP stats.
 func NewARPCollector() (Collector, error) {
 	return &arpCollector{
-		entries: prometheus.NewDesc(
+		entries: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "arp", "entries"),
 			"ARP entries by device",
 			[]string{"device"}, nil,

--- a/collector/bcache_linux.go
+++ b/collector/bcache_linux.go
@@ -282,7 +282,7 @@ func (c *bcacheCollector) updateBcacheStats(ch chan<- prometheus.Metric, s *bcac
 	for _, m := range allMetrics {
 		labels := append(devLabel, m.extraLabel...)
 
-		desc := prometheus.NewDesc(
+		desc := PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, m.name),
 			m.desc,
 			labels,

--- a/collector/bonding_linux.go
+++ b/collector/bonding_linux.go
@@ -38,12 +38,12 @@ func init() {
 // It exposes the number of configured and active slave of linux bonding interfaces.
 func NewBondingCollector() (Collector, error) {
 	return &bondingCollector{
-		slaves: typedDesc{prometheus.NewDesc(
+		slaves: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "bonding", "slaves"),
 			"Number of configured slaves per bonding interface.",
 			[]string{"master"}, nil,
 		), prometheus.GaugeValue},
-		active: typedDesc{prometheus.NewDesc(
+		active: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "bonding", "active"),
 			"Number of active slaves per bonding interface.",
 			[]string{"master"}, nil,

--- a/collector/boot_time_bsd.go
+++ b/collector/boot_time_bsd.go
@@ -46,7 +46,7 @@ func (c *bootTimeCollector) Update(ch chan<- prometheus.Metric) error {
 	}
 
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "", c.boottime.name),
 			c.boottime.description,
 			nil, nil,

--- a/collector/buddyinfo.go
+++ b/collector/buddyinfo.go
@@ -39,7 +39,7 @@ func init() {
 
 // NewBuddyinfoCollector returns a new Collector exposing buddyinfo stats.
 func NewBuddyinfoCollector() (Collector, error) {
-	desc := prometheus.NewDesc(
+	desc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, buddyInfoSubsystem, "blocks"),
 		"Count of free blocks according to size.",
 		[]string{"node", "zone", "size"}, nil,

--- a/collector/conntrack_linux.go
+++ b/collector/conntrack_linux.go
@@ -31,12 +31,12 @@ func init() {
 // NewConntrackCollector returns a new Collector exposing conntrack stats.
 func NewConntrackCollector() (Collector, error) {
 	return &conntrackCollector{
-		current: prometheus.NewDesc(
+		current: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "", "nf_conntrack_entries"),
 			"Number of currently allocated flow entries for connection tracking.",
 			nil, nil,
 		),
-		limit: prometheus.NewDesc(
+		limit: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "", "nf_conntrack_entries_limit"),
 			"Maximum size of connection tracking table.",
 			nil, nil,

--- a/collector/cpu_common.go
+++ b/collector/cpu_common.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	nodeCPUSecondsDesc = prometheus.NewDesc(
+	nodeCPUSecondsDesc = PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "seconds_total"),
 		"Seconds the cpus spent in each mode.",
 		[]string{"cpu", "mode"}, nil,

--- a/collector/cpu_freebsd.go
+++ b/collector/cpu_freebsd.go
@@ -93,7 +93,7 @@ func init() {
 func NewStatCollector() (Collector, error) {
 	return &statCollector{
 		cpu: typedDesc{nodeCPUSecondsDesc, prometheus.CounterValue},
-		temp: typedDesc{prometheus.NewDesc(
+		temp: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "temperature_celsius"),
 			"CPU temperature",
 			[]string{"cpu"}, nil,

--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -45,32 +45,32 @@ func init() {
 func NewCPUCollector() (Collector, error) {
 	return &cpuCollector{
 		cpu: nodeCPUSecondsDesc,
-		cpuGuest: prometheus.NewDesc(
+		cpuGuest: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "guest_seconds_total"),
 			"Seconds the cpus spent in guests (VMs) for each mode.",
 			[]string{"cpu", "mode"}, nil,
 		),
-		cpuFreq: prometheus.NewDesc(
+		cpuFreq: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "frequency_hertz"),
 			"Current cpu thread frequency in hertz.",
 			[]string{"cpu"}, nil,
 		),
-		cpuFreqMin: prometheus.NewDesc(
+		cpuFreqMin: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "frequency_min_hertz"),
 			"Minimum cpu thread frequency in hertz.",
 			[]string{"cpu"}, nil,
 		),
-		cpuFreqMax: prometheus.NewDesc(
+		cpuFreqMax: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "frequency_max_hertz"),
 			"Maximum cpu thread frequency in hertz.",
 			[]string{"cpu"}, nil,
 		),
-		cpuCoreThrottle: prometheus.NewDesc(
+		cpuCoreThrottle: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "core_throttles_total"),
 			"Number of times this cpu core has been throttled.",
 			[]string{"package", "core"}, nil,
 		),
-		cpuPackageThrottle: prometheus.NewDesc(
+		cpuPackageThrottle: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "package_throttles_total"),
 			"Number of times this cpu package has been throttled.",
 			[]string{"package"}, nil,

--- a/collector/devstat_dragonfly.go
+++ b/collector/devstat_dragonfly.go
@@ -105,17 +105,17 @@ func init() {
 // NewDevstatCollector returns a new Collector exposing Device stats.
 func NewDevstatCollector() (Collector, error) {
 	return &devstatCollector{
-		bytesDesc: prometheus.NewDesc(
+		bytesDesc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, devstatSubsystem, "bytes_total"),
 			"The total number of bytes transferred for reads and writes on the device.",
 			[]string{"device"}, nil,
 		),
-		transfersDesc: prometheus.NewDesc(
+		transfersDesc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, devstatSubsystem, "transfers_total"),
 			"The total number of transactions completed.",
 			[]string{"device"}, nil,
 		),
-		blocksDesc: prometheus.NewDesc(
+		blocksDesc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, devstatSubsystem, "blocks_total"),
 			"The total number of bytes given in terms of the devices blocksize.",
 			[]string{"device"}, nil,

--- a/collector/devstat_freebsd.go
+++ b/collector/devstat_freebsd.go
@@ -51,27 +51,27 @@ func init() {
 func NewDevstatCollector() (Collector, error) {
 	return &devstatCollector{
 		devinfo: &C.struct_devinfo{},
-		bytes: typedDesc{prometheus.NewDesc(
+		bytes: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, devstatSubsystem, "bytes_total"),
 			"The total number of bytes in transactions.",
 			[]string{"device", "type"}, nil,
 		), prometheus.CounterValue},
-		transfers: typedDesc{prometheus.NewDesc(
+		transfers: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, devstatSubsystem, "transfers_total"),
 			"The total number of transactions.",
 			[]string{"device", "type"}, nil,
 		), prometheus.CounterValue},
-		duration: typedDesc{prometheus.NewDesc(
+		duration: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, devstatSubsystem, "duration_seconds_total"),
 			"The total duration of transactions in seconds.",
 			[]string{"device", "type"}, nil,
 		), prometheus.CounterValue},
-		busyTime: typedDesc{prometheus.NewDesc(
+		busyTime: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, devstatSubsystem, "busy_time_seconds_total"),
 			"Total time the device had one or more transactions outstanding in seconds.",
 			[]string{"device"}, nil,
 		), prometheus.CounterValue},
-		blocks: typedDesc{prometheus.NewDesc(
+		blocks: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, devstatSubsystem, "blocks_transferred_total"),
 			"The total number of blocks transferred.",
 			[]string{"device"}, nil,

--- a/collector/diskstats_darwin.go
+++ b/collector/diskstats_darwin.go
@@ -47,7 +47,7 @@ func NewDiskstatsCollector() (Collector, error) {
 		descs: []typedDescFunc{
 			{
 				typedDesc: typedDesc{
-					desc: prometheus.NewDesc(
+					desc: PrometheusNewDesc(
 						prometheus.BuildFQName(namespace, diskSubsystem, "reads_completed_total"),
 						"The total number of reads completed successfully.",
 						diskLabelNames,
@@ -61,7 +61,7 @@ func NewDiskstatsCollector() (Collector, error) {
 			},
 			{
 				typedDesc: typedDesc{
-					desc: prometheus.NewDesc(
+					desc: PrometheusNewDesc(
 						prometheus.BuildFQName(namespace, diskSubsystem, "read_sectors_total"),
 						"The total number of sectors read successfully.",
 						diskLabelNames,
@@ -75,7 +75,7 @@ func NewDiskstatsCollector() (Collector, error) {
 			},
 			{
 				typedDesc: typedDesc{
-					desc: prometheus.NewDesc(
+					desc: PrometheusNewDesc(
 						prometheus.BuildFQName(namespace, diskSubsystem, "read_time_seconds_total"),
 						"The total number of seconds spent by all reads.",
 						diskLabelNames,
@@ -89,7 +89,7 @@ func NewDiskstatsCollector() (Collector, error) {
 			},
 			{
 				typedDesc: typedDesc{
-					desc: prometheus.NewDesc(
+					desc: PrometheusNewDesc(
 						prometheus.BuildFQName(namespace, diskSubsystem, "writes_completed_total"),
 						"The total number of writes completed successfully.",
 						diskLabelNames,
@@ -103,7 +103,7 @@ func NewDiskstatsCollector() (Collector, error) {
 			},
 			{
 				typedDesc: typedDesc{
-					desc: prometheus.NewDesc(
+					desc: PrometheusNewDesc(
 						prometheus.BuildFQName(namespace, diskSubsystem, "written_sectors_total"),
 						"The total number of sectors written successfully.",
 						diskLabelNames,
@@ -117,7 +117,7 @@ func NewDiskstatsCollector() (Collector, error) {
 			},
 			{
 				typedDesc: typedDesc{
-					desc: prometheus.NewDesc(
+					desc: PrometheusNewDesc(
 						prometheus.BuildFQName(namespace, diskSubsystem, "write_time_seconds_total"),
 						"This is the total number of seconds spent by all writes.",
 						diskLabelNames,
@@ -131,7 +131,7 @@ func NewDiskstatsCollector() (Collector, error) {
 			},
 			{
 				typedDesc: typedDesc{
-					desc: prometheus.NewDesc(
+					desc: PrometheusNewDesc(
 						prometheus.BuildFQName(namespace, diskSubsystem, "read_bytes_total"),
 						"The total number of bytes read successfully.",
 						diskLabelNames,
@@ -145,7 +145,7 @@ func NewDiskstatsCollector() (Collector, error) {
 			},
 			{
 				typedDesc: typedDesc{
-					desc: prometheus.NewDesc(
+					desc: PrometheusNewDesc(
 						prometheus.BuildFQName(namespace, diskSubsystem, "written_bytes_total"),
 						"The total number of bytes written successfully.",
 						diskLabelNames,

--- a/collector/diskstats_linux.go
+++ b/collector/diskstats_linux.go
@@ -69,7 +69,7 @@ func NewDiskstatsCollector() (Collector, error) {
 		// Docs from https://www.kernel.org/doc/Documentation/iostats.txt
 		descs: []typedFactorDesc{
 			{
-				desc: prometheus.NewDesc(
+				desc: PrometheusNewDesc(
 					prometheus.BuildFQName(namespace, diskSubsystem, "reads_completed_total"),
 					"The total number of reads completed successfully.",
 					diskLabelNames,
@@ -77,7 +77,7 @@ func NewDiskstatsCollector() (Collector, error) {
 				), valueType: prometheus.CounterValue,
 			},
 			{
-				desc: prometheus.NewDesc(
+				desc: PrometheusNewDesc(
 					prometheus.BuildFQName(namespace, diskSubsystem, "reads_merged_total"),
 					"The total number of reads merged. See https://www.kernel.org/doc/Documentation/iostats.txt.",
 					diskLabelNames,
@@ -85,7 +85,7 @@ func NewDiskstatsCollector() (Collector, error) {
 				), valueType: prometheus.CounterValue,
 			},
 			{
-				desc: prometheus.NewDesc(
+				desc: PrometheusNewDesc(
 					prometheus.BuildFQName(namespace, diskSubsystem, "read_bytes_total"),
 					"The total number of bytes read successfully.",
 					diskLabelNames,
@@ -94,7 +94,7 @@ func NewDiskstatsCollector() (Collector, error) {
 				factor: diskSectorSize,
 			},
 			{
-				desc: prometheus.NewDesc(
+				desc: PrometheusNewDesc(
 					prometheus.BuildFQName(namespace, diskSubsystem, "read_time_seconds_total"),
 					"The total number of milliseconds spent by all reads.",
 					diskLabelNames,
@@ -103,7 +103,7 @@ func NewDiskstatsCollector() (Collector, error) {
 				factor: .001,
 			},
 			{
-				desc: prometheus.NewDesc(
+				desc: PrometheusNewDesc(
 					prometheus.BuildFQName(namespace, diskSubsystem, "writes_completed_total"),
 					"The total number of writes completed successfully.",
 					diskLabelNames,
@@ -111,7 +111,7 @@ func NewDiskstatsCollector() (Collector, error) {
 				), valueType: prometheus.CounterValue,
 			},
 			{
-				desc: prometheus.NewDesc(
+				desc: PrometheusNewDesc(
 					prometheus.BuildFQName(namespace, diskSubsystem, "writes_merged_total"),
 					"The number of writes merged. See https://www.kernel.org/doc/Documentation/iostats.txt.",
 					diskLabelNames,
@@ -119,7 +119,7 @@ func NewDiskstatsCollector() (Collector, error) {
 				), valueType: prometheus.CounterValue,
 			},
 			{
-				desc: prometheus.NewDesc(
+				desc: PrometheusNewDesc(
 					prometheus.BuildFQName(namespace, diskSubsystem, "written_bytes_total"),
 					"The total number of bytes written successfully.",
 					diskLabelNames,
@@ -128,7 +128,7 @@ func NewDiskstatsCollector() (Collector, error) {
 				factor: diskSectorSize,
 			},
 			{
-				desc: prometheus.NewDesc(
+				desc: PrometheusNewDesc(
 					prometheus.BuildFQName(namespace, diskSubsystem, "write_time_seconds_total"),
 					"This is the total number of seconds spent by all writes.",
 					diskLabelNames,
@@ -137,7 +137,7 @@ func NewDiskstatsCollector() (Collector, error) {
 				factor: .001,
 			},
 			{
-				desc: prometheus.NewDesc(
+				desc: PrometheusNewDesc(
 					prometheus.BuildFQName(namespace, diskSubsystem, "io_now"),
 					"The number of I/Os currently in progress.",
 					diskLabelNames,
@@ -145,7 +145,7 @@ func NewDiskstatsCollector() (Collector, error) {
 				), valueType: prometheus.GaugeValue,
 			},
 			{
-				desc: prometheus.NewDesc(
+				desc: PrometheusNewDesc(
 					prometheus.BuildFQName(namespace, diskSubsystem, "io_time_seconds_total"),
 					"Total seconds spent doing I/Os.",
 					diskLabelNames,
@@ -154,7 +154,7 @@ func NewDiskstatsCollector() (Collector, error) {
 				factor: .001,
 			},
 			{
-				desc: prometheus.NewDesc(
+				desc: PrometheusNewDesc(
 					prometheus.BuildFQName(namespace, diskSubsystem, "io_time_weighted_seconds_total"),
 					"The weighted # of seconds spent doing I/Os. See https://www.kernel.org/doc/Documentation/iostats.txt.",
 					diskLabelNames,

--- a/collector/drbd_linux.go
+++ b/collector/drbd_linux.go
@@ -33,7 +33,7 @@ type drbdNumericalMetric struct {
 
 func newDRBDNumericalMetric(name string, desc string, valueType prometheus.ValueType, multiplier float64) drbdNumericalMetric {
 	return drbdNumericalMetric{
-		desc: prometheus.NewDesc(
+		desc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "drbd", name),
 			desc,
 			[]string{"device"}, nil),
@@ -57,7 +57,7 @@ func (metric *drbdStringPairMetric) isOkay(value string) float64 {
 
 func newDRBDStringPairMetric(name string, desc string, valueOkay string) drbdStringPairMetric {
 	return drbdStringPairMetric{
-		desc: prometheus.NewDesc(
+		desc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "drbd", name),
 			desc,
 			[]string{"device", "node"}, nil),
@@ -139,7 +139,7 @@ var (
 			"UpToDate"),
 	}
 
-	drbdConnected = prometheus.NewDesc(
+	drbdConnected = PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, "drbd", "connected"),
 		"Whether DRBD is connected to the peer.",
 		[]string{"device"}, nil)

--- a/collector/edac_linux.go
+++ b/collector/edac_linux.go
@@ -47,22 +47,22 @@ func init() {
 // NewEdacCollector returns a new Collector exposing edac stats.
 func NewEdacCollector() (Collector, error) {
 	return &edacCollector{
-		ceCount: prometheus.NewDesc(
+		ceCount: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, edacSubsystem, "correctable_errors_total"),
 			"Total correctable memory errors.",
 			[]string{"controller"}, nil,
 		),
-		ueCount: prometheus.NewDesc(
+		ueCount: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, edacSubsystem, "uncorrectable_errors_total"),
 			"Total uncorrectable memory errors.",
 			[]string{"controller"}, nil,
 		),
-		csRowCECount: prometheus.NewDesc(
+		csRowCECount: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, edacSubsystem, "csrow_correctable_errors_total"),
 			"Total correctable memory errors for this csrow.",
 			[]string{"controller", "csrow"}, nil,
 		),
-		csRowUECount: prometheus.NewDesc(
+		csRowUECount: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, edacSubsystem, "csrow_uncorrectable_errors_total"),
 			"Total uncorrectable memory errors for this csrow.",
 			[]string{"controller", "csrow"}, nil,

--- a/collector/entropy_linux.go
+++ b/collector/entropy_linux.go
@@ -32,7 +32,7 @@ func init() {
 // NewEntropyCollector returns a new Collector exposing entropy stats.
 func NewEntropyCollector() (Collector, error) {
 	return &entropyCollector{
-		entropyAvail: prometheus.NewDesc(
+		entropyAvail: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "", "entropy_available_bits"),
 			"Bits of available entropy.",
 			nil, nil,

--- a/collector/exec_bsd.go
+++ b/collector/exec_bsd.go
@@ -85,7 +85,7 @@ func (c *execCollector) Update(ch chan<- prometheus.Metric) error {
 		}
 
 		ch <- prometheus.MustNewConstMetric(
-			prometheus.NewDesc(
+			PrometheusNewDesc(
 				namespace+"_"+m.name,
 				m.description,
 				nil, nil,

--- a/collector/filefd_linux.go
+++ b/collector/filefd_linux.go
@@ -51,7 +51,7 @@ func (c *fileFDStatCollector) Update(ch chan<- prometheus.Metric) error {
 			return fmt.Errorf("invalid value %s in file-nr: %s", value, err)
 		}
 		ch <- prometheus.MustNewConstMetric(
-			prometheus.NewDesc(
+			PrometheusNewDesc(
 				prometheus.BuildFQName(namespace, fileFDStatSubsystem, name),
 				fmt.Sprintf("File descriptor statistics: %s.", name),
 				nil, nil,

--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -71,43 +71,43 @@ func NewFilesystemCollector() (Collector, error) {
 	mountPointPattern := regexp.MustCompile(*ignoredMountPoints)
 	filesystemsTypesPattern := regexp.MustCompile(*ignoredFSTypes)
 
-	sizeDesc := prometheus.NewDesc(
+	sizeDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "size_bytes"),
 		"Filesystem size in bytes.",
 		filesystemLabelNames, nil,
 	)
 
-	freeDesc := prometheus.NewDesc(
+	freeDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "free_bytes"),
 		"Filesystem free space in bytes.",
 		filesystemLabelNames, nil,
 	)
 
-	availDesc := prometheus.NewDesc(
+	availDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "avail_bytes"),
 		"Filesystem space available to non-root users in bytes.",
 		filesystemLabelNames, nil,
 	)
 
-	filesDesc := prometheus.NewDesc(
+	filesDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "files"),
 		"Filesystem total file nodes.",
 		filesystemLabelNames, nil,
 	)
 
-	filesFreeDesc := prometheus.NewDesc(
+	filesFreeDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "files_free"),
 		"Filesystem total free file nodes.",
 		filesystemLabelNames, nil,
 	)
 
-	roDesc := prometheus.NewDesc(
+	roDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "readonly"),
 		"Filesystem read-only status.",
 		filesystemLabelNames, nil,
 	)
 
-	deviceErrorDesc := prometheus.NewDesc(
+	deviceErrorDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "device_error"),
 		"Whether an error occurred while getting statistics for the given device.",
 		filesystemLabelNames, nil,

--- a/collector/hwmon_linux.go
+++ b/collector/hwmon_linux.go
@@ -167,7 +167,7 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) er
 	hwmonChipName, err := c.hwmonHumanReadableChipName(dir)
 	if err == nil {
 		// sensor chip metadata
-		desc := prometheus.NewDesc(
+		desc := PrometheusNewDesc(
 			"node_hwmon_chip_names",
 			"Annotation metric for human-readable chip names",
 			hwmonChipNameLabelDesc,
@@ -192,7 +192,7 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) er
 		if labelText, ok := sensorData["label"]; ok {
 			label := cleanMetricName(labelText)
 			if label != "" {
-				desc := prometheus.NewDesc("node_hwmon_sensor_label", "Label for given chip and sensor",
+				desc := PrometheusNewDesc("node_hwmon_sensor_label", "Label for given chip and sensor",
 					[]string{"chip", "sensor", "label"}, nil)
 				ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, 1.0, hwmonName, sensor, label)
 			}
@@ -204,7 +204,7 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) er
 				value = 1.0
 			}
 			metricName := "node_hwmon_beep_enabled"
-			desc := prometheus.NewDesc(metricName, "Hardware beep enabled", hwmonLabelDesc, nil)
+			desc := PrometheusNewDesc(metricName, "Hardware beep enabled", hwmonLabelDesc, nil)
 			ch <- prometheus.MustNewConstMetric(
 				desc, prometheus.GaugeValue, value, labels...)
 			continue
@@ -215,7 +215,7 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) er
 				continue
 			}
 			metricName := "node_hwmon_voltage_regulator_version"
-			desc := prometheus.NewDesc(metricName, "Hardware voltage regulator", hwmonLabelDesc, nil)
+			desc := PrometheusNewDesc(metricName, "Hardware voltage regulator", hwmonLabelDesc, nil)
 			ch <- prometheus.MustNewConstMetric(
 				desc, prometheus.GaugeValue, parsedValue, labels...)
 			continue
@@ -226,7 +226,7 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) er
 				continue
 			}
 			metricName := "node_hwmon_update_interval_seconds"
-			desc := prometheus.NewDesc(metricName, "Hardware monitor update interval", hwmonLabelDesc, nil)
+			desc := PrometheusNewDesc(metricName, "Hardware monitor update interval", hwmonLabelDesc, nil)
 			ch <- prometheus.MustNewConstMetric(
 				desc, prometheus.GaugeValue, parsedValue*0.001, labels...)
 			continue
@@ -256,69 +256,69 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) er
 
 			// special elements, fault, alarm & beep should be handed out without units
 			if element == "fault" || element == "alarm" {
-				desc := prometheus.NewDesc(name, "Hardware sensor "+element+" status ("+sensorType+")", hwmonLabelDesc, nil)
+				desc := PrometheusNewDesc(name, "Hardware sensor "+element+" status ("+sensorType+")", hwmonLabelDesc, nil)
 				ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, parsedValue, labels...)
 				continue
 			}
 			if element == "beep" {
-				desc := prometheus.NewDesc(name+"_enabled", "Hardware monitor sensor has beeping enabled", hwmonLabelDesc, nil)
+				desc := PrometheusNewDesc(name+"_enabled", "Hardware monitor sensor has beeping enabled", hwmonLabelDesc, nil)
 				ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, parsedValue, labels...)
 				continue
 			}
 
 			// everything else should get a unit
 			if sensorType == "in" || sensorType == "cpu" {
-				desc := prometheus.NewDesc(name+"_volts", "Hardware monitor for voltage ("+element+")", hwmonLabelDesc, nil)
+				desc := PrometheusNewDesc(name+"_volts", "Hardware monitor for voltage ("+element+")", hwmonLabelDesc, nil)
 				ch <- prometheus.MustNewConstMetric(
 					desc, prometheus.GaugeValue, parsedValue*0.001, labels...)
 				continue
 			}
 			if sensorType == "temp" && element != "type" {
-				desc := prometheus.NewDesc(name+"_celsius", "Hardware monitor for temperature ("+element+")", hwmonLabelDesc, nil)
+				desc := PrometheusNewDesc(name+"_celsius", "Hardware monitor for temperature ("+element+")", hwmonLabelDesc, nil)
 				ch <- prometheus.MustNewConstMetric(
 					desc, prometheus.GaugeValue, parsedValue*0.001, labels...)
 				continue
 			}
 			if sensorType == "curr" {
-				desc := prometheus.NewDesc(name+"_amps", "Hardware monitor for current ("+element+")", hwmonLabelDesc, nil)
+				desc := PrometheusNewDesc(name+"_amps", "Hardware monitor for current ("+element+")", hwmonLabelDesc, nil)
 				ch <- prometheus.MustNewConstMetric(
 					desc, prometheus.GaugeValue, parsedValue*0.001, labels...)
 				continue
 			}
 			if sensorType == "energy" {
-				desc := prometheus.NewDesc(name+"_joule_total", "Hardware monitor for joules used so far ("+element+")", hwmonLabelDesc, nil)
+				desc := PrometheusNewDesc(name+"_joule_total", "Hardware monitor for joules used so far ("+element+")", hwmonLabelDesc, nil)
 				ch <- prometheus.MustNewConstMetric(
 					desc, prometheus.CounterValue, parsedValue/1000000.0, labels...)
 				continue
 			}
 			if sensorType == "power" && element == "accuracy" {
-				desc := prometheus.NewDesc(name, "Hardware monitor power meter accuracy, as a ratio", hwmonLabelDesc, nil)
+				desc := PrometheusNewDesc(name, "Hardware monitor power meter accuracy, as a ratio", hwmonLabelDesc, nil)
 				ch <- prometheus.MustNewConstMetric(
 					desc, prometheus.GaugeValue, parsedValue/1000000.0, labels...)
 				continue
 			}
 			if sensorType == "power" && (element == "average_interval" || element == "average_interval_min" || element == "average_interval_max") {
-				desc := prometheus.NewDesc(name+"_seconds", "Hardware monitor power usage update interval ("+element+")", hwmonLabelDesc, nil)
+				desc := PrometheusNewDesc(name+"_seconds", "Hardware monitor power usage update interval ("+element+")", hwmonLabelDesc, nil)
 				ch <- prometheus.MustNewConstMetric(
 					desc, prometheus.GaugeValue, parsedValue*0.001, labels...)
 				continue
 			}
 			if sensorType == "power" {
-				desc := prometheus.NewDesc(name+"_watt", "Hardware monitor for power usage in watts ("+element+")", hwmonLabelDesc, nil)
+				desc := PrometheusNewDesc(name+"_watt", "Hardware monitor for power usage in watts ("+element+")", hwmonLabelDesc, nil)
 				ch <- prometheus.MustNewConstMetric(
 					desc, prometheus.GaugeValue, parsedValue/1000000.0, labels...)
 				continue
 			}
 
 			if sensorType == "humidity" {
-				desc := prometheus.NewDesc(name, "Hardware monitor for humidity, as a ratio (multiply with 100.0 to get the humidity as a percentage) ("+element+")", hwmonLabelDesc, nil)
+				desc := PrometheusNewDesc(name, "Hardware monitor for humidity, as a ratio (multiply with 100.0 to get the humidity as a percentage) ("+element+")", hwmonLabelDesc, nil)
 				ch <- prometheus.MustNewConstMetric(
 					desc, prometheus.GaugeValue, parsedValue/1000000.0, labels...)
 				continue
 			}
 
 			if sensorType == "fan" && (element == "input" || element == "min" || element == "max" || element == "target") {
-				desc := prometheus.NewDesc(name+"_rpm", "Hardware monitor for fan revolutions per minute ("+element+")", hwmonLabelDesc, nil)
+				desc := PrometheusNewDesc(name+"_rpm", "Hardware monitor for fan revolutions per minute ("+element+")", hwmonLabelDesc, nil)
 				ch <- prometheus.MustNewConstMetric(
 					desc, prometheus.GaugeValue, parsedValue, labels...)
 				continue
@@ -326,7 +326,7 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) er
 
 			// fallback, just dump the metric as is
 
-			desc := prometheus.NewDesc(name, "Hardware monitor "+sensorType+" element "+element, hwmonLabelDesc, nil)
+			desc := PrometheusNewDesc(name, "Hardware monitor "+sensorType+" element "+element, hwmonLabelDesc, nil)
 			ch <- prometheus.MustNewConstMetric(
 				desc, prometheus.GaugeValue, parsedValue, labels...)
 		}

--- a/collector/infiniband_linux.go
+++ b/collector/infiniband_linux.go
@@ -79,7 +79,7 @@ func NewInfiniBandCollector() (Collector, error) {
 	i.metricDescs = make(map[string]*prometheus.Desc)
 
 	for metricName, infinibandMetric := range i.counters {
-		i.metricDescs[metricName] = prometheus.NewDesc(
+		i.metricDescs[metricName] = PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, metricName),
 			infinibandMetric.Help,
 			[]string{"device", "port"},
@@ -88,7 +88,7 @@ func NewInfiniBandCollector() (Collector, error) {
 	}
 
 	for metricName, infinibandMetric := range i.legacyCounters {
-		i.metricDescs[metricName] = prometheus.NewDesc(
+		i.metricDescs[metricName] = PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, metricName),
 			infinibandMetric.Help,
 			[]string{"device", "port"},

--- a/collector/interrupts_common.go
+++ b/collector/interrupts_common.go
@@ -29,7 +29,7 @@ func init() {
 // NewInterruptsCollector returns a new Collector exposing interrupts stats.
 func NewInterruptsCollector() (Collector, error) {
 	return &interruptsCollector{
-		desc: typedDesc{prometheus.NewDesc(
+		desc: typedDesc{PrometheusNewDesc(
 			namespace+"_interrupts_total",
 			"Interrupt details.",
 			interruptLabelNames, nil,

--- a/collector/ipvs_linux.go
+++ b/collector/ipvs_linux.go
@@ -61,42 +61,42 @@ func newIPVSCollector() (*ipvsCollector, error) {
 		return nil, err
 	}
 
-	c.connections = typedDesc{prometheus.NewDesc(
+	c.connections = typedDesc{PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "connections_total"),
 		"The total number of connections made.",
 		nil, nil,
 	), prometheus.CounterValue}
-	c.incomingPackets = typedDesc{prometheus.NewDesc(
+	c.incomingPackets = typedDesc{PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "incoming_packets_total"),
 		"The total number of incoming packets.",
 		nil, nil,
 	), prometheus.CounterValue}
-	c.outgoingPackets = typedDesc{prometheus.NewDesc(
+	c.outgoingPackets = typedDesc{PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "outgoing_packets_total"),
 		"The total number of outgoing packets.",
 		nil, nil,
 	), prometheus.CounterValue}
-	c.incomingBytes = typedDesc{prometheus.NewDesc(
+	c.incomingBytes = typedDesc{PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "incoming_bytes_total"),
 		"The total amount of incoming data.",
 		nil, nil,
 	), prometheus.CounterValue}
-	c.outgoingBytes = typedDesc{prometheus.NewDesc(
+	c.outgoingBytes = typedDesc{PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "outgoing_bytes_total"),
 		"The total amount of outgoing data.",
 		nil, nil,
 	), prometheus.CounterValue}
-	c.backendConnectionsActive = typedDesc{prometheus.NewDesc(
+	c.backendConnectionsActive = typedDesc{PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "backend_connections_active"),
 		"The current active connections by local and remote address.",
 		ipvsBackendLabelNames, nil,
 	), prometheus.GaugeValue}
-	c.backendConnectionsInact = typedDesc{prometheus.NewDesc(
+	c.backendConnectionsInact = typedDesc{PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "backend_connections_inactive"),
 		"The current inactive connections by local and remote address.",
 		ipvsBackendLabelNames, nil,
 	), prometheus.GaugeValue}
-	c.backendWeight = typedDesc{prometheus.NewDesc(
+	c.backendWeight = typedDesc{PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "backend_weight"),
 		"The current backend weight by local and remote address.",
 		ipvsBackendLabelNames, nil,

--- a/collector/ipvs_linux_test.go
+++ b/collector/ipvs_linux_test.go
@@ -42,14 +42,14 @@ func TestIPVSCollector(t *testing.T) {
 		}
 	}()
 	for expected, got := range map[string]string{
-		prometheus.NewDesc("node_ipvs_connections_total", "The total number of connections made.", nil, nil).String():                                                                                                                  (<-sink).Desc().String(),
-		prometheus.NewDesc("node_ipvs_incoming_packets_total", "The total number of incoming packets.", nil, nil).String():                                                                                                             (<-sink).Desc().String(),
-		prometheus.NewDesc("node_ipvs_outgoing_packets_total", "The total number of outgoing packets.", nil, nil).String():                                                                                                             (<-sink).Desc().String(),
-		prometheus.NewDesc("node_ipvs_incoming_bytes_total", "The total amount of incoming data.", nil, nil).String():                                                                                                                  (<-sink).Desc().String(),
-		prometheus.NewDesc("node_ipvs_outgoing_bytes_total", "The total amount of outgoing data.", nil, nil).String():                                                                                                                  (<-sink).Desc().String(),
-		prometheus.NewDesc("node_ipvs_backend_connections_active", "The current active connections by local and remote address.", []string{"local_address", "local_port", "remote_address", "remote_port", "proto"}, nil).String():     (<-sink).Desc().String(),
-		prometheus.NewDesc("node_ipvs_backend_connections_inactive", "The current inactive connections by local and remote address.", []string{"local_address", "local_port", "remote_address", "remote_port", "proto"}, nil).String(): (<-sink).Desc().String(),
-		prometheus.NewDesc("node_ipvs_backend_weight", "The current backend weight by local and remote address.", []string{"local_address", "local_port", "remote_address", "remote_port", "proto"}, nil).String():                     (<-sink).Desc().String(),
+		PrometheusNewDesc("node_ipvs_connections_total", "The total number of connections made.", nil, nil).String():                                                                                                                  (<-sink).Desc().String(),
+		PrometheusNewDesc("node_ipvs_incoming_packets_total", "The total number of incoming packets.", nil, nil).String():                                                                                                             (<-sink).Desc().String(),
+		PrometheusNewDesc("node_ipvs_outgoing_packets_total", "The total number of outgoing packets.", nil, nil).String():                                                                                                             (<-sink).Desc().String(),
+		PrometheusNewDesc("node_ipvs_incoming_bytes_total", "The total amount of incoming data.", nil, nil).String():                                                                                                                  (<-sink).Desc().String(),
+		PrometheusNewDesc("node_ipvs_outgoing_bytes_total", "The total amount of outgoing data.", nil, nil).String():                                                                                                                  (<-sink).Desc().String(),
+		PrometheusNewDesc("node_ipvs_backend_connections_active", "The current active connections by local and remote address.", []string{"local_address", "local_port", "remote_address", "remote_port", "proto"}, nil).String():     (<-sink).Desc().String(),
+		PrometheusNewDesc("node_ipvs_backend_connections_inactive", "The current inactive connections by local and remote address.", []string{"local_address", "local_port", "remote_address", "remote_port", "proto"}, nil).String(): (<-sink).Desc().String(),
+		PrometheusNewDesc("node_ipvs_backend_weight", "The current backend weight by local and remote address.", []string{"local_address", "local_port", "remote_address", "remote_port", "proto"}, nil).String():                     (<-sink).Desc().String(),
 	} {
 		if expected != got {
 			t.Fatalf("Expected '%s' but got '%s'", expected, got)

--- a/collector/ksmd_linux.go
+++ b/collector/ksmd_linux.go
@@ -52,7 +52,7 @@ func NewKsmdCollector() (Collector, error) {
 	descs := make(map[string]*prometheus.Desc)
 
 	for _, n := range ksmdFiles {
-		descs[n] = prometheus.NewDesc(
+		descs[n] = PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, getCanonicalMetricName(n)),
 			fmt.Sprintf("ksmd '%s' file.", n), nil, nil)
 	}

--- a/collector/loadavg.go
+++ b/collector/loadavg.go
@@ -35,9 +35,9 @@ func init() {
 func NewLoadavgCollector() (Collector, error) {
 	return &loadavgCollector{
 		metric: []typedDesc{
-			{prometheus.NewDesc(namespace+"_load1", "1m load average.", nil, nil), prometheus.GaugeValue},
-			{prometheus.NewDesc(namespace+"_load5", "5m load average.", nil, nil), prometheus.GaugeValue},
-			{prometheus.NewDesc(namespace+"_load15", "15m load average.", nil, nil), prometheus.GaugeValue},
+			{PrometheusNewDesc(namespace+"_load1", "1m load average.", nil, nil), prometheus.GaugeValue},
+			{PrometheusNewDesc(namespace+"_load5", "5m load average.", nil, nil), prometheus.GaugeValue},
+			{PrometheusNewDesc(namespace+"_load15", "15m load average.", nil, nil), prometheus.GaugeValue},
 		},
 	}, nil
 }

--- a/collector/logind_linux.go
+++ b/collector/logind_linux.go
@@ -37,7 +37,7 @@ var (
 	attrTypeValues   = []string{"other", "unspecified", "tty", "x11", "wayland", "mir", "web"}
 	attrClassValues  = []string{"other", "user", "greeter", "lock-screen", "background"}
 
-	sessionsDesc = prometheus.NewDesc(
+	sessionsDesc = PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, logindSubsystem, "sessions"),
 		"Number of sessions registered in logind.", []string{"seat", "remote", "type", "class"}, nil,
 	)

--- a/collector/mdadm_linux.go
+++ b/collector/mdadm_linux.go
@@ -224,35 +224,35 @@ func NewMdadmCollector() (Collector, error) {
 }
 
 var (
-	isActiveDesc = prometheus.NewDesc(
+	isActiveDesc = PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, "md", "is_active"),
 		"Indicator whether the md-device is active or not.",
 		[]string{"device"},
 		nil,
 	)
 
-	disksActiveDesc = prometheus.NewDesc(
+	disksActiveDesc = PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, "md", "disks_active"),
 		"Number of active disks of device.",
 		[]string{"device"},
 		nil,
 	)
 
-	disksTotalDesc = prometheus.NewDesc(
+	disksTotalDesc = PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, "md", "disks"),
 		"Total number of disks of device.",
 		[]string{"device"},
 		nil,
 	)
 
-	blocksTotalDesc = prometheus.NewDesc(
+	blocksTotalDesc = PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, "md", "blocks"),
 		"Total number of blocks on device.",
 		[]string{"device"},
 		nil,
 	)
 
-	blocksSyncedDesc = prometheus.NewDesc(
+	blocksSyncedDesc = PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, "md", "blocks_synced"),
 		"Number of blocks synced on device.",
 		[]string{"device"},

--- a/collector/meminfo.go
+++ b/collector/meminfo.go
@@ -48,7 +48,7 @@ func (c *meminfoCollector) Update(ch chan<- prometheus.Metric) error {
 	log.Debugf("Set node_mem: %#v", memInfo)
 	for k, v := range memInfo {
 		ch <- prometheus.MustNewConstMetric(
-			prometheus.NewDesc(
+			PrometheusNewDesc(
 				prometheus.BuildFQName(namespace, memInfoSubsystem, k),
 				fmt.Sprintf("Memory information field %s.", k),
 				nil, nil,

--- a/collector/meminfo_numa_linux.go
+++ b/collector/meminfo_numa_linux.go
@@ -65,7 +65,7 @@ func (c *meminfoNumaCollector) Update(ch chan<- prometheus.Metric) error {
 	for _, v := range metrics {
 		desc, ok := c.metricDescs[v.metricName]
 		if !ok {
-			desc = prometheus.NewDesc(
+			desc = PrometheusNewDesc(
 				prometheus.BuildFQName(namespace, memInfoNumaSubsystem, v.metricName),
 				fmt.Sprintf("Memory information field %s.", v.metricName),
 				[]string{"node"}, nil)

--- a/collector/memory_bsd.go
+++ b/collector/memory_bsd.go
@@ -135,7 +135,7 @@ func (c *memoryCollector) Update(ch chan<- prometheus.Metric) error {
 		}
 
 		ch <- prometheus.MustNewConstMetric(
-			prometheus.NewDesc(
+			PrometheusNewDesc(
 				prometheus.BuildFQName(namespace, memorySubsystem, m.name),
 				m.description,
 				nil, nil,
@@ -148,7 +148,7 @@ func (c *memoryCollector) Update(ch chan<- prometheus.Metric) error {
 	}
 
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, memorySubsystem, "swap_used_bytes"),
 			"Currently allocated swap",
 			nil, nil,

--- a/collector/mountstats_linux.go
+++ b/collector/mountstats_linux.go
@@ -116,371 +116,371 @@ func NewMountStatsCollector() (Collector, error) {
 	)
 
 	return &mountStatsCollector{
-		NFSAgeSecondsTotal: prometheus.NewDesc(
+		NFSAgeSecondsTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "age_seconds_total"),
 			"The age of the NFS mount in seconds.",
 			labels,
 			nil,
 		),
 
-		NFSReadBytesTotal: prometheus.NewDesc(
+		NFSReadBytesTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "read_bytes_total"),
 			"Number of bytes read using the read() syscall.",
 			labels,
 			nil,
 		),
 
-		NFSWriteBytesTotal: prometheus.NewDesc(
+		NFSWriteBytesTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "write_bytes_total"),
 			"Number of bytes written using the write() syscall.",
 			labels,
 			nil,
 		),
 
-		NFSDirectReadBytesTotal: prometheus.NewDesc(
+		NFSDirectReadBytesTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "direct_read_bytes_total"),
 			"Number of bytes read using the read() syscall in O_DIRECT mode.",
 			labels,
 			nil,
 		),
 
-		NFSDirectWriteBytesTotal: prometheus.NewDesc(
+		NFSDirectWriteBytesTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "direct_write_bytes_total"),
 			"Number of bytes written using the write() syscall in O_DIRECT mode.",
 			labels,
 			nil,
 		),
 
-		NFSTotalReadBytesTotal: prometheus.NewDesc(
+		NFSTotalReadBytesTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "total_read_bytes_total"),
 			"Number of bytes read from the NFS server, in total.",
 			labels,
 			nil,
 		),
 
-		NFSTotalWriteBytesTotal: prometheus.NewDesc(
+		NFSTotalWriteBytesTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "total_write_bytes_total"),
 			"Number of bytes written to the NFS server, in total.",
 			labels,
 			nil,
 		),
 
-		NFSReadPagesTotal: prometheus.NewDesc(
+		NFSReadPagesTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "read_pages_total"),
 			"Number of pages read directly via mmap()'d files.",
 			labels,
 			nil,
 		),
 
-		NFSWritePagesTotal: prometheus.NewDesc(
+		NFSWritePagesTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "write_pages_total"),
 			"Number of pages written directly via mmap()'d files.",
 			labels,
 			nil,
 		),
 
-		NFSTransportBindTotal: prometheus.NewDesc(
+		NFSTransportBindTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "transport_bind_total"),
 			"Number of times the client has had to establish a connection from scratch to the NFS server.",
 			labels,
 			nil,
 		),
 
-		NFSTransportConnectTotal: prometheus.NewDesc(
+		NFSTransportConnectTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "transport_connect_total"),
 			"Number of times the client has made a TCP connection to the NFS server.",
 			labels,
 			nil,
 		),
 
-		NFSTransportIdleTimeSeconds: prometheus.NewDesc(
+		NFSTransportIdleTimeSeconds: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "transport_idle_time_seconds"),
 			"Duration since the NFS mount last saw any RPC traffic, in seconds.",
 			labels,
 			nil,
 		),
 
-		NFSTransportSendsTotal: prometheus.NewDesc(
+		NFSTransportSendsTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "transport_sends_total"),
 			"Number of RPC requests for this mount sent to the NFS server.",
 			labels,
 			nil,
 		),
 
-		NFSTransportReceivesTotal: prometheus.NewDesc(
+		NFSTransportReceivesTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "transport_receives_total"),
 			"Number of RPC responses for this mount received from the NFS server.",
 			labels,
 			nil,
 		),
 
-		NFSTransportBadTransactionIDsTotal: prometheus.NewDesc(
+		NFSTransportBadTransactionIDsTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "transport_bad_transaction_ids_total"),
 			"Number of times the NFS server sent a response with a transaction ID unknown to this client.",
 			labels,
 			nil,
 		),
 
-		NFSTransportBacklogQueueTotal: prometheus.NewDesc(
+		NFSTransportBacklogQueueTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "transport_backlog_queue_total"),
 			"Total number of items added to the RPC backlog queue.",
 			labels,
 			nil,
 		),
 
-		NFSTransportMaximumRPCSlots: prometheus.NewDesc(
+		NFSTransportMaximumRPCSlots: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "transport_maximum_rpc_slots"),
 			"Maximum number of simultaneously active RPC requests ever used.",
 			labels,
 			nil,
 		),
 
-		NFSTransportSendingQueueTotal: prometheus.NewDesc(
+		NFSTransportSendingQueueTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "transport_sending_queue_total"),
 			"Total number of items added to the RPC transmission sending queue.",
 			labels,
 			nil,
 		),
 
-		NFSTransportPendingQueueTotal: prometheus.NewDesc(
+		NFSTransportPendingQueueTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "transport_pending_queue_total"),
 			"Total number of items added to the RPC transmission pending queue.",
 			labels,
 			nil,
 		),
 
-		NFSOperationsRequestsTotal: prometheus.NewDesc(
+		NFSOperationsRequestsTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "operations_requests_total"),
 			"Number of requests performed for a given operation.",
 			opLabels,
 			nil,
 		),
 
-		NFSOperationsTransmissionsTotal: prometheus.NewDesc(
+		NFSOperationsTransmissionsTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "operations_transmissions_total"),
 			"Number of times an actual RPC request has been transmitted for a given operation.",
 			opLabels,
 			nil,
 		),
 
-		NFSOperationsMajorTimeoutsTotal: prometheus.NewDesc(
+		NFSOperationsMajorTimeoutsTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "operations_major_timeouts_total"),
 			"Number of times a request has had a major timeout for a given operation.",
 			opLabels,
 			nil,
 		),
 
-		NFSOperationsSentBytesTotal: prometheus.NewDesc(
+		NFSOperationsSentBytesTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "operations_sent_bytes_total"),
 			"Number of bytes sent for a given operation, including RPC headers and payload.",
 			opLabels,
 			nil,
 		),
 
-		NFSOperationsReceivedBytesTotal: prometheus.NewDesc(
+		NFSOperationsReceivedBytesTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "operations_received_bytes_total"),
 			"Number of bytes received for a given operation, including RPC headers and payload.",
 			opLabels,
 			nil,
 		),
 
-		NFSOperationsQueueTimeSecondsTotal: prometheus.NewDesc(
+		NFSOperationsQueueTimeSecondsTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "operations_queue_time_seconds_total"),
 			"Duration all requests spent queued for transmission for a given operation before they were sent, in seconds.",
 			opLabels,
 			nil,
 		),
 
-		NFSOperationsResponseTimeSecondsTotal: prometheus.NewDesc(
+		NFSOperationsResponseTimeSecondsTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "operations_response_time_seconds_total"),
 			"Duration all requests took to get a reply back after a request for a given operation was transmitted, in seconds.",
 			opLabels,
 			nil,
 		),
 
-		NFSOperationsRequestTimeSecondsTotal: prometheus.NewDesc(
+		NFSOperationsRequestTimeSecondsTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "operations_request_time_seconds_total"),
 			"Duration all requests took from when a request was enqueued to when it was completely handled for a given operation, in seconds.",
 			opLabels,
 			nil,
 		),
 
-		NFSEventInodeRevalidateTotal: prometheus.NewDesc(
+		NFSEventInodeRevalidateTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_inode_revalidate_total"),
 			"Number of times cached inode attributes are re-validated from the server.",
 			labels,
 			nil,
 		),
 
-		NFSEventDnodeRevalidateTotal: prometheus.NewDesc(
+		NFSEventDnodeRevalidateTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_dnode_revalidate_total"),
 			"Number of times cached dentry nodes are re-validated from the server.",
 			labels,
 			nil,
 		),
 
-		NFSEventDataInvalidateTotal: prometheus.NewDesc(
+		NFSEventDataInvalidateTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_data_invalidate_total"),
 			"Number of times an inode cache is cleared.",
 			labels,
 			nil,
 		),
 
-		NFSEventAttributeInvalidateTotal: prometheus.NewDesc(
+		NFSEventAttributeInvalidateTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_attribute_invalidate_total"),
 			"Number of times cached inode attributes are invalidated.",
 			labels,
 			nil,
 		),
 
-		NFSEventVFSOpenTotal: prometheus.NewDesc(
+		NFSEventVFSOpenTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_vfs_open_total"),
 			"Number of times cached inode attributes are invalidated.",
 			labels,
 			nil,
 		),
 
-		NFSEventVFSLookupTotal: prometheus.NewDesc(
+		NFSEventVFSLookupTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_vfs_lookup_total"),
 			"Number of times a directory lookup has occurred.",
 			labels,
 			nil,
 		),
 
-		NFSEventVFSAccessTotal: prometheus.NewDesc(
+		NFSEventVFSAccessTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_vfs_access_total"),
 			"Number of times permissions have been checked.",
 			labels,
 			nil,
 		),
 
-		NFSEventVFSUpdatePageTotal: prometheus.NewDesc(
+		NFSEventVFSUpdatePageTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_vfs_update_page_total"),
 			"Number of updates (and potential writes) to pages.",
 			labels,
 			nil,
 		),
 
-		NFSEventVFSReadPageTotal: prometheus.NewDesc(
+		NFSEventVFSReadPageTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_vfs_read_page_total"),
 			"Number of pages read directly via mmap()'d files.",
 			labels,
 			nil,
 		),
 
-		NFSEventVFSReadPagesTotal: prometheus.NewDesc(
+		NFSEventVFSReadPagesTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_vfs_read_pages_total"),
 			"Number of times a group of pages have been read.",
 			labels,
 			nil,
 		),
 
-		NFSEventVFSWritePageTotal: prometheus.NewDesc(
+		NFSEventVFSWritePageTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_vfs_write_page_total"),
 			"Number of pages written directly via mmap()'d files.",
 			labels,
 			nil,
 		),
 
-		NFSEventVFSWritePagesTotal: prometheus.NewDesc(
+		NFSEventVFSWritePagesTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_vfs_write_pages_total"),
 			"Number of times a group of pages have been written.",
 			labels,
 			nil,
 		),
 
-		NFSEventVFSGetdentsTotal: prometheus.NewDesc(
+		NFSEventVFSGetdentsTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_vfs_getdents_total"),
 			"Number of times directory entries have been read with getdents().",
 			labels,
 			nil,
 		),
 
-		NFSEventVFSSetattrTotal: prometheus.NewDesc(
+		NFSEventVFSSetattrTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_vfs_setattr_total"),
 			"Number of times directory entries have been read with getdents().",
 			labels,
 			nil,
 		),
 
-		NFSEventVFSFlushTotal: prometheus.NewDesc(
+		NFSEventVFSFlushTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_vfs_flush_total"),
 			"Number of pending writes that have been forcefully flushed to the server.",
 			labels,
 			nil,
 		),
 
-		NFSEventVFSFsyncTotal: prometheus.NewDesc(
+		NFSEventVFSFsyncTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_vfs_fsync_total"),
 			"Number of times fsync() has been called on directories and files.",
 			labels,
 			nil,
 		),
 
-		NFSEventVFSLockTotal: prometheus.NewDesc(
+		NFSEventVFSLockTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_vfs_lock_total"),
 			"Number of times locking has been attempted on a file.",
 			labels,
 			nil,
 		),
 
-		NFSEventVFSFileReleaseTotal: prometheus.NewDesc(
+		NFSEventVFSFileReleaseTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_vfs_file_release_total"),
 			"Number of times files have been closed and released.",
 			labels,
 			nil,
 		),
 
-		NFSEventTruncationTotal: prometheus.NewDesc(
+		NFSEventTruncationTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_truncation_total"),
 			"Number of times files have been truncated.",
 			labels,
 			nil,
 		),
 
-		NFSEventWriteExtensionTotal: prometheus.NewDesc(
+		NFSEventWriteExtensionTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_write_extension_total"),
 			"Number of times a file has been grown due to writes beyond its existing end.",
 			labels,
 			nil,
 		),
 
-		NFSEventSillyRenameTotal: prometheus.NewDesc(
+		NFSEventSillyRenameTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_silly_rename_total"),
 			"Number of times a file was removed while still open by another process.",
 			labels,
 			nil,
 		),
 
-		NFSEventShortReadTotal: prometheus.NewDesc(
+		NFSEventShortReadTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_short_read_total"),
 			"Number of times the NFS server gave less data than expected while reading.",
 			labels,
 			nil,
 		),
 
-		NFSEventShortWriteTotal: prometheus.NewDesc(
+		NFSEventShortWriteTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_short_write_total"),
 			"Number of times the NFS server wrote less data than expected while writing.",
 			labels,
 			nil,
 		),
 
-		NFSEventJukeboxDelayTotal: prometheus.NewDesc(
+		NFSEventJukeboxDelayTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_jukebox_delay_total"),
 			"Number of times the NFS server indicated EJUKEBOX; retrieving data from offline storage.",
 			labels,
 			nil,
 		),
 
-		NFSEventPNFSReadTotal: prometheus.NewDesc(
+		NFSEventPNFSReadTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_pnfs_read_total"),
 			"Number of NFS v4.1+ pNFS reads.",
 			labels,
 			nil,
 		),
 
-		NFSEventPNFSWriteTotal: prometheus.NewDesc(
+		NFSEventPNFSWriteTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "event_pnfs_write_total"),
 			"Number of NFS v4.1+ pNFS writes.",
 			labels,

--- a/collector/netclass_linux.go
+++ b/collector/netclass_linux.go
@@ -55,7 +55,7 @@ func (c *netClassCollector) Update(ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("could not get net class info: %s", err)
 	}
 	for _, ifaceInfo := range netClass {
-		upDesc := prometheus.NewDesc(
+		upDesc := PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, c.subsystem, "up"),
 			"Valid operstate for interface.",
 			[]string{"interface", "address", "broadcast", "duplex", "operstate", "ifalias"},
@@ -142,7 +142,7 @@ func (c *netClassCollector) Update(ch chan<- prometheus.Metric) error {
 }
 
 func pushMetric(ch chan<- prometheus.Metric, subsystem string, name string, value int64, ifaceName string, valueType prometheus.ValueType) {
-	fieldDesc := prometheus.NewDesc(
+	fieldDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, name),
 		fmt.Sprintf("%s value of /sys/class/net/<iface>.", name),
 		[]string{"interface"},

--- a/collector/netdev_common.go
+++ b/collector/netdev_common.go
@@ -58,7 +58,7 @@ func (c *netDevCollector) Update(ch chan<- prometheus.Metric) error {
 		for key, value := range devStats {
 			desc, ok := c.metricDescs[key]
 			if !ok {
-				desc = prometheus.NewDesc(
+				desc = PrometheusNewDesc(
 					prometheus.BuildFQName(namespace, c.subsystem, key+"_total"),
 					fmt.Sprintf("Network device statistic %s.", key),
 					[]string{"device"},

--- a/collector/netstat_linux.go
+++ b/collector/netstat_linux.go
@@ -85,7 +85,7 @@ func (c *netStatCollector) Update(ch chan<- prometheus.Metric) error {
 				continue
 			}
 			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(
+				PrometheusNewDesc(
 					prometheus.BuildFQName(namespace, netStatsSubsystem, key),
 					fmt.Sprintf("Statistic %s.", protocol+name),
 					nil, nil,

--- a/collector/nfs_linux.go
+++ b/collector/nfs_linux.go
@@ -51,37 +51,37 @@ func NewNfsCollector() (Collector, error) {
 
 	return &nfsCollector{
 		fs: fs,
-		nfsNetReadsDesc: prometheus.NewDesc(
+		nfsNetReadsDesc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsSubsystem, "packets_total"),
 			"Total NFSd network packets (sent+received) by protocol type.",
 			[]string{"protocol"},
 			nil,
 		),
-		nfsNetConnectionsDesc: prometheus.NewDesc(
+		nfsNetConnectionsDesc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsSubsystem, "connections_total"),
 			"Total number of NFSd TCP connections.",
 			nil,
 			nil,
 		),
-		nfsRPCOperationsDesc: prometheus.NewDesc(
+		nfsRPCOperationsDesc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsSubsystem, "rpcs_total"),
 			"Total number of RPCs performed.",
 			nil,
 			nil,
 		),
-		nfsRPCRetransmissionsDesc: prometheus.NewDesc(
+		nfsRPCRetransmissionsDesc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsSubsystem, "rpc_retransmissions_total"),
 			"Number of RPC transmissions performed.",
 			nil,
 			nil,
 		),
-		nfsRPCAuthenticationRefreshesDesc: prometheus.NewDesc(
+		nfsRPCAuthenticationRefreshesDesc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsSubsystem, "rpc_authentication_refreshes_total"),
 			"Number of RPC authentication refreshes performed.",
 			nil,
 			nil,
 		),
-		nfsProceduresDesc: prometheus.NewDesc(
+		nfsProceduresDesc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsSubsystem, "requests_total"),
 			"Number of NFS procedures invoked.",
 			[]string{"proto", "method"},

--- a/collector/nfsd_linux.go
+++ b/collector/nfsd_linux.go
@@ -47,7 +47,7 @@ func NewNFSdCollector() (Collector, error) {
 
 	return &nfsdCollector{
 		fs: fs,
-		requestsDesc: prometheus.NewDesc(
+		requestsDesc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsdSubsystem, "requests_total"),
 			"Total number NFSd Requests by method and protocol.",
 			[]string{"proto", "method"}, nil,
@@ -83,7 +83,7 @@ func (c *nfsdCollector) Update(ch chan<- prometheus.Metric) error {
 // updateNFSdReplyCacheStats collects statistics for the reply cache.
 func (c *nfsdCollector) updateNFSdReplyCacheStats(ch chan<- prometheus.Metric, s *nfs.ReplyCache) {
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsdSubsystem, "reply_cache_hits_total"),
 			"Total number of NFSd Reply Cache hits (client lost server response).",
 			nil,
@@ -92,7 +92,7 @@ func (c *nfsdCollector) updateNFSdReplyCacheStats(ch chan<- prometheus.Metric, s
 		prometheus.CounterValue,
 		float64(s.Hits))
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsdSubsystem, "reply_cache_misses_total"),
 			"Total number of NFSd Reply Cache an operation that requires caching (idempotent).",
 			nil,
@@ -101,7 +101,7 @@ func (c *nfsdCollector) updateNFSdReplyCacheStats(ch chan<- prometheus.Metric, s
 		prometheus.CounterValue,
 		float64(s.Misses))
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsdSubsystem, "reply_cache_nocache_total"),
 			"Total number of NFSd Reply Cache non-idempotent operations (rename/delete/…).",
 			nil,
@@ -114,7 +114,7 @@ func (c *nfsdCollector) updateNFSdReplyCacheStats(ch chan<- prometheus.Metric, s
 // updateNFSdFileHandlesStats collects statistics for the file handles.
 func (c *nfsdCollector) updateNFSdFileHandlesStats(ch chan<- prometheus.Metric, s *nfs.FileHandles) {
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsdSubsystem, "file_handles_stale_total"),
 			"Total number of NFSd stale file handles",
 			nil,
@@ -128,7 +128,7 @@ func (c *nfsdCollector) updateNFSdFileHandlesStats(ch chan<- prometheus.Metric, 
 // updateNFSdInputOutputStats collects statistics for the bytes in/out.
 func (c *nfsdCollector) updateNFSdInputOutputStats(ch chan<- prometheus.Metric, s *nfs.InputOutput) {
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsdSubsystem, "disk_bytes_read_total"),
 			"Total NFSd bytes read.",
 			nil,
@@ -137,7 +137,7 @@ func (c *nfsdCollector) updateNFSdInputOutputStats(ch chan<- prometheus.Metric, 
 		prometheus.CounterValue,
 		float64(s.Read))
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsdSubsystem, "disk_bytes_written_total"),
 			"Total NFSd bytes written.",
 			nil,
@@ -150,7 +150,7 @@ func (c *nfsdCollector) updateNFSdInputOutputStats(ch chan<- prometheus.Metric, 
 // updateNFSdThreadsStats collects statistics for kernel server threads.
 func (c *nfsdCollector) updateNFSdThreadsStats(ch chan<- prometheus.Metric, s *nfs.Threads) {
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsdSubsystem, "server_threads"),
 			"Total number of NFSd kernel threads that are running.",
 			nil,
@@ -163,7 +163,7 @@ func (c *nfsdCollector) updateNFSdThreadsStats(ch chan<- prometheus.Metric, s *n
 // updateNFSdReadAheadCacheStats collects statistics for the read ahead cache.
 func (c *nfsdCollector) updateNFSdReadAheadCacheStats(ch chan<- prometheus.Metric, s *nfs.ReadAheadCache) {
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsdSubsystem, "read_ahead_cache_size_blocks"),
 			"How large the read ahead cache is in blocks.",
 			nil,
@@ -172,7 +172,7 @@ func (c *nfsdCollector) updateNFSdReadAheadCacheStats(ch chan<- prometheus.Metri
 		prometheus.GaugeValue,
 		float64(s.CacheSize))
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsdSubsystem, "read_ahead_cache_not_found_total"),
 			"Total number of NFSd read ahead cache not found.",
 			nil,
@@ -184,7 +184,7 @@ func (c *nfsdCollector) updateNFSdReadAheadCacheStats(ch chan<- prometheus.Metri
 
 // updateNFSdNetworkStats collects statistics for network packets/connections.
 func (c *nfsdCollector) updateNFSdNetworkStats(ch chan<- prometheus.Metric, s *nfs.Network) {
-	packetDesc := prometheus.NewDesc(
+	packetDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, nfsdSubsystem, "packets_total"),
 		"Total NFSd network packets (sent+received) by protocol type.",
 		[]string{"proto"},
@@ -199,7 +199,7 @@ func (c *nfsdCollector) updateNFSdNetworkStats(ch chan<- prometheus.Metric, s *n
 		prometheus.CounterValue,
 		float64(s.TCPCount), "tcp")
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsdSubsystem, "connections_total"),
 			"Total number of NFSd TCP connections.",
 			nil,
@@ -211,7 +211,7 @@ func (c *nfsdCollector) updateNFSdNetworkStats(ch chan<- prometheus.Metric, s *n
 
 // updateNFSdServerRPCStats collects statistics for kernel server RPCs.
 func (c *nfsdCollector) updateNFSdServerRPCStats(ch chan<- prometheus.Metric, s *nfs.ServerRPC) {
-	badRPCDesc := prometheus.NewDesc(
+	badRPCDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, nfsdSubsystem, "rpc_errors_total"),
 		"Total number of NFSd RPC errors by error type.",
 		[]string{"error"},
@@ -230,7 +230,7 @@ func (c *nfsdCollector) updateNFSdServerRPCStats(ch chan<- prometheus.Metric, s 
 		prometheus.CounterValue,
 		float64(s.BadcInt), "cInt")
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, nfsdSubsystem, "server_rpcs_total"),
 			"Total number of NFSd RPCs.",
 			nil,

--- a/collector/ntp.go
+++ b/collector/ntp.go
@@ -70,42 +70,42 @@ func NewNtpCollector() (Collector, error) {
 	}
 
 	return &ntpCollector{
-		stratum: typedDesc{prometheus.NewDesc(
+		stratum: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, ntpSubsystem, "stratum"),
 			"NTPD stratum.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		leap: typedDesc{prometheus.NewDesc(
+		leap: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, ntpSubsystem, "leap"),
 			"NTPD leap second indicator, 2 bits.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		rtt: typedDesc{prometheus.NewDesc(
+		rtt: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, ntpSubsystem, "rtt_seconds"),
 			"RTT to NTPD.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		offset: typedDesc{prometheus.NewDesc(
+		offset: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, ntpSubsystem, "offset_seconds"),
 			"ClockOffset between NTP and local clock.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		reftime: typedDesc{prometheus.NewDesc(
+		reftime: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, ntpSubsystem, "reference_timestamp_seconds"),
 			"NTPD ReferenceTime, UNIX timestamp.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		rootDelay: typedDesc{prometheus.NewDesc(
+		rootDelay: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, ntpSubsystem, "root_delay_seconds"),
 			"NTPD RootDelay.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		rootDispersion: typedDesc{prometheus.NewDesc(
+		rootDispersion: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, ntpSubsystem, "root_dispersion_seconds"),
 			"NTPD RootDispersion.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		sanity: typedDesc{prometheus.NewDesc(
+		sanity: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, ntpSubsystem, "sanity"),
 			"NTPD sanity according to RFC5905 heuristics and configured limits.",
 			nil, nil,

--- a/collector/processes_linux.go
+++ b/collector/processes_linux.go
@@ -36,25 +36,25 @@ func init() {
 func NewProcessStatCollector() (Collector, error) {
 	subsystem := "processes"
 	return &processCollector{
-		threadAlloc: prometheus.NewDesc(
+		threadAlloc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "threads"),
 			"Allocated threads in system",
 			nil, nil,
 		),
-		threadLimit: prometheus.NewDesc(
+		threadLimit: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "max_threads"),
 			"Limit of threads in the system",
 			nil, nil,
 		),
-		procsState: prometheus.NewDesc(
+		procsState: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "state"),
 			"Number of processes in each state.",
 			[]string{"state"}, nil,
 		),
-		pidUsed: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "pids"),
+		pidUsed: PrometheusNewDesc(prometheus.BuildFQName(namespace, subsystem, "pids"),
 			"Number of PIDs", nil, nil,
 		),
-		pidMax: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "max_processes"),
+		pidMax: PrometheusNewDesc(prometheus.BuildFQName(namespace, subsystem, "max_processes"),
 			"Number of max PIDs limit", nil, nil,
 		),
 	}, nil

--- a/collector/qdisc_linux.go
+++ b/collector/qdisc_linux.go
@@ -44,27 +44,27 @@ func init() {
 // NewQdiscStatCollector returns a new Collector exposing queuing discipline statistics.
 func NewQdiscStatCollector() (Collector, error) {
 	return &qdiscStatCollector{
-		bytes: typedDesc{prometheus.NewDesc(
+		bytes: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "qdisc", "bytes_total"),
 			"Number of bytes sent.",
 			[]string{"device", "kind"}, nil,
 		), prometheus.CounterValue},
-		packets: typedDesc{prometheus.NewDesc(
+		packets: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "qdisc", "packets_total"),
 			"Number of packets sent.",
 			[]string{"device", "kind"}, nil,
 		), prometheus.CounterValue},
-		drops: typedDesc{prometheus.NewDesc(
+		drops: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "qdisc", "drops_total"),
 			"Number of packets dropped.",
 			[]string{"device", "kind"}, nil,
 		), prometheus.CounterValue},
-		requeues: typedDesc{prometheus.NewDesc(
+		requeues: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "qdisc", "requeues_total"),
 			"Number of packets dequeued, not transmitted, and requeued.",
 			[]string{"device", "kind"}, nil,
 		), prometheus.CounterValue},
-		overlimits: typedDesc{prometheus.NewDesc(
+		overlimits: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "qdisc", "overlimits_total"),
 			"Number of overlimit packets.",
 			[]string{"device", "kind"}, nil,

--- a/collector/runit.go
+++ b/collector/runit.go
@@ -41,22 +41,22 @@ func NewRunitCollector() (Collector, error) {
 	)
 
 	return &runitCollector{
-		state: typedDesc{prometheus.NewDesc(
+		state: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "state"),
 			"State of runit service.",
 			labelNames, constLabels,
 		), prometheus.GaugeValue},
-		stateDesired: typedDesc{prometheus.NewDesc(
+		stateDesired: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "desired_state"),
 			"Desired state of runit service.",
 			labelNames, constLabels,
 		), prometheus.GaugeValue},
-		stateNormal: typedDesc{prometheus.NewDesc(
+		stateNormal: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "normal_state"),
 			"Normal state of runit service.",
 			labelNames, constLabels,
 		), prometheus.GaugeValue},
-		stateTimestamp: typedDesc{prometheus.NewDesc(
+		stateTimestamp: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "state_last_change_timestamp_seconds"),
 			"Unix timestamp of the last runit service state change.",
 			labelNames, constLabels,

--- a/collector/sockstat_linux.go
+++ b/collector/sockstat_linux.go
@@ -56,7 +56,7 @@ func (c *sockStatCollector) Update(ch chan<- prometheus.Metric) error {
 				return fmt.Errorf("invalid value %s in sockstats: %s", value, err)
 			}
 			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(
+				PrometheusNewDesc(
 					prometheus.BuildFQName(namespace, sockStatSubsystem, protocol+"_"+name),
 					fmt.Sprintf("Number of %s sockets in state %s.", protocol, name),
 					nil, nil,

--- a/collector/stat_linux.go
+++ b/collector/stat_linux.go
@@ -39,32 +39,32 @@ func init() {
 // NewStatCollector returns a new Collector exposing kernel/system statistics.
 func NewStatCollector() (Collector, error) {
 	return &statCollector{
-		intr: prometheus.NewDesc(
+		intr: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "", "intr_total"),
 			"Total number of interrupts serviced.",
 			nil, nil,
 		),
-		ctxt: prometheus.NewDesc(
+		ctxt: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "", "context_switches_total"),
 			"Total number of context switches.",
 			nil, nil,
 		),
-		forks: prometheus.NewDesc(
+		forks: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "", "forks_total"),
 			"Total number of forks.",
 			nil, nil,
 		),
-		btime: prometheus.NewDesc(
+		btime: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "", "boot_time_seconds"),
 			"Node boot time, in unixtime.",
 			nil, nil,
 		),
-		procsRunning: prometheus.NewDesc(
+		procsRunning: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "", "procs_running"),
 			"Number of processes in runnable state.",
 			nil, nil,
 		),
-		procsBlocked: prometheus.NewDesc(
+		procsBlocked: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "", "procs_blocked"),
 			"Number of processes blocked waiting for I/O to complete.",
 			nil, nil,

--- a/collector/supervisord.go
+++ b/collector/supervisord.go
@@ -51,25 +51,25 @@ func NewSupervisordCollector() (Collector, error) {
 	)
 	return &supervisordCollector{
 		client: client,
-		upDesc: prometheus.NewDesc(
+		upDesc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "up"),
 			"Process Up",
 			labelNames,
 			nil,
 		),
-		stateDesc: prometheus.NewDesc(
+		stateDesc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "state"),
 			"Process State",
 			labelNames,
 			nil,
 		),
-		exitStatusDesc: prometheus.NewDesc(
+		exitStatusDesc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "exit_status"),
 			"Process Exit Status",
 			labelNames,
 			nil,
 		),
-		uptimeDesc: prometheus.NewDesc(
+		uptimeDesc: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "uptime"),
 			"Process Uptime",
 			labelNames,

--- a/collector/systemd_linux.go
+++ b/collector/systemd_linux.go
@@ -56,35 +56,35 @@ func init() {
 func NewSystemdCollector() (Collector, error) {
 	const subsystem = "systemd"
 
-	unitDesc := prometheus.NewDesc(
+	unitDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "unit_state"),
 		"Systemd unit", []string{"name", "state"}, nil,
 	)
-	unitStartTimeDesc := prometheus.NewDesc(
+	unitStartTimeDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "unit_start_time_seconds"),
 		"Start time of the unit since unix epoch in seconds.", []string{"name"}, nil,
 	)
-	systemRunningDesc := prometheus.NewDesc(
+	systemRunningDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "system_running"),
 		"Whether the system is operational (see 'systemctl is-system-running')",
 		nil, nil,
 	)
-	summaryDesc := prometheus.NewDesc(
+	summaryDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "units"),
 		"Summary of systemd unit states", []string{"state"}, nil)
-	nRestartsDesc := prometheus.NewDesc(
+	nRestartsDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "service_restart_total"),
 		"Service unit count of Restart triggers", []string{"state"}, nil)
-	timerLastTriggerDesc := prometheus.NewDesc(
+	timerLastTriggerDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "timer_last_trigger_seconds"),
 		"Seconds since epoch of last trigger.", []string{"name"}, nil)
-	socketAcceptedConnectionsDesc := prometheus.NewDesc(
+	socketAcceptedConnectionsDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "socket_accepted_connections_total"),
 		"Total number of accepted socket connections", []string{"name"}, nil)
-	socketCurrentConnectionsDesc := prometheus.NewDesc(
+	socketCurrentConnectionsDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "socket_current_connections"),
 		"Current number of socket connections", []string{"name"}, nil)
-	socketRefusedConnectionsDesc := prometheus.NewDesc(
+	socketRefusedConnectionsDesc := PrometheusNewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "socket_refused_connections_total"),
 		"Total number of refused socket connections", []string{"name"}, nil)
 	unitWhitelistPattern := regexp.MustCompile(fmt.Sprintf("^(?:%s)$", *unitWhitelist))

--- a/collector/tcpstat_linux.go
+++ b/collector/tcpstat_linux.go
@@ -64,7 +64,7 @@ func init() {
 // NewTCPStatCollector returns a new Collector exposing network stats.
 func NewTCPStatCollector() (Collector, error) {
 	return &tcpStatCollector{
-		desc: typedDesc{prometheus.NewDesc(
+		desc: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "tcp", "connection_states"),
 			"Number of connection states.",
 			[]string{"state"}, nil,

--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	textFileDirectory = kingpin.Flag("collector.textfile.directory", "Directory to read text files with metrics from.").Default("").String()
-	mtimeDesc         = prometheus.NewDesc(
+	mtimeDesc         = PrometheusNewDesc(
 		"node_textfile_mtime_seconds",
 		"Unixtime mtime of textfiles successfully read.",
 		[]string{"file"},
@@ -121,7 +121,7 @@ func convertMetricFamily(metricFamily *dto.MetricFamily, ch chan<- prometheus.Me
 				quantiles[q.GetQuantile()] = q.GetValue()
 			}
 			ch <- prometheus.MustNewConstSummary(
-				prometheus.NewDesc(
+				PrometheusNewDesc(
 					*metricFamily.Name,
 					metricFamily.GetHelp(),
 					names, nil,
@@ -136,7 +136,7 @@ func convertMetricFamily(metricFamily *dto.MetricFamily, ch chan<- prometheus.Me
 				buckets[b.GetUpperBound()] = b.GetCumulativeCount()
 			}
 			ch <- prometheus.MustNewConstHistogram(
-				prometheus.NewDesc(
+				PrometheusNewDesc(
 					*metricFamily.Name,
 					metricFamily.GetHelp(),
 					names, nil,
@@ -150,7 +150,7 @@ func convertMetricFamily(metricFamily *dto.MetricFamily, ch chan<- prometheus.Me
 		}
 		if metricType == dto.MetricType_GAUGE || metricType == dto.MetricType_COUNTER || metricType == dto.MetricType_UNTYPED {
 			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(
+				PrometheusNewDesc(
 					*metricFamily.Name,
 					metricFamily.GetHelp(),
 					names, nil,
@@ -240,7 +240,7 @@ fileLoop:
 
 	// Export if there were errors.
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			"node_textfile_scrape_error",
 			"1 if there was an error opening or reading a file, 0 otherwise",
 			nil, nil,

--- a/collector/time.go
+++ b/collector/time.go
@@ -34,7 +34,7 @@ func init() {
 // seconds since epoch.
 func NewTimeCollector() (Collector, error) {
 	return &timeCollector{
-		desc: prometheus.NewDesc(
+		desc: PrometheusNewDesc(
 			namespace+"_time_seconds",
 			"System time in seconds since epoch (1970).",
 			nil, nil,

--- a/collector/timex.go
+++ b/collector/timex.go
@@ -65,87 +65,87 @@ func NewTimexCollector() (Collector, error) {
 	const subsystem = "timex"
 
 	return &timexCollector{
-		offset: typedDesc{prometheus.NewDesc(
+		offset: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "offset_seconds"),
 			"Time offset in between local system and reference clock.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		freq: typedDesc{prometheus.NewDesc(
+		freq: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "frequency_adjustment_ratio"),
 			"Local clock frequency adjustment.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		maxerror: typedDesc{prometheus.NewDesc(
+		maxerror: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "maxerror_seconds"),
 			"Maximum error in seconds.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		esterror: typedDesc{prometheus.NewDesc(
+		esterror: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "estimated_error_seconds"),
 			"Estimated error in seconds.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		status: typedDesc{prometheus.NewDesc(
+		status: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "status"),
 			"Value of the status array bits.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		constant: typedDesc{prometheus.NewDesc(
+		constant: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "loop_time_constant"),
 			"Phase-locked loop time constant.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		tick: typedDesc{prometheus.NewDesc(
+		tick: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "tick_seconds"),
 			"Seconds between clock ticks.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		ppsfreq: typedDesc{prometheus.NewDesc(
+		ppsfreq: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "pps_frequency_hertz"),
 			"Pulse per second frequency.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		jitter: typedDesc{prometheus.NewDesc(
+		jitter: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "pps_jitter_seconds"),
 			"Pulse per second jitter.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		shift: typedDesc{prometheus.NewDesc(
+		shift: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "pps_shift_seconds"),
 			"Pulse per second interval duration.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		stabil: typedDesc{prometheus.NewDesc(
+		stabil: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "pps_stability_hertz"),
 			"Pulse per second stability, average of recent frequency changes.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		jitcnt: typedDesc{prometheus.NewDesc(
+		jitcnt: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "pps_jitter_total"),
 			"Pulse per second count of jitter limit exceeded events.",
 			nil, nil,
 		), prometheus.CounterValue},
-		calcnt: typedDesc{prometheus.NewDesc(
+		calcnt: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "pps_calibration_total"),
 			"Pulse per second count of calibration intervals.",
 			nil, nil,
 		), prometheus.CounterValue},
-		errcnt: typedDesc{prometheus.NewDesc(
+		errcnt: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "pps_error_total"),
 			"Pulse per second count of calibration errors.",
 			nil, nil,
 		), prometheus.CounterValue},
-		stbcnt: typedDesc{prometheus.NewDesc(
+		stbcnt: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "pps_stability_exceeded_total"),
 			"Pulse per second count of stability limit exceeded events.",
 			nil, nil,
 		), prometheus.CounterValue},
-		tai: typedDesc{prometheus.NewDesc(
+		tai: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "tai_offset_seconds"),
 			"International Atomic Time (TAI) offset.",
 			nil, nil,
 		), prometheus.GaugeValue},
-		syncStatus: typedDesc{prometheus.NewDesc(
+		syncStatus: typedDesc{PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "sync_status"),
 			"Is clock synchronized to a reliable server (1 = yes, 0 = no).",
 			nil, nil,

--- a/collector/uname_linux.go
+++ b/collector/uname_linux.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var unameDesc = prometheus.NewDesc(
+var unameDesc = PrometheusNewDesc(
 	prometheus.BuildFQName(namespace, "uname", "info"),
 	"Labeled system information as provided by the uname system call.",
 	[]string{

--- a/collector/vmstat_linux.go
+++ b/collector/vmstat_linux.go
@@ -70,7 +70,7 @@ func (c *vmStatCollector) Update(ch chan<- prometheus.Metric) error {
 		}
 
 		ch <- prometheus.MustNewConstMetric(
-			prometheus.NewDesc(
+			PrometheusNewDesc(
 				prometheus.BuildFQName(namespace, vmStatSubsystem, parts[0]),
 				fmt.Sprintf("/proc/vmstat information field %s.", parts[0]),
 				nil, nil),

--- a/collector/wifi_linux.go
+++ b/collector/wifi_linux.go
@@ -69,70 +69,70 @@ func NewWifiCollector() (Collector, error) {
 	)
 
 	return &wifiCollector{
-		interfaceFrequencyHertz: prometheus.NewDesc(
+		interfaceFrequencyHertz: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "interface_frequency_hertz"),
 			"The current frequency a WiFi interface is operating at, in hertz.",
 			[]string{"device"},
 			nil,
 		),
 
-		stationInfo: prometheus.NewDesc(
+		stationInfo: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "station_info"),
 			"Labeled WiFi interface station information as provided by the operating system.",
 			[]string{"device", "bssid", "ssid", "mode"},
 			nil,
 		),
 
-		stationConnectedSecondsTotal: prometheus.NewDesc(
+		stationConnectedSecondsTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "station_connected_seconds_total"),
 			"The total number of seconds a station has been connected to an access point.",
 			labels,
 			nil,
 		),
 
-		stationInactiveSeconds: prometheus.NewDesc(
+		stationInactiveSeconds: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "station_inactive_seconds"),
 			"The number of seconds since any wireless activity has occurred on a station.",
 			labels,
 			nil,
 		),
 
-		stationReceiveBitsPerSecond: prometheus.NewDesc(
+		stationReceiveBitsPerSecond: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "station_receive_bits_per_second"),
 			"The current WiFi receive bitrate of a station, in bits per second.",
 			labels,
 			nil,
 		),
 
-		stationTransmitBitsPerSecond: prometheus.NewDesc(
+		stationTransmitBitsPerSecond: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "station_transmit_bits_per_second"),
 			"The current WiFi transmit bitrate of a station, in bits per second.",
 			labels,
 			nil,
 		),
 
-		stationSignalDBM: prometheus.NewDesc(
+		stationSignalDBM: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "station_signal_dbm"),
 			"The current WiFi signal strength, in decibel-milliwatts (dBm).",
 			labels,
 			nil,
 		),
 
-		stationTransmitRetriesTotal: prometheus.NewDesc(
+		stationTransmitRetriesTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "station_transmit_retries_total"),
 			"The total number of times a station has had to retry while sending a packet.",
 			labels,
 			nil,
 		),
 
-		stationTransmitFailedTotal: prometheus.NewDesc(
+		stationTransmitFailedTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "station_transmit_failed_total"),
 			"The total number of times a station has failed to send a packet.",
 			labels,
 			nil,
 		),
 
-		stationBeaconLossTotal: prometheus.NewDesc(
+		stationBeaconLossTotal: PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "station_beacon_loss_total"),
 			"The total number of times a station has detected a beacon loss.",
 			labels,

--- a/collector/xfs_linux.go
+++ b/collector/xfs_linux.go
@@ -178,7 +178,7 @@ func (c *xfsCollector) updateXFSStats(ch chan<- prometheus.Metric, s *xfs.Stats)
 	}
 
 	for _, m := range metrics {
-		desc := prometheus.NewDesc(
+		desc := PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, m.name),
 			m.desc,
 			labels,

--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -84,7 +84,7 @@ func (c *zfsCollector) constSysctlMetric(subsystem string, sysctl zfsSysctl, val
 	metricName := sysctl.metricName()
 
 	return prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, subsystem, metricName),
 			string(sysctl),
 			nil,
@@ -99,7 +99,7 @@ func (c *zfsCollector) constPoolMetric(poolName string, sysctl zfsSysctl, value 
 	metricName := sysctl.metricName()
 
 	return prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
+		PrometheusNewDesc(
 			prometheus.BuildFQName(namespace, "zfs_zpool", metricName),
 			string(sysctl),
 			[]string{"zpool"},


### PR DESCRIPTION
This patch series adds the ability to configure an instance label.
Not all system report their instance as IP or hostname; it is still helpful to be able to correlate the node_exporter information and the specific system running on the host.

The series replaces metrics creation with a wrapper helper function; this function adds the instance label if it's configured.
