### PR TITLE
collector/hwmon_linux: handle temperature sensor file which doesn't h…

### DIFF
--- a/collector/hwmon_linux.go
+++ b/collector/hwmon_linux.go
@@ -274,6 +274,9 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) er
 				continue
 			}
 			if sensorType == "temp" && element != "type" {
+				if element == "" {
+					element = "input"
+				}
 				desc := prometheus.NewDesc(name+"_celsius", "Hardware monitor for temperature ("+element+")", hwmonLabelDesc, nil)
 				ch <- prometheus.MustNewConstMetric(
 					desc, prometheus.GaugeValue, parsedValue*0.001, labels...)


### PR DESCRIPTION
…ave item suffix

In some cases the file might be called "temp" instead of the usual format "temp<index>_<item>"
as described in the kernel docs: https://www.kernel.org/doc/Documentation/hwmon/sysfs-interface
In this case, treat this as an _input file containing the current temperature reading.

Fixes #1122

Signed-off-by: Paul Gier <pgier@redhat.com>