### PR TITLE
Don't ignore unit if NRestarts isn't available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,12 @@ The wifi collector is disabled by default due to suspected caching issues and go
 * https://github.com/prometheus/node_exporter/issues/1008
 
 * [CHANGE] Filter out non-installed units when collecting all systemd units #1011
+* [CHANGE] `service_restart_total` and `socket_refused_connections_total` will not be reported if you're running an older version of systemd
 * [FEATURE] Collect NRefused property for systemd socket units (available as of systemd v239)
 * [FEATURE] Collect NRestarts property for systemd service units
 * [FEATURE] Add socket unit stats to systemd collector #968
 * [FEATURE] Collect start time for systemd units
-* [ENHANCEMENT]
-* [BUGFIX]
-
+* [BUGFIX] Systemd units will not be ignored if you're running older versions of systemd
 * [BUGFIX] Fix goroutine leak in supervisord collector
 
 ## 0.16.0 / 2018-05-15


### PR DESCRIPTION
Pulled from #1036. The latest systemd in our CentOS is not new enough to have NRestarts so this effectively means the systemd collector cannot collect any services. Instead of ignoring a service without NRestarts, just log and leave it at 0.

Fixes: https://github.com/prometheus/node_exporter/issues/567

@SuperQ @discordianfish 