### PR TITLE
vendor: bump github.com/mdlayher/wifi and dependencies

### DIFF
--- a/vendor/github.com/mdlayher/genetlink/conn.go
+++ b/vendor/github.com/mdlayher/genetlink/conn.go
@@ -67,6 +67,16 @@ func (c *Conn) SetBPF(filter []bpf.RawInstruction) error {
 	return c.c.SetBPF(filter)
 }
 
+// RemoveBPF removes a BPF filter from a Conn.
+func (c *Conn) RemoveBPF() error {
+	return c.c.RemoveBPF()
+}
+
+// SetOption enables or disables a netlink socket option for the Conn.
+func (c *Conn) SetOption(option netlink.ConnOption, enable bool) error {
+	return c.c.SetOption(option, enable)
+}
+
 // Send sends a single Message to netlink, wrapping it in a netlink.Message
 // using the specified generic netlink family and flags.  On success, Send
 // returns a copy of the netlink.Message with all parameters populated, for

--- a/vendor/github.com/mdlayher/netlink/conn_linux.go
+++ b/vendor/github.com/mdlayher/netlink/conn_linux.go
@@ -94,6 +94,25 @@ func bind(s socket, config *Config) (*conn, uint32, error) {
 	}, pid, nil
 }
 
+// SendMessages serializes multiple Messages and sends them to netlink.
+func (c *conn) SendMessages(messages []Message) error {
+	var buf []byte
+	for _, m := range messages {
+		b, err := m.MarshalBinary()
+		if err != nil {
+			return err
+		}
+
+		buf = append(buf, b...)
+	}
+
+	addr := &unix.SockaddrNetlink{
+		Family: unix.AF_NETLINK,
+	}
+
+	return c.s.Sendmsg(buf, nil, addr, 0)
+}
+
 // Send sends a single Message to netlink.
 func (c *conn) Send(m Message) error {
 	b, err := m.MarshalBinary()
@@ -112,7 +131,10 @@ func (c *conn) Send(m Message) error {
 func (c *conn) Receive() ([]Message, error) {
 	b := make([]byte, os.Getpagesize())
 	for {
-		// Peek at the buffer to see how many bytes are available
+		// Peek at the buffer to see how many bytes are available.
+		//
+		// TODO(mdlayher): deal with OOB message data if available, such as
+		// when PacketInfo ConnOption is true.
 		n, _, _, _, err := c.s.Recvmsg(b, nil, unix.MSG_PEEK)
 		if err != nil {
 			return nil, err
@@ -204,6 +226,58 @@ func (c *conn) SetBPF(filter []bpf.RawInstruction) error {
 	)
 }
 
+// RemoveBPF removes a BPF filter from a conn.
+func (c *conn) RemoveBPF() error {
+	// dummy is ignored as argument to SO_DETACH_FILTER
+	// but SetSockopt requires it as an argument
+	var dummy uint32
+	return c.s.SetSockopt(
+		unix.SOL_SOCKET,
+		unix.SO_DETACH_FILTER,
+		unsafe.Pointer(&dummy),
+		uint32(unsafe.Sizeof(dummy)),
+	)
+}
+
+// SetOption enables or disables a netlink socket option for the Conn.
+func (c *conn) SetOption(option ConnOption, enable bool) error {
+	o, ok := linuxOption(option)
+	if !ok {
+		// Return the typical Linux error for an unknown ConnOption.
+		return unix.ENOPROTOOPT
+	}
+
+	var v uint32
+	if enable {
+		v = 1
+	}
+
+	return c.s.SetSockopt(
+		unix.SOL_NETLINK,
+		o,
+		unsafe.Pointer(&v),
+		uint32(unsafe.Sizeof(v)),
+	)
+}
+
+// linuxOption converts a ConnOption to its Linux value.
+func linuxOption(o ConnOption) (int, bool) {
+	switch o {
+	case PacketInfo:
+		return unix.NETLINK_PKTINFO, true
+	case BroadcastError:
+		return unix.NETLINK_BROADCAST_ERROR, true
+	case NoENOBUFS:
+		return unix.NETLINK_NO_ENOBUFS, true
+	case ListenAllNSID:
+		return unix.NETLINK_LISTEN_ALL_NSID, true
+	case CapAcknowledge:
+		return unix.NETLINK_CAP_ACK, true
+	default:
+		return 0, false
+	}
+}
+
 // sysToHeader converts a syscall.NlMsghdr to a Header.
 func sysToHeader(r syscall.NlMsghdr) Header {
 	// NB: the memory layout of Header and syscall.NlMsgHdr must be
@@ -247,10 +321,20 @@ func newSysSocket(lockThread bool) *sysSocket {
 		// But since this is very experimental, we'll leave it as a configurable at
 		// this point.
 		if lockThread {
-			// Never unlock the OS thread, so that the thread will terminate when
-			// the goroutine exits starting in Go 1.10:
+			// The intent is to never unlock the OS thread, so that the thread
+			// will terminate when the goroutine exits starting in Go 1.10:
 			// https://go-review.googlesource.com/c/go/+/46038.
+			//
+			// However, due to recent instability and a potential bad interaction
+			// with the Go runtime for threads which are not unlocked, we have
+			// elected to temporarily unlock the thread:
+			// https://github.com/golang/go/issues/25128#issuecomment-410764489.
+			//
+			// If we ever allow a Conn to set its own network namespace, we must
+			// either ensure that the namespace is restored on exit here or that
+			// the thread is properly terminated at some point in the future.
 			runtime.LockOSThread()
+			defer runtime.UnlockOSThread()
 		}
 
 		defer wg.Done()

--- a/vendor/github.com/mdlayher/netlink/conn_others.go
+++ b/vendor/github.com/mdlayher/netlink/conn_others.go
@@ -5,14 +5,12 @@ package netlink
 import (
 	"fmt"
 	"runtime"
-
-	"golang.org/x/net/bpf"
 )
 
 var (
 	// errUnimplemented is returned by all functions on platforms that
 	// cannot make use of netlink sockets.
-	errUnimplemented = fmt.Errorf("netlink sockets not implemented on %s/%s",
+	errUnimplemented = fmt.Errorf("netlink: not implemented on %s/%s",
 		runtime.GOOS, runtime.GOARCH)
 )
 
@@ -21,42 +19,13 @@ var _ Socket = &conn{}
 // A conn is the no-op implementation of a netlink sockets connection.
 type conn struct{}
 
-// dial is the entry point for Dial.  dial always returns an error.
-func dial(family int, config *Config) (*conn, uint32, error) {
-	return nil, 0, errUnimplemented
-}
+// All cross-platform functions and Socket methods are unimplemented outside
+// of Linux.
 
-// Send always returns an error.
-func (c *conn) Send(m Message) error {
-	return errUnimplemented
-}
+func dial(_ int, _ *Config) (*conn, uint32, error) { return nil, 0, errUnimplemented }
+func newError(_ int) error                         { return errUnimplemented }
 
-// Receive always returns an error.
-func (c *conn) Receive() ([]Message, error) {
-	return nil, errUnimplemented
-}
-
-// Close always returns an error.
-func (c *conn) Close() error {
-	return errUnimplemented
-}
-
-// JoinGroup always returns an error.
-func (c *conn) JoinGroup(group uint32) error {
-	return errUnimplemented
-}
-
-// LeaveGroup always returns an error.
-func (c *conn) LeaveGroup(group uint32) error {
-	return errUnimplemented
-}
-
-// SetBPF always returns an error.
-func (c *conn) SetBPF(filter []bpf.RawInstruction) error {
-	return errUnimplemented
-}
-
-// newError always returns an error.
-func newError(errno int) error {
-	return errUnimplemented
-}
+func (c *conn) Send(_ Message) error           { return errUnimplemented }
+func (c *conn) SendMessages(_ []Message) error { return errUnimplemented }
+func (c *conn) Receive() ([]Message, error)    { return nil, errUnimplemented }
+func (c *conn) Close() error                   { return errUnimplemented }

--- a/vendor/github.com/mdlayher/netlink/debug.go
+++ b/vendor/github.com/mdlayher/netlink/debug.go
@@ -1,0 +1,71 @@
+package netlink
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+)
+
+var (
+	// Arguments used to create a debugger.
+	debugArgs []string
+)
+
+func init() {
+	// Is netlink debugging enabled?
+	s := os.Getenv("NLDEBUG")
+	if s == "" {
+		return
+	}
+
+	debugArgs = strings.Split(s, ",")
+}
+
+// A debugger is used to provide debugging information about a netlink connection.
+type debugger struct {
+	Log   *log.Logger
+	Level int
+}
+
+// newDebugger creates a debugger by parsing key=value arguments.
+func newDebugger(args []string) *debugger {
+	d := &debugger{
+		Log:   log.New(os.Stderr, "nl: ", 0),
+		Level: 1,
+	}
+
+	for _, a := range args {
+		kv := strings.Split(a, "=")
+		if len(kv) != 2 {
+			// Ignore malformed pairs and assume callers wants defaults.
+			continue
+		}
+
+		switch kv[0] {
+		// Select the log level for the debugger.
+		case "level":
+			level, err := strconv.Atoi(kv[1])
+			if err != nil {
+				panicf("netlink: invalid NLDEBUG level: %q", a)
+			}
+
+			d.Level = level
+		}
+	}
+
+	return d
+}
+
+// debugf prints debugging information at the specified level, if d.Level is
+// high enough to print the message.
+func (d *debugger) debugf(level int, format string, v ...interface{}) {
+	if d.Level >= level {
+		d.Log.Printf(format, v...)
+	}
+}
+
+func panicf(format string, a ...interface{}) {
+	panic(fmt.Sprintf(format, a...))
+}

--- a/vendor/github.com/mdlayher/netlink/doc.go
+++ b/vendor/github.com/mdlayher/netlink/doc.go
@@ -1,2 +1,22 @@
 // Package netlink provides low-level access to Linux netlink sockets.
+//
+//
+// Debugging
+//
+// This package supports rudimentary netlink connection debugging support.
+// To enable this, run your binary with the NLDEBUG environment variable set.
+// Debugging information will be output to stderr with a prefix of "nl:".
+//
+// To use the debugging defaults, use:
+//
+//   $ NLDEBUG=1 ./nlctl
+//
+// To configure individual aspects of the debugger, pass key/value options such
+// as:
+//
+//   $ NLDEBUG=level=1 ./nlctl
+//
+// Available key/value debugger options include:
+//
+//   level=N: specify the debugging level (only "1" is currently supported)
 package netlink

--- a/vendor/github.com/mdlayher/netlink/nlenc/endian.go
+++ b/vendor/github.com/mdlayher/netlink/nlenc/endian.go
@@ -1,0 +1,16 @@
+package nlenc
+
+import (
+	"encoding/binary"
+)
+
+// NativeEndian returns the native byte order of this system.
+func NativeEndian() binary.ByteOrder {
+	// Determine endianness by storing a uint16 in a byte slice.
+	b := Uint16Bytes(1)
+	if b[0] == 1 {
+		return binary.LittleEndian
+	}
+
+	return binary.BigEndian
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -85,28 +85,28 @@
 			"versionExact": "v1.0.0"
 		},
 		{
-			"checksumSHA1": "VZIJG8dML/XqZbL9bpeDNgkazcg=",
+			"checksumSHA1": "zLH8BV9kYzpqGB5PS4VDjADFvVM=",
 			"path": "github.com/mdlayher/genetlink",
-			"revision": "76fecce4c787fb8eaa21a8755f722d67c53038e1",
-			"revisionTime": "2017-09-01T18:19:24Z"
+			"revision": "ca85b5a307448462b0aa7a07c67c0846bc12568f",
+			"revisionTime": "2018-07-28T17:03:40Z"
 		},
 		{
-			"checksumSHA1": "S6NatJYh1aOFzSIs6Agp2R0ydtM=",
+			"checksumSHA1": "ybkJbYD6wyjdoPp/KncnDpCyYiU=",
 			"path": "github.com/mdlayher/netlink",
-			"revision": "756e798fb38fac19fb2234d3acc32e902bc1af44",
-			"revisionTime": "2017-12-14T18:12:53Z"
+			"revision": "80a6f93efd374ddee4e0ea862ca0085ef42eed65",
+			"revisionTime": "2018-08-10T15:28:04Z"
 		},
 		{
-			"checksumSHA1": "9nig0WuuiTICStI/8S+pIGqYksc=",
+			"checksumSHA1": "P7eEo2V7/kQEkt2ihW+26S39eEw=",
 			"path": "github.com/mdlayher/netlink/nlenc",
-			"revision": "756e798fb38fac19fb2234d3acc32e902bc1af44",
-			"revisionTime": "2017-12-14T18:12:53Z"
+			"revision": "80a6f93efd374ddee4e0ea862ca0085ef42eed65",
+			"revisionTime": "2018-08-10T15:28:04Z"
 		},
 		{
 			"checksumSHA1": "Y7cjrOeOvA/ic+B8WCp2JyLEuvs=",
 			"path": "github.com/mdlayher/wifi",
-			"revision": "9a2549315201616119128afe421d1601ef3506f9",
-			"revisionTime": "2018-06-15T12:49:15Z"
+			"revision": "efdf3f4195d9fc8b73013b3706fe626b7fb807d8",
+			"revisionTime": "2018-07-27T16:38:19Z"
 		},
 		{
 			"checksumSHA1": "VzutdH69PUqRqhrDVv6F91ebQd4=",


### PR DESCRIPTION
We're dealing with a possible Go runtime bug as part of https://github.com/prometheus/node_exporter/issues/870, so this updates the wifi dependency to a patch I've had some luck with that seems to stop the potential bad runtime interaction found in: https://github.com/golang/go/issues/25128.

The key point is that the OS thread is now unlocked before a netlink connection is terminated.