### PR TITLE
smartmon.sh: Shellcheck, and support more OSes

### DIFF
--- a/text_collector_examples/smartmon.sh
+++ b/text_collector_examples/smartmon.sh
@@ -7,8 +7,6 @@
 #       data in them than you'd think.
 #       http://arstechnica.com/civis/viewtopic.php?p=22062211
 
-PATH="/usr/sbin:$PATH"
-
 set -euo pipefail
 
 parse_smartctl_attributes_awk="$(cat << 'SMARTCTLAWK'

--- a/text_collector_examples/smartmon.sh
+++ b/text_collector_examples/smartmon.sh
@@ -9,7 +9,7 @@
 
 PATH="/usr/sbin:$PATH"
 
-set -eu
+set -euo pipefail
 
 parse_smartctl_attributes_awk="$(cat << 'SMARTCTLAWK'
 $1 ~ /^ *[0-9]+$/ && $2 ~ /^[a-zA-Z0-9_-]+$/ {
@@ -66,7 +66,7 @@ parse_smartctl_attributes() {
   local disk="$1"
   local disk_type="$2"
   local labels="disk=\"${disk}\",type=\"${disk_type}\""
-  
+
   sed 's/^ \+//g' \
     | awk -v labels="${labels}" "${parse_smartctl_attributes_awk}" 2>/dev/null \
     | tr '[:upper:]' '[:lower:]' \

--- a/text_collector_examples/smartmon.sh
+++ b/text_collector_examples/smartmon.sh
@@ -7,7 +7,7 @@
 #       data in them than you'd think.
 #       http://arstechnica.com/civis/viewtopic.php?p=22062211
 
-set -euo pipefail
+set -uo pipefail
 
 parse_smartctl_attributes_awk="$(cat << 'SMARTCTLAWK'
 $1 ~ /^ *[0-9]+$/ && $2 ~ /^[a-zA-Z0-9_-]+$/ {


### PR DESCRIPTION
 - Hard-coding /usr/sbin/smartmon breaks it on OSes where smartmon isn't there. Instead, I explicitly add it to the PATH to support the existing use cases.
 - Use `/usr/bin/env bash` to find bash
 - Improve various quotings to be safer
 - Simplify the definition of smartmon_attrs