### PR TITLE
Disable wifi collector by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 supvervisord collector reports "start_time_seconds" rather than "uptime"
 
+The wifi collector is disabled by default due to suspected cashing issues and goroutine leaks.
+* https://github.com/prometheus/node_exporter/issues/870
+* https://github.com/prometheus/node_exporter/issues/1008
+
 * [CHANGE] Filter out non-installed units when collecting all systemd units #1011
 * [FEATURE] Collect NRefused property for systemd socket units (available as of systemd v239)
 * [FEATURE] Collect NRestarts property for systemd service units

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 supvervisord collector reports "start_time_seconds" rather than "uptime"
 
-The wifi collector is disabled by default due to suspected cashing issues and goroutine leaks.
+The wifi collector is disabled by default due to suspected caching issues and goroutine leaks.
 * https://github.com/prometheus/node_exporter/issues/870
 * https://github.com/prometheus/node_exporter/issues/1008
 

--- a/collector/wifi_linux.go
+++ b/collector/wifi_linux.go
@@ -45,7 +45,7 @@ var (
 )
 
 func init() {
-	registerCollector("wifi", defaultEnabled, NewWifiCollector)
+	registerCollector("wifi", defaultDisabled, NewWifiCollector)
 }
 
 var _ wifiStater = &wifi.Client{}


### PR DESCRIPTION
Disable the wifi collector by default due to suspected cashing issues and goroutine leaks.
* https://github.com/prometheus/node_exporter/issues/870
* https://github.com/prometheus/node_exporter/issues/1008

Signed-off-by: Ben Kochie <superq@gmail.com>