### PR TITLE
Add receive/transmit bytes total metric (wifi collector).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Darwin meminfo metrics have been renamed to match Prometheus conventions. #1060
 * [FEATURE] Allow removal of rootfs prefix for run in docker #1058
 * [ENHANCEMENT] Support for octal characters in mountpoints #954
 * [ENHANCEMENT] Update wifi stats to support multiple stations #980
+* [ENHANCEMENT] Add transmit/receive bytes total for wifi stations #1150
 * [ENHANCEMENT] Handle stuck NFS mounts #997
 * [ENHANCEMENT] infiniband: Handle iWARP RDMA modules N/A #974
 * [ENHANCEMENT] Update diskstats for linux kernel 4.19 #1109

--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -2451,6 +2451,10 @@ node_wifi_station_info{bssid="00:11:22:33:44:55",device="wlan0",mode="client",ss
 # TYPE node_wifi_station_receive_bits_per_second gauge
 node_wifi_station_receive_bits_per_second{device="wlan0",mac_address="01:02:03:04:05:06"} 2.56e+08
 node_wifi_station_receive_bits_per_second{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 1.28e+08
+# HELP node_wifi_station_receive_bytes_total The total number of bytes received by a WiFi station.
+# TYPE node_wifi_station_receive_bytes_total counter
+node_wifi_station_receive_bytes_total{device="wlan0",mac_address="01:02:03:04:05:06"} 0
+node_wifi_station_receive_bytes_total{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 0
 # HELP node_wifi_station_signal_dbm The current WiFi signal strength, in decibel-milliwatts (dBm).
 # TYPE node_wifi_station_signal_dbm gauge
 node_wifi_station_signal_dbm{device="wlan0",mac_address="01:02:03:04:05:06"} -26
@@ -2459,6 +2463,10 @@ node_wifi_station_signal_dbm{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} -52
 # TYPE node_wifi_station_transmit_bits_per_second gauge
 node_wifi_station_transmit_bits_per_second{device="wlan0",mac_address="01:02:03:04:05:06"} 3.28e+08
 node_wifi_station_transmit_bits_per_second{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 1.64e+08
+# HELP node_wifi_station_transmit_bytes_total The total number of bytes transmitted by a WiFi station.
+# TYPE node_wifi_station_transmit_bytes_total counter
+node_wifi_station_transmit_bytes_total{device="wlan0",mac_address="01:02:03:04:05:06"} 0
+node_wifi_station_transmit_bytes_total{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 0
 # HELP node_wifi_station_transmit_failed_total The total number of times a station has failed to send a packet.
 # TYPE node_wifi_station_transmit_failed_total counter
 node_wifi_station_transmit_failed_total{device="wlan0",mac_address="01:02:03:04:05:06"} 4

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2451,6 +2451,10 @@ node_wifi_station_info{bssid="00:11:22:33:44:55",device="wlan0",mode="client",ss
 # TYPE node_wifi_station_receive_bits_per_second gauge
 node_wifi_station_receive_bits_per_second{device="wlan0",mac_address="01:02:03:04:05:06"} 2.56e+08
 node_wifi_station_receive_bits_per_second{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 1.28e+08
+# HELP node_wifi_station_receive_bytes_total The total number of bytes received by a WiFi station.
+# TYPE node_wifi_station_receive_bytes_total counter
+node_wifi_station_receive_bytes_total{device="wlan0",mac_address="01:02:03:04:05:06"} 0
+node_wifi_station_receive_bytes_total{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 0
 # HELP node_wifi_station_signal_dbm The current WiFi signal strength, in decibel-milliwatts (dBm).
 # TYPE node_wifi_station_signal_dbm gauge
 node_wifi_station_signal_dbm{device="wlan0",mac_address="01:02:03:04:05:06"} -26
@@ -2459,6 +2463,10 @@ node_wifi_station_signal_dbm{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} -52
 # TYPE node_wifi_station_transmit_bits_per_second gauge
 node_wifi_station_transmit_bits_per_second{device="wlan0",mac_address="01:02:03:04:05:06"} 3.28e+08
 node_wifi_station_transmit_bits_per_second{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 1.64e+08
+# HELP node_wifi_station_transmit_bytes_total The total number of bytes transmitted by a WiFi station.
+# TYPE node_wifi_station_transmit_bytes_total counter
+node_wifi_station_transmit_bytes_total{device="wlan0",mac_address="01:02:03:04:05:06"} 0
+node_wifi_station_transmit_bytes_total{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 0
 # HELP node_wifi_station_transmit_failed_total The total number of times a station has failed to send a packet.
 # TYPE node_wifi_station_transmit_failed_total counter
 node_wifi_station_transmit_failed_total{device="wlan0",mac_address="01:02:03:04:05:06"} 4

--- a/collector/wifi_linux.go
+++ b/collector/wifi_linux.go
@@ -34,6 +34,8 @@ type wifiCollector struct {
 	stationInactiveSeconds       *prometheus.Desc
 	stationReceiveBitsPerSecond  *prometheus.Desc
 	stationTransmitBitsPerSecond *prometheus.Desc
+	stationReceiveBytesTotal     *prometheus.Desc
+	stationTransmitBytesTotal    *prometheus.Desc
 	stationSignalDBM             *prometheus.Desc
 	stationTransmitRetriesTotal  *prometheus.Desc
 	stationTransmitFailedTotal   *prometheus.Desc
@@ -107,6 +109,20 @@ func NewWifiCollector() (Collector, error) {
 		stationTransmitBitsPerSecond: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "station_transmit_bits_per_second"),
 			"The current WiFi transmit bitrate of a station, in bits per second.",
+			labels,
+			nil,
+		),
+
+		stationReceiveBytesTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "station_receive_bytes_total"),
+			"The total number of bytes received by a WiFi station.",
+			labels,
+			nil,
+		),
+
+		stationTransmitBytesTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "station_transmit_bytes_total"),
+			"The total number of bytes transmitted by a WiFi station.",
 			labels,
 			nil,
 		),
@@ -252,6 +268,22 @@ func (c *wifiCollector) updateStationStats(ch chan<- prometheus.Metric, device s
 		c.stationTransmitBitsPerSecond,
 		prometheus.GaugeValue,
 		float64(info.TransmitBitrate),
+		device,
+		info.HardwareAddr.String(),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.stationReceiveBytesTotal,
+		prometheus.CounterValue,
+		float64(info.ReceivedBytes),
+		device,
+		info.HardwareAddr.String(),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.stationTransmitBytesTotal,
+		prometheus.CounterValue,
+		float64(info.TransmittedBytes),
 		device,
 		info.HardwareAddr.String(),
 	)


### PR DESCRIPTION
This commit add transmit/receive bytes total for the wifi collector (which is not enabled by default). The `wifi` package by @mdlayher already collects those values but they were not sent to prometheus, that's why the change is fairly trivial.

I currently need those values for our monitoring setup. Are you happy to have them added as is?
If not, what do you think the best solution would be?

cc @SuperQ

(the contributors guide says to mention someone, but I wasn't sure who given that this collector was written by @mdlayher)