### PR TITLE
collector/timex: remove cgo dependency

### DIFF
--- a/collector/timex.go
+++ b/collector/timex.go
@@ -16,9 +16,6 @@
 
 package collector
 
-// #include <sys/timex.h>
-import "C"
-
 import (
 	"fmt"
 	"syscall"
@@ -27,10 +24,13 @@ import (
 )
 
 const (
-	// The system clock is not synchronized to a reliable server.
-	timeError = C.TIME_ERROR
-	// The timex.Status time resolution bit, 0 = microsecond, 1 = nanoseconds.
-	staNano = C.STA_NANO
+	// The system clock is not synchronized to a reliable
+	// server (TIME_ERROR).
+	timeError = 5
+	// The timex.Status time resolution bit (STA_NANO),
+	// 0 = microsecond, 1 = nanoseconds.
+	staNano = 0x2000
+
 	// 1 second in
 	nanoSeconds  = 1000000000
 	microSeconds = 1000000


### PR DESCRIPTION
This removes the cgo import from timex collector, as it was only used
to define two constants. Those are part of the Linux kernel<->userspace
interface, thus there is no need to depend on libc to source them:
https://github.com/torvalds/linux/blob/v4.18/include/uapi/linux/timex.h

Signed-off-by: Luca Bruno <luca.bruno@coreos.com>