### PR TITLE
Correctly cast Darwin memory info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master / unreleased
 
-**Breaking changes**
+### **Breaking changes**
 
 supvervisord collector reports "start_time_seconds" rather than "uptime"
 
@@ -8,6 +8,9 @@ The wifi collector is disabled by default due to suspected caching issues and go
 * https://github.com/prometheus/node_exporter/issues/870
 * https://github.com/prometheus/node_exporter/issues/1008
 
+Darwin meminfo metrics have been renamed to match Prometheus conventions. #1060
+
+### Changes
 * [CHANGE] Filter out non-installed units when collecting all systemd units #1011
 * [CHANGE] `service_restart_total` and `socket_refused_connections_total` will not be reported if you're running an older version of systemd
 * [FEATURE] Collect NRefused property for systemd socket units (available as of systemd v239)
@@ -19,6 +22,7 @@ The wifi collector is disabled by default due to suspected caching issues and go
 * [BUGFIX] Fix goroutine leak in supervisord collector
 * [BUGFIX] Systemd units will not be ignored if you're running older versions of systemd #1039
 * [BUGFIX] Handle vanishing PIDs #1043
+* [BUGFIX] Correctly cast Darwin memory info #1060
 
 ## 0.16.0 / 2018-05-15
 

--- a/collector/meminfo_darwin.go
+++ b/collector/meminfo_darwin.go
@@ -46,14 +46,14 @@ func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 	// Syscall removes terminating NUL which we need to cast to uint64
 	total := binary.LittleEndian.Uint64([]byte(totalb + "\x00"))
 
-	ps := C.natural_t(syscall.Getpagesize())
+	ps := float64(C.natural_t(syscall.Getpagesize()))
 	return map[string]float64{
-		"active_bytes_total":      float64(ps * vmstat.active_count),
-		"inactive_bytes_total":    float64(ps * vmstat.inactive_count),
-		"wired_bytes_total":       float64(ps * vmstat.wire_count),
-		"free_bytes_total":        float64(ps * vmstat.free_count),
-		"swapped_in_pages_total":  float64(ps * vmstat.pageins),
-		"swapped_out_pages_total": float64(ps * vmstat.pageouts),
-		"bytes_total":             float64(total),
+		"active_bytes":            ps * float64(vmstat.active_count),
+		"inactive_bytes":          ps * float64(vmstat.inactive_count),
+		"wired_bytes":             ps * float64(vmstat.wire_count),
+		"free_bytes":              ps * float64(vmstat.free_count),
+		"swapped_in_bytes_total":  ps * float64(vmstat.pageins),
+		"swapped_out_bytes_total": ps * float64(vmstat.pageouts),
+		"total_bytes":             float64(total),
 	}, nil
 }


### PR DESCRIPTION
* Cast stats to float64 before doing math on them to avoid integer
wrapping.
* Remove invalid `_total` suffix from gauge values.

Fixes: https://github.com/prometheus/node_exporter/issues/855

Signed-off-by: Ben Kochie <superq@gmail.com>