### PR TITLE
launchctl example based on LaunchDaemons

### DIFF
--- a/examples/launchctl/README.md
+++ b/examples/launchctl/README.md
@@ -1,17 +1,16 @@
-# MacOS LaunchAgent
+# MacOS LaunchDaemon
 
 If you're installing through a package manager, you probably don't need to deal
 with this file.
 
-The `plist` file should be put in `~/Library/LaunchAgents/` (user-install) or
-`/Library/LaunchAgents/` (global install), and the binary installed at
+The `plist` file should be put in `/Library/LaunchDaemons/` (user defined daemons), and the binary installed at
 `/usr/local/bin/node_exporter`.
 
 Ex. install globally by
 
     sudo cp -n node_exporter /usr/local/bin/
-    sudo cp -n examples/launchctl/io.prometheus.node_exporter.plist /Library/LaunchAgents/
-    sudo launchctl bootstrap system/ /Library/LaunchAgents/io.prometheus.node_exporter.plist
+    sudo cp -n examples/launchctl/io.prometheus.node_exporter.plist /Library/LaunchDaemons/
+    sudo launchctl bootstrap system/ /Library/LaunchDaemons/io.prometheus.node_exporter.plist
 
     # Optionally configure by dropping CLI arguments in a file
     echo -- '--web.listen-address=:9101' | sudo tee /usr/local/etc/node_exporter.args


### PR DESCRIPTION
LaunchDaemons are the correct way to create services that are restart proof.
There is now only a single destination place mentioned in the readme for the plist file.

Signed-off-by: David Balakirev <dave00ster@gmail.com>