### PR TITLE
Update build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - checkout
     - run: make promu
-    - run: promu crossbuild -v --go 1.9
+    - run: promu crossbuild -v --go 1.10
     - persist_to_workspace:
         root: .
         paths:

--- a/.promu.yml
+++ b/.promu.yml
@@ -26,7 +26,8 @@ crossbuild:
         - netbsd/386
         - linux/arm
         - linux/arm64
+        - linux/mips
+        - linux/mipsle
+        - linux/mips64
+        - linux/mips64le
         - linux/ppc64le
-        # Temporarily deactivated as this does not currently build with promu.
-        #- linux/mips64
-        #- linux/mips64le

--- a/.promu.yml
+++ b/.promu.yml
@@ -26,6 +26,7 @@ crossbuild:
         - netbsd/386
         - linux/arm
         - linux/arm64
+        - linux/ppc64le
         # Temporarily deactivated as this does not currently build with promu.
         #- linux/mips64
         #- linux/mips64le


### PR DESCRIPTION
* Update to Go 1.10.
* Enable `ppc64le` build.
* Enable MIPS builds.

Signed-off-by: Ben Kochie <superq@gmail.com>