### PR TITLE
 Change Dfly's CPU counting frequency

### DIFF
--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -31,7 +31,7 @@ import (
 #include <stdio.h>
 
 int
-getCPUTimes(uint64_t **cputime, size_t *cpu_times_len, long *freq) {
+getCPUTimes(uint64_t **cputime, size_t *cpu_times_len) {
 	size_t len;
 
 	// Get number of cpu cores.
@@ -41,15 +41,6 @@ getCPUTimes(uint64_t **cputime, size_t *cpu_times_len, long *freq) {
 	mib[1] = HW_NCPU;
 	len = sizeof(ncpu);
 	if (sysctl(mib, 2, &ncpu, &len, NULL, 0)) {
-		return -1;
-	}
-
-	// The bump on each statclock is
-	// ((cur_systimer - prev_systimer) * systimer_freq) >> 32
-	// where
-	// systimer_freq = sysctl kern.cputimer.freq
-	len = sizeof(*freq);
-	if (sysctlbyname("kern.cputimer.freq", freq, &len, NULL, 0)) {
 		return -1;
 	}
 
@@ -103,18 +94,16 @@ func getDragonFlyCPUTimes() ([]float64, error) {
 	// CPUSTATES (number of CPUSTATES) is defined as 5U.
 	// States: CP_USER | CP_NICE | CP_SYS | CP_IDLE | CP_INTR
 	//
-	// Each value is a counter incremented at frequency
-	//   kern.cputimer.freq
+	// Each value is in microseconds
 	//
 	// Look into sys/kern/kern_clock.c for details.
 
 	var (
 		cpuTimesC      *C.uint64_t
-		cpuTimerFreq   C.long
 		cpuTimesLength C.size_t
 	)
 
-	if C.getCPUTimes(&cpuTimesC, &cpuTimesLength, &cpuTimerFreq) == -1 {
+	if C.getCPUTimes(&cpuTimesC, &cpuTimesLength) == -1 {
 		return nil, errors.New("could not retrieve CPU times")
 	}
 	defer C.free(unsafe.Pointer(cpuTimesC))
@@ -123,7 +112,7 @@ func getDragonFlyCPUTimes() ([]float64, error) {
 
 	cpuTimes := make([]float64, cpuTimesLength)
 	for i, value := range cput {
-		cpuTimes[i] = float64(value) / float64(cpuTimerFreq)
+		cpuTimes[i] = float64(value)
 	}
 	return cpuTimes, nil
 }

--- a/collector/cpu_dragonfly.go
+++ b/collector/cpu_dragonfly.go
@@ -112,7 +112,7 @@ func getDragonFlyCPUTimes() ([]float64, error) {
 
 	cpuTimes := make([]float64, cpuTimesLength)
 	for i, value := range cput {
-		cpuTimes[i] = float64(value)
+		cpuTimes[i] = float64(value) / float64(1000000)
 	}
 	return cpuTimes, nil
 }


### PR DESCRIPTION
I have confirmed this simple unit change works fine with following step:

1. Run `cat /dev/urandom | gzip -c > /dev/null` as many as the number of cores (it was 4 here)
2. Confirm `(sum(irate(node_cpu_seconds_total{}[5m])) - sum(irate(node_cpu_seconds_total{mode="idle"}[5m])))` reports similar number as above (was completely same to 4 in grafana dashborad)
3. Kill one of those processes and confirm it decrease around 1
4. Do 3 until no 2's processes alive

Fixes: https://github.com/prometheus/node_exporter/issues/1129