### PR TITLE
 Change Dfly's CPU counting frequency, see: #1129

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [BUGFIX]
 * [CHANGE]
-* [ENHANCEMENT]
+* [ENHANCEMENT] Add Infiniband counters #1120
 * [FEATURE]
 
 ## 0.17.0-rc.0 / 2018-10-19

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ $(eval $(call goarch_pair,amd64,386))
 $(eval $(call goarch_pair,mips64,mips))
 $(eval $(call goarch_pair,mips64el,mipsel))
 
-all: style vet staticcheck checkmetrics build test $(cross-test) $(test-e2e)
+all: style vet staticcheck checkmetrics checkrules build test $(cross-test) $(test-e2e)
 
 .PHONY: test
 test: collector/fixtures/sys/.unpacked
@@ -120,6 +120,11 @@ skip-test-e2e:
 checkmetrics: $(PROMTOOL)
 	@echo ">> checking metrics for correctness"
 	./checkmetrics.sh $(PROMTOOL) $(e2e-out)
+
+.PHONY: checkrules
+checkrules: $(PROMTOOL)
+	@echo ">> checking rules for correctness"
+	find . -name "*rules*.yml" | xargs -I {} $(PROMTOOL) check rules {}
 
 .PHONY: docker
 docker:

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -71,12 +71,12 @@ func registerCollector(collector string, isDefaultEnabled bool, factory func() (
 }
 
 // NodeCollector implements the prometheus.Collector interface.
-type nodeCollector struct {
+type NodeCollector struct {
 	Collectors map[string]Collector
 }
 
-// NewNodeCollector creates a new NodeCollector
-func NewNodeCollector(filters ...string) (*nodeCollector, error) {
+// NewNodeCollector creates a new NodeCollector.
+func NewNodeCollector(filters ...string) (*NodeCollector, error) {
 	f := make(map[string]bool)
 	for _, filter := range filters {
 		enabled, exist := collectorState[filter]
@@ -100,17 +100,17 @@ func NewNodeCollector(filters ...string) (*nodeCollector, error) {
 			}
 		}
 	}
-	return &nodeCollector{Collectors: collectors}, nil
+	return &NodeCollector{Collectors: collectors}, nil
 }
 
 // Describe implements the prometheus.Collector interface.
-func (n nodeCollector) Describe(ch chan<- *prometheus.Desc) {
+func (n NodeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- scrapeDurationDesc
 	ch <- scrapeSuccessDesc
 }
 
 // Collect implements the prometheus.Collector interface.
-func (n nodeCollector) Collect(ch chan<- prometheus.Metric) {
+func (n NodeCollector) Collect(ch chan<- prometheus.Metric) {
 	wg := sync.WaitGroup{}
 	wg.Add(len(n.Collectors))
 	for name, c := range n.Collectors {

--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -31,7 +31,7 @@ import (
 #include <stdio.h>
 
 int
-getCPUTimes(uint64_t **cputime, size_t *cpu_times_len, long *freq) {
+getCPUTimes(uint64_t **cputime, size_t *cpu_times_len) {
 	size_t len;
 
 	// Get number of cpu cores.
@@ -41,15 +41,6 @@ getCPUTimes(uint64_t **cputime, size_t *cpu_times_len, long *freq) {
 	mib[1] = HW_NCPU;
 	len = sizeof(ncpu);
 	if (sysctl(mib, 2, &ncpu, &len, NULL, 0)) {
-		return -1;
-	}
-
-	// The bump on each statclock is
-	// ((cur_systimer - prev_systimer) * systimer_freq) >> 32
-	// where
-	// systimer_freq = sysctl kern.cputimer.freq
-	len = sizeof(*freq);
-	if (sysctlbyname("kern.cputimer.freq", freq, &len, NULL, 0)) {
 		return -1;
 	}
 
@@ -103,18 +94,16 @@ func getDragonFlyCPUTimes() ([]float64, error) {
 	// CPUSTATES (number of CPUSTATES) is defined as 5U.
 	// States: CP_USER | CP_NICE | CP_SYS | CP_IDLE | CP_INTR
 	//
-	// Each value is a counter incremented at frequency
-	//   kern.cputimer.freq
+	// Each value is in microseconds
 	//
 	// Look into sys/kern/kern_clock.c for details.
 
 	var (
 		cpuTimesC      *C.uint64_t
-		cpuTimerFreq   C.long
 		cpuTimesLength C.size_t
 	)
 
-	if C.getCPUTimes(&cpuTimesC, &cpuTimesLength, &cpuTimerFreq) == -1 {
+	if C.getCPUTimes(&cpuTimesC, &cpuTimesLength) == -1 {
 		return nil, errors.New("could not retrieve CPU times")
 	}
 	defer C.free(unsafe.Pointer(cpuTimesC))
@@ -123,7 +112,7 @@ func getDragonFlyCPUTimes() ([]float64, error) {
 
 	cpuTimes := make([]float64, cpuTimesLength)
 	for i, value := range cput {
-		cpuTimes[i] = float64(value) / float64(cpuTimerFreq)
+		cpuTimes[i] = float64(value)
 	}
 	return cpuTimes, nil
 }

--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -112,7 +112,7 @@ func getDragonFlyCPUTimes() ([]float64, error) {
 
 	cpuTimes := make([]float64, cpuTimesLength)
 	for i, value := range cput {
-		cpuTimes[i] = float64(value)
+		cpuTimes[i] = float64(value) / float64(1000000)
 	}
 	return cpuTimes, nil
 }

--- a/collector/diskstats_linux.go
+++ b/collector/diskstats_linux.go
@@ -182,7 +182,7 @@ func NewDiskstatsCollector() (Collector, error) {
 			{
 				desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, diskSubsystem, "discarded_sectors_total"),
-					"The total number of sectors discard successfully.",
+					"The total number of sectors discarded successfully.",
 					diskLabelNames,
 					nil,
 				), valueType: prometheus.CounterValue,
@@ -212,11 +212,11 @@ func (c *diskstatsCollector) Update(ch chan<- prometheus.Metric) error {
 			continue
 		}
 
-		if len(stats) > len(c.descs) {
-			return fmt.Errorf("invalid line for %s for %s", procFilePath(diskstatsFilename), dev)
-		}
-
 		for i, value := range stats {
+			// ignore unrecognized additional stats
+			if i >= len(c.descs) {
+				break
+			}
 			v, err := strconv.ParseFloat(value, 64)
 			if err != nil {
 				return fmt.Errorf("invalid value %s in diskstats: %s", value, err)

--- a/collector/filesystem_linux_test.go
+++ b/collector/filesystem_linux_test.go
@@ -16,10 +16,31 @@
 package collector
 
 import (
+	"strings"
 	"testing"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
+
+func Test_parseFilesystemLabelsError(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{
+			name: "too few fields",
+			in:   "hello world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseFilesystemLabels(strings.NewReader(tt.in)); err == nil {
+				t.Fatal("expected an error, but none occurred")
+			}
+		})
+	}
+}
 
 func TestMountPointDetails(t *testing.T) {
 	if _, err := kingpin.CommandLine.Parse([]string{"--path.procfs", "./fixtures/proc"}); err != nil {

--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -293,7 +293,7 @@ node_cpu_seconds_total{cpu="7",mode="user"} 290.98
 # HELP node_disk_discard_time_seconds_total This is the total number of seconds spent by all discards.
 # TYPE node_disk_discard_time_seconds_total counter
 node_disk_discard_time_seconds_total{device="sdb"} 11.13
-# HELP node_disk_discarded_sectors_total The total number of sectors discard successfully.
+# HELP node_disk_discarded_sectors_total The total number of sectors discarded successfully.
 # TYPE node_disk_discarded_sectors_total counter
 node_disk_discarded_sectors_total{device="sdb"} 1.925173784e+09
 # HELP node_disk_discards_completed_total The total number of discards completed successfully.

--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -826,6 +826,14 @@ node_infiniband_multicast_packets_received_total{device="mlx4_0",port="2"} 0
 # TYPE node_infiniband_multicast_packets_transmitted_total counter
 node_infiniband_multicast_packets_transmitted_total{device="mlx4_0",port="1"} 16
 node_infiniband_multicast_packets_transmitted_total{device="mlx4_0",port="2"} 0
+# HELP node_infiniband_port_constraint_errors_received_total Number of packets received on the switch physical port that are discarded
+# TYPE node_infiniband_port_constraint_errors_received_total counter
+node_infiniband_port_constraint_errors_received_total{device="i40iw0",port="1"} 0
+node_infiniband_port_constraint_errors_received_total{device="mlx4_0",port="1"} 0
+# HELP node_infiniband_port_constraint_errors_transmitted_total Number of packets not transmitted from the switch physical port
+# TYPE node_infiniband_port_constraint_errors_transmitted_total counter
+node_infiniband_port_constraint_errors_transmitted_total{device="i40iw0",port="1"} 0
+node_infiniband_port_constraint_errors_transmitted_total{device="mlx4_0",port="1"} 0
 # HELP node_infiniband_port_data_received_bytes_total Number of data octets received on all links
 # TYPE node_infiniband_port_data_received_bytes_total counter
 node_infiniband_port_data_received_bytes_total{device="i40iw0",port="1"} 0
@@ -836,6 +844,29 @@ node_infiniband_port_data_received_bytes_total{device="mlx4_0",port="2"} 0
 node_infiniband_port_data_transmitted_bytes_total{device="i40iw0",port="1"} 0
 node_infiniband_port_data_transmitted_bytes_total{device="mlx4_0",port="1"} 1.493376e+07
 node_infiniband_port_data_transmitted_bytes_total{device="mlx4_0",port="2"} 0
+# HELP node_infiniband_port_discards_received_total Number of inbound packets discarded by the port because the port is down or congested
+# TYPE node_infiniband_port_discards_received_total counter
+node_infiniband_port_discards_received_total{device="mlx4_0",port="1"} 0
+# HELP node_infiniband_port_discards_transmitted_total Number of outbound packets discarded by the port because the port is down or congested
+# TYPE node_infiniband_port_discards_transmitted_total counter
+node_infiniband_port_discards_transmitted_total{device="i40iw0",port="1"} 0
+node_infiniband_port_discards_transmitted_total{device="mlx4_0",port="1"} 5
+# HELP node_infiniband_port_errors_received_total Number of packets containing an error that were received on this port
+# TYPE node_infiniband_port_errors_received_total counter
+node_infiniband_port_errors_received_total{device="i40iw0",port="1"} 0
+node_infiniband_port_errors_received_total{device="mlx4_0",port="1"} 0
+# HELP node_infiniband_port_packets_received_total Number of packets received on all VLs by this port (including errors)
+# TYPE node_infiniband_port_packets_received_total counter
+node_infiniband_port_packets_received_total{device="i40iw0",port="1"} 0
+node_infiniband_port_packets_received_total{device="mlx4_0",port="1"} 6.825908347e+09
+# HELP node_infiniband_port_packets_transmitted_total Number of packets transmitted on all VLs from this port (including errors)
+# TYPE node_infiniband_port_packets_transmitted_total counter
+node_infiniband_port_packets_transmitted_total{device="i40iw0",port="1"} 0
+node_infiniband_port_packets_transmitted_total{device="mlx4_0",port="1"} 6.235865e+06
+# HELP node_infiniband_port_transmit_wait_total Number of ticks during which the port had data to transmit but no data was sent during the entire tick
+# TYPE node_infiniband_port_transmit_wait_total counter
+node_infiniband_port_transmit_wait_total{device="i40iw0",port="1"} 0
+node_infiniband_port_transmit_wait_total{device="mlx4_0",port="1"} 4.294967295e+09
 # HELP node_infiniband_unicast_packets_received_total Number of unicast packets received (including errors)
 # TYPE node_infiniband_unicast_packets_received_total counter
 node_infiniband_unicast_packets_received_total{device="mlx4_0",port="1"} 61148

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -293,7 +293,7 @@ node_cpu_seconds_total{cpu="7",mode="user"} 290.98
 # HELP node_disk_discard_time_seconds_total This is the total number of seconds spent by all discards.
 # TYPE node_disk_discard_time_seconds_total counter
 node_disk_discard_time_seconds_total{device="sdb"} 11.13
-# HELP node_disk_discarded_sectors_total The total number of sectors discard successfully.
+# HELP node_disk_discarded_sectors_total The total number of sectors discarded successfully.
 # TYPE node_disk_discarded_sectors_total counter
 node_disk_discarded_sectors_total{device="sdb"} 1.925173784e+09
 # HELP node_disk_discards_completed_total The total number of discards completed successfully.

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -826,6 +826,14 @@ node_infiniband_multicast_packets_received_total{device="mlx4_0",port="2"} 0
 # TYPE node_infiniband_multicast_packets_transmitted_total counter
 node_infiniband_multicast_packets_transmitted_total{device="mlx4_0",port="1"} 16
 node_infiniband_multicast_packets_transmitted_total{device="mlx4_0",port="2"} 0
+# HELP node_infiniband_port_constraint_errors_received_total Number of packets received on the switch physical port that are discarded
+# TYPE node_infiniband_port_constraint_errors_received_total counter
+node_infiniband_port_constraint_errors_received_total{device="i40iw0",port="1"} 0
+node_infiniband_port_constraint_errors_received_total{device="mlx4_0",port="1"} 0
+# HELP node_infiniband_port_constraint_errors_transmitted_total Number of packets not transmitted from the switch physical port
+# TYPE node_infiniband_port_constraint_errors_transmitted_total counter
+node_infiniband_port_constraint_errors_transmitted_total{device="i40iw0",port="1"} 0
+node_infiniband_port_constraint_errors_transmitted_total{device="mlx4_0",port="1"} 0
 # HELP node_infiniband_port_data_received_bytes_total Number of data octets received on all links
 # TYPE node_infiniband_port_data_received_bytes_total counter
 node_infiniband_port_data_received_bytes_total{device="i40iw0",port="1"} 0
@@ -836,6 +844,29 @@ node_infiniband_port_data_received_bytes_total{device="mlx4_0",port="2"} 0
 node_infiniband_port_data_transmitted_bytes_total{device="i40iw0",port="1"} 0
 node_infiniband_port_data_transmitted_bytes_total{device="mlx4_0",port="1"} 1.493376e+07
 node_infiniband_port_data_transmitted_bytes_total{device="mlx4_0",port="2"} 0
+# HELP node_infiniband_port_discards_received_total Number of inbound packets discarded by the port because the port is down or congested
+# TYPE node_infiniband_port_discards_received_total counter
+node_infiniband_port_discards_received_total{device="mlx4_0",port="1"} 0
+# HELP node_infiniband_port_discards_transmitted_total Number of outbound packets discarded by the port because the port is down or congested
+# TYPE node_infiniband_port_discards_transmitted_total counter
+node_infiniband_port_discards_transmitted_total{device="i40iw0",port="1"} 0
+node_infiniband_port_discards_transmitted_total{device="mlx4_0",port="1"} 5
+# HELP node_infiniband_port_errors_received_total Number of packets containing an error that were received on this port
+# TYPE node_infiniband_port_errors_received_total counter
+node_infiniband_port_errors_received_total{device="i40iw0",port="1"} 0
+node_infiniband_port_errors_received_total{device="mlx4_0",port="1"} 0
+# HELP node_infiniband_port_packets_received_total Number of packets received on all VLs by this port (including errors)
+# TYPE node_infiniband_port_packets_received_total counter
+node_infiniband_port_packets_received_total{device="i40iw0",port="1"} 0
+node_infiniband_port_packets_received_total{device="mlx4_0",port="1"} 6.825908347e+09
+# HELP node_infiniband_port_packets_transmitted_total Number of packets transmitted on all VLs from this port (including errors)
+# TYPE node_infiniband_port_packets_transmitted_total counter
+node_infiniband_port_packets_transmitted_total{device="i40iw0",port="1"} 0
+node_infiniband_port_packets_transmitted_total{device="mlx4_0",port="1"} 6.235865e+06
+# HELP node_infiniband_port_transmit_wait_total Number of ticks during which the port had data to transmit but no data was sent during the entire tick
+# TYPE node_infiniband_port_transmit_wait_total counter
+node_infiniband_port_transmit_wait_total{device="i40iw0",port="1"} 0
+node_infiniband_port_transmit_wait_total{device="mlx4_0",port="1"} 4.294967295e+09
 # HELP node_infiniband_unicast_packets_received_total Number of unicast packets received (including errors)
 # TYPE node_infiniband_unicast_packets_received_total counter
 node_infiniband_unicast_packets_received_total{device="mlx4_0",port="1"} 61148

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -238,14 +238,59 @@ Lines: 1
 16
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/infiniband/mlx4_0/ports/1/counters/port_rcv_constraint_errors
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/class/infiniband/mlx4_0/ports/1/counters/port_rcv_data
 Lines: 1
 4631917
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/infiniband/mlx4_0/ports/1/counters/port_rcv_discards
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/infiniband/mlx4_0/ports/1/counters/port_xmit_discards
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/infiniband/mlx4_0/ports/1/counters/port_rcv_errors
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/infiniband/mlx4_0/ports/1/counters/port_rcv_packets
+Lines: 1
+6825908347
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/infiniband/mlx4_0/ports/1/counters/port_xmit_constraint_errors
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/class/infiniband/mlx4_0/ports/1/counters/port_xmit_data
 Lines: 1
 3733440
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/infiniband/mlx4_0/ports/1/counters/port_xmit_discards
+Lines: 1
+5
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/infiniband/mlx4_0/ports/1/counters/port_xmit_packets
+Lines: 1
+6235865
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/infiniband/mlx4_0/ports/1/counters/port_xmit_wait
+Lines: 1
+4294967295
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/class/infiniband/mlx4_0/ports/1/counters/unicast_rcv_packets

--- a/collector/hwmon_linux.go
+++ b/collector/hwmon_linux.go
@@ -274,6 +274,9 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) er
 				continue
 			}
 			if sensorType == "temp" && element != "type" {
+				if element == "" {
+					element = "input"
+				}
 				desc := prometheus.NewDesc(name+"_celsius", "Hardware monitor for temperature ("+element+")", hwmonLabelDesc, nil)
 				ch <- prometheus.MustNewConstMetric(
 					desc, prometheus.GaugeValue, parsedValue*0.001, labels...)

--- a/collector/infiniband_linux.go
+++ b/collector/infiniband_linux.go
@@ -54,14 +54,22 @@ func NewInfiniBandCollector() (Collector, error) {
 
 	// Filenames of all InfiniBand counter metrics including a detailed description.
 	i.counters = map[string]infinibandMetric{
-		"link_downed_total":                   {"link_downed", "Number of times the link failed to recover from an error state and went down"},
-		"link_error_recovery_total":           {"link_error_recovery", "Number of times the link successfully recovered from an error state"},
-		"multicast_packets_received_total":    {"multicast_rcv_packets", "Number of multicast packets received (including errors)"},
-		"multicast_packets_transmitted_total": {"multicast_xmit_packets", "Number of multicast packets transmitted (including errors)"},
-		"port_data_received_bytes_total":      {"port_rcv_data", "Number of data octets received on all links"},
-		"port_data_transmitted_bytes_total":   {"port_xmit_data", "Number of data octets transmitted on all links"},
-		"unicast_packets_received_total":      {"unicast_rcv_packets", "Number of unicast packets received (including errors)"},
-		"unicast_packets_transmitted_total":   {"unicast_xmit_packets", "Number of unicast packets transmitted (including errors)"},
+		"link_downed_total":                        {"link_downed", "Number of times the link failed to recover from an error state and went down"},
+		"link_error_recovery_total":                {"link_error_recovery", "Number of times the link successfully recovered from an error state"},
+		"multicast_packets_received_total":         {"multicast_rcv_packets", "Number of multicast packets received (including errors)"},
+		"multicast_packets_transmitted_total":      {"multicast_xmit_packets", "Number of multicast packets transmitted (including errors)"},
+		"port_constraint_errors_received_total":    {"port_rcv_constraint_errors", "Number of packets received on the switch physical port that are discarded"},
+		"port_constraint_errors_transmitted_total": {"port_xmit_constraint_errors", "Number of packets not transmitted from the switch physical port"},
+		"port_data_received_bytes_total":           {"port_rcv_data", "Number of data octets received on all links"},
+		"port_data_transmitted_bytes_total":        {"port_xmit_data", "Number of data octets transmitted on all links"},
+		"port_discards_received_total":             {"port_rcv_discards", "Number of inbound packets discarded by the port because the port is down or congested"},
+		"port_discards_transmitted_total":          {"port_xmit_discards", "Number of outbound packets discarded by the port because the port is down or congested"},
+		"port_errors_received_total":               {"port_rcv_errors", "Number of packets containing an error that were received on this port"},
+		"port_packets_received_total":              {"port_rcv_packets", "Number of packets received on all VLs by this port (including errors)"},
+		"port_packets_transmitted_total":           {"port_xmit_packets", "Number of packets transmitted on all VLs from this port (including errors)"},
+		"port_transmit_wait_total":                 {"port_xmit_wait", "Number of ticks during which the port had data to transmit but no data was sent during the entire tick"},
+		"unicast_packets_received_total":           {"unicast_rcv_packets", "Number of unicast packets received (including errors)"},
+		"unicast_packets_transmitted_total":        {"unicast_xmit_packets", "Number of unicast packets transmitted (including errors)"},
 	}
 
 	// Deprecated counters for some older versions of InfiniBand drivers.

--- a/collector/tcpstat_linux.go
+++ b/collector/tcpstat_linux.go
@@ -118,6 +118,10 @@ func parseTCPStats(r io.Reader) (map[tcpConnectionState]float64, error) {
 		if len(parts) == 0 {
 			continue
 		}
+		if len(parts) < 4 {
+			return nil, fmt.Errorf("invalid TCP stats line: %q", scanner.Text())
+		}
+
 		if strings.HasPrefix(parts[0], "sl") {
 			continue
 		}

--- a/collector/tcpstat_linux_test.go
+++ b/collector/tcpstat_linux_test.go
@@ -15,8 +15,29 @@ package collector
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
+
+func Test_parseTCPStatsError(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{
+			name: "too few fields",
+			in:   "hello world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseTCPStats(strings.NewReader(tt.in)); err == nil {
+				t.Fatal("expected an error, but none occurred")
+			}
+		})
+	}
+}
 
 func TestTCPStat(t *testing.T) {
 	file, err := os.Open("fixtures/proc/net/tcpstat")

--- a/collector/zfs_linux.go
+++ b/collector/zfs_linux.go
@@ -29,14 +29,14 @@ import (
 // constants from https://github.com/zfsonlinux/zfs/blob/master/lib/libspl/include/sys/kstat.h
 // kept as strings for comparison thus avoiding conversion to int
 const (
-	KSTAT_DATA_CHAR   = "0"
-	KSTAT_DATA_INT32  = "1"
-	KSTAT_DATA_UINT32 = "2"
-	KSTAT_DATA_INT64  = "3"
-	KSTAT_DATA_UINT64 = "4"
-	KSTAT_DATA_LONG   = "5"
-	KSTAT_DATA_ULONG  = "6"
-	KSTAT_DATA_STRING = "7"
+	kstatDataChar   = "0"
+	kstatDataInt32  = "1"
+	kstatDataUint32 = "2"
+	kstatDataInt64  = "3"
+	kstatDataUint64 = "4"
+	kstatDataLong   = "5"
+	kstatDataUlong  = "6"
+	kstatDataString = "7"
 )
 
 func (c *zfsCollector) openProcFile(path string) (*os.File, error) {
@@ -112,7 +112,7 @@ func (c *zfsCollector) parseProcfsFile(reader io.Reader, fmtExt string, handler 
 
 		// kstat data type (column 2) should be KSTAT_DATA_UINT64, otherwise ignore
 		// TODO: when other KSTAT_DATA_* types arrive, much of this will need to be restructured
-		if parts[1] == KSTAT_DATA_UINT64 {
+		if parts[1] == kstatDataUint64 {
 			key := fmt.Sprintf("kstat.zfs.misc.%s.%s", fmtExt, parts[0])
 			value, err := strconv.ParseUint(parts[2], 10, 64)
 			if err != nil {

--- a/text_collector_examples/deleted_libraries.py
+++ b/text_collector_examples/deleted_libraries.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Script to count the number of deleted libraries that are linked by running
 processes and expose a summary as Prometheus metrics.
@@ -20,7 +20,7 @@ def main():
         try:
             with open(path, 'rb') as file:
                 for line in file:
-                    part = line.strip().split()
+                    part = line.decode().strip().split()
 
                     if len(part) == 7:
                         library = part[5]
@@ -42,9 +42,9 @@ def main():
 
     num_processes_per_library = {}
 
-    for process, library_count in processes_linking_deleted_libraries.iteritems():
+    for process, library_count in processes_linking_deleted_libraries.items():
         libraries_seen = set()
-        for library, count in library_count.iteritems():
+        for library, count in library_count.items():
             if library in libraries_seen:
                 continue
 
@@ -59,7 +59,7 @@ def main():
     print('# HELP {0} {1}'.format(metric_name, description))
     print('# TYPE {0} gauge'.format(metric_name))
 
-    for library, count in num_processes_per_library.iteritems():
+    for library, count in num_processes_per_library.items():
         dir_path, basename = os.path.split(library)
         basename = basename.replace('"', '\\"')
         dir_path = dir_path.replace('"', '\\"')

--- a/text_collector_examples/mellanox_hca_temp
+++ b/text_collector_examples/mellanox_hca_temp
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -eu
+
+# Script to read Mellanox HCA temperature using the Mellanox mget_temp_ext tool
+
+# Copyright 2018 The Prometheus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Jan Phillip Greimann <jan.greimann@cloud.ionos.com>
+
+# check if root
+if [ "$EUID" -ne 0 ]; then
+    echo "${0##*/}: Please run as root!" >&2
+    exit 1
+fi
+
+# check if programs are installed
+if ! command -v mget_temp_ext >/dev/null 2>&1; then
+    echo "${0##*/}: mget_temp_ext is not installed. Aborting." >&2
+    exit 1
+fi
+
+cat <<EOF
+# HELP node_infiniband_hca_temp_celsius Celsius temperature of Mellanox InfiniBand HCA.
+# TYPE node_infiniband_hca_temp_celsius gauge
+EOF
+
+# run for each found Mellanox device
+for dev in /sys/class/infiniband/*; do
+    if test ! -d "$dev"; then
+        continue
+    fi
+    device="${dev##*/}"
+
+    # get temperature
+    if temperature="$(mget_temp_ext -d "${device}")"; then
+        # output
+        echo "node_infiniband_hca_temp_celsius{hca_device=\"${device}\"} ${temperature//[[:space:]]/}"
+    else
+        echo "${0##*/}: Failed to get temperature from InfiniBand HCA '${device}'!" >&2
+    fi
+done
+
+# if device is empty, no device was found
+if [ -z "${device-}" ]; then
+    echo "${0##*/}: No InfiniBand HCA device found!" >&2
+    exit 1
+fi


### PR DESCRIPTION
I have confirmed this simple unit change works fine with following step:

1. Run `cat /dev/urandom | gzip -c > /dev/null` as many as the number of cores (it was 4 here)
2. Confirm `(sum(irate(node_cpu_seconds_total{}[5m])) - sum(irate(node_cpu_seconds_total{mode="idle"}[5m])))` reports similar number as above (was completely same to 4 in grafana dashborad)
3. Kill one of those processes and confirm it decrease around 1
4. Do 3 until no 2's processes alive

