### PR TITLE
examples/init.d: fix web.listen-address flag

### DIFF
--- a/examples/init.d/node_exporter
+++ b/examples/init.d/node_exporter
@@ -4,7 +4,7 @@ RETVAL=0
 PROG="node_exporter"
 EXEC="/etc/node_exporter/node_exporter"
 LOCKFILE="/var/lock/subsys/$PROG"
-OPTIONS="-web.listen-address=:9201"
+OPTIONS="--web.listen-address=:9100"
 
 # Source function library.
 if [ -f /etc/rc.d/init.d/functions ]; then


### PR DESCRIPTION
CLI flags use two dashes instead of one since v0.15.0
Fixes #1156

Signed-off-by: Paul Gier <pgier@redhat.com>