### PR TITLE
Handle vanishing PIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ The wifi collector is disabled by default due to suspected caching issues and go
 * [FEATURE] Add socket unit stats to systemd collector #968
 * [FEATURE] Collect start time for systemd units
 * [ENHANCEMENT]
-* [BUGFIX]
 
 * [BUGFIX] Fix goroutine leak in supervisord collector
+* [BUGFIX] Handle vanishing PIDs #1043
 
 ## 0.16.0 / 2018-05-15
 


### PR DESCRIPTION
PIDs can vanish (exit) from /proc/ between gathering the list of PIDs
and getting all of their stats.
* Ignore file not found errors.
* Explicitly count the PIDs we find.
* Cleanup some error style issues.

Fixes: https://github.com/prometheus/node_exporter/issues/1042

Signed-off-by: Ben Kochie <superq@gmail.com>