### PR TITLE
Fix typo on description of read_time_seconds_total

### DIFF
--- a/collector/diskstats_linux.go
+++ b/collector/diskstats_linux.go
@@ -96,7 +96,7 @@ func NewDiskstatsCollector() (Collector, error) {
 			{
 				desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, diskSubsystem, "read_time_seconds_total"),
-					"The total number of milliseconds spent by all reads.",
+					"The total number of seconds spent by all reads.",
 					diskLabelNames,
 					nil,
 				), valueType: prometheus.CounterValue,

--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -350,7 +350,7 @@ node_disk_read_bytes_total{device="nvme0n1"} 2.377714176e+09
 node_disk_read_bytes_total{device="sda"} 5.13713216512e+11
 node_disk_read_bytes_total{device="sr0"} 0
 node_disk_read_bytes_total{device="vda"} 1.6727491584e+10
-# HELP node_disk_read_time_seconds_total The total number of milliseconds spent by all reads.
+# HELP node_disk_read_time_seconds_total The total number of seconds spent by all reads.
 # TYPE node_disk_read_time_seconds_total counter
 node_disk_read_time_seconds_total{device="dm-0"} 46229.572
 node_disk_read_time_seconds_total{device="dm-1"} 0.084

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -350,7 +350,7 @@ node_disk_read_bytes_total{device="nvme0n1"} 2.377714176e+09
 node_disk_read_bytes_total{device="sda"} 5.13713216512e+11
 node_disk_read_bytes_total{device="sr0"} 0
 node_disk_read_bytes_total{device="vda"} 1.6727491584e+10
-# HELP node_disk_read_time_seconds_total The total number of milliseconds spent by all reads.
+# HELP node_disk_read_time_seconds_total The total number of seconds spent by all reads.
 # TYPE node_disk_read_time_seconds_total counter
 node_disk_read_time_seconds_total{device="dm-0"} 46229.572
 node_disk_read_time_seconds_total{device="dm-1"} 0.084


### PR DESCRIPTION
@SuperQ @languitar 
Fix typo on unit description of metric `*read_time_seconds_total` from milliseconds to seconds.