### PR TITLE
build: Fix staticcheck failure due to test regexp #1025

### DIFF
--- a/collector/systemd_linux_test.go
+++ b/collector/systemd_linux_test.go
@@ -109,8 +109,8 @@ func TestSystemdCollectorDoesntCrash(t *testing.T) {
 
 func TestSystemdIgnoreFilter(t *testing.T) {
 	fixtures := getUnitListFixtures()
-	whitelistPattern := regexp.MustCompile("foo")
-	blacklistPattern := regexp.MustCompile("bar")
+	whitelistPattern := regexp.MustCompile("^foo$")
+	blacklistPattern := regexp.MustCompile("^bar$")
 	filtered := filterUnits(fixtures[0], whitelistPattern, blacklistPattern)
 	for _, unit := range filtered {
 		if blacklistPattern.MatchString(unit.Name) || !whitelistPattern.MatchString(unit.Name) {


### PR DESCRIPTION
The staticcheck tools seems to have been modified to include a new check which validates regexps and bails out if they contain no meta characters (e.g. they are static strings) [1].
The systemd test case uses such a regexp, staticcheck detects that and this breaks the build.

~~This PR adds the relevant file+check to the ignore list in the Makefile and fixes #1025.~~
This PR circumvents that by anchoring the regexp pattern. This fixes #1025.

[1] https://github.com/dominikh/go-tools/blob/master/cmd/staticcheck/docs/checks/SA6004 says 2018-07-28 even if the relevant commit timestamp is from 2017.