### PR TITLE
Change systemd unit filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Darwin meminfo metrics have been renamed to match Prometheus conventions. #1060
 * [BUGFIX] Systemd units will not be ignored if you're running older versions of systemd #1039
 * [BUGFIX] Handle vanishing PIDs #1043
 * [BUGFIX] Correctly cast Darwin memory info #1060
+* [BUGFIX] Filter systemd units in Go for compatibility with older versions #1083
 
 ## 0.16.0 / 2018-05-15
 

--- a/collector/systemd_linux_test.go
+++ b/collector/systemd_linux_test.go
@@ -126,7 +126,8 @@ func TestSystemdIgnoreFilterDefaultKeepsAll(t *testing.T) {
 	fixtures := getUnitListFixtures()
 	collector := c.(*systemdCollector)
 	filtered := filterUnits(fixtures[0], collector.unitWhitelistPattern, collector.unitBlacklistPattern)
-	if len(filtered) != len(fixtures[0]) {
+	// Adjust fixtures by 3 "not-found" units.
+	if len(filtered) != len(fixtures[0])-3 {
 		t.Error("Default filters removed units")
 	}
 }


### PR DESCRIPTION
Get all units from systemd and filter in Go.
* Improves compatibility with older versions of systemd.
* Improve debugging by printing when units pass the filter.
* Remove extraneous newlines from log messages.

Signed-off-by: Ben Kochie <superq@gmail.com>

Fixes: https://github.com/prometheus/node_exporter/issues/1075