### PR TITLE
Update cpu collector for OpenBSD 6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Darwin meminfo metrics have been renamed to match Prometheus conventions. #1060
 * [BUGFIX] Handle vanishing PIDs #1043
 * [BUGFIX] Correctly cast Darwin memory info #1060
 * [BUGFIX] Filter systemd units in Go for compatibility with older versions #1083
+* [BUGFIX] Update cpu collector for OpenBSD 6.4
 
 ## 0.16.0 / 2018-05-15
 

--- a/collector/cpu_openbsd.go
+++ b/collector/cpu_openbsd.go
@@ -59,10 +59,12 @@ func (c *cpuCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	var cp_time [][C.CPUSTATES]C.int64_t
 	for i := 0; i < int(ncpus); i++ {
 		cp_timeb, err := unix.SysctlRaw("kern.cp_time2", i)
-		if err != nil {
+		if err != nil && err != unix.ENODEV {
 			return err
 		}
-		cp_time = append(cp_time, *(*[C.CPUSTATES]C.int64_t)(unsafe.Pointer(&cp_timeb[0])))
+		if err != unix.ENODEV {
+			cp_time = append(cp_time, *(*[C.CPUSTATES]C.int64_t)(unsafe.Pointer(&cp_timeb[0])))
+		}
 	}
 
 	for cpu, time := range cp_time {


### PR DESCRIPTION
Starting with (not yet released) OpenBSD 6.4, sysctl KERN_CPTIME2 will
return ENODEV for offline CPUs.

SMT siblings are reported as offline when hw.smt is disabled, which is
the default since one of the later Spectre variants. So this might
affect a few systems.

For more details see:
https://cvsweb.openbsd.org/src/sys/kern/kern_sysctl.c#rev1.348

Signed-off-by: Ralf Horstmann <ralf@ackstorm.de>

@SuperQ @discordianfish 