### PR TITLE
Handle 'Unknown' as measurement value.

### DIFF
--- a/text_collector_examples/storcli.py
+++ b/text_collector_examples/storcli.py
@@ -171,8 +171,9 @@ def print_all_metrics(metrics):
         print('# HELP {}{} MegaRAID {}'.format(metric_prefix, metric, metric.replace('_', ' ')))
         print('# TYPE {}{} gauge'.format(metric_prefix, metric))
         for measurement in measurements:
-            print('{}{}{} {}'.format(metric_prefix, metric, '{' + measurement['labels'] + '}',
-                                     measurement['value']))
+            if measurement['value'] != 'Unknown':
+                print('{}{}{} {}'.format(metric_prefix, metric, '{' + measurement['labels'] + '}',
+                                         measurement['value']))
 
 
 def get_storcli_json(storcli_args):


### PR DESCRIPTION
We use the output-compatible perccli and storcli.py does not handle 'Unknown' as a result:
```
sg="Error parsing \"/var/lib/node_exporter/perccli.prom\": text format parsing error in line 222: expected float as value, got \"Unknown\"" source="textfile.go:212"
```
I know, the perccli should not return 'Unknown' but this error breaks all other useful measurements because the prom file is not parsable. My if condition fixes this.