### PR TITLE
Add fallback for missing /proc/1/mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [BUGFIX]
+* [BUGFIX] Add fallback for missing /proc/1/mounts #1172
 * [CHANGE] Add TCPSynRetrans to netstat default filter #1143
 * [ENHANCEMENT] Add Infiniband counters #1120
 * [FEATURE] Add a flag to disable exporter metrics #1148

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -136,6 +136,11 @@ func stuckMountWatcher(mountPoint string, success chan struct{}) {
 
 func mountPointDetails() ([]filesystemLabels, error) {
 	file, err := os.Open(procFilePath("1/mounts"))
+	if os.IsNotExist(err) {
+		// Fallback to `/proc/mounts` if `/proc/1/mounts` is missing due hidepid.
+		log.Debugf("Got %q reading root mounts, falling back to system mounts", err)
+		file, err = os.Open(procFilePath("mounts"))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/collector/filesystem_linux_test.go
+++ b/collector/filesystem_linux_test.go
@@ -91,3 +91,24 @@ func TestMountPointDetails(t *testing.T) {
 		}
 	}
 }
+
+func TestMountsFallback(t *testing.T) {
+	if _, err := kingpin.CommandLine.Parse([]string{"--path.procfs", "./fixtures_hidepid/proc"}); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]string{
+		"/": "",
+	}
+
+	filesystems, err := mountPointDetails()
+	if err != nil {
+		t.Log(err)
+	}
+
+	for _, fs := range filesystems {
+		if _, ok := expected[fs.mountPoint]; !ok {
+			t.Errorf("Got unexpected %s", fs.mountPoint)
+		}
+	}
+}

--- a/collector/fixtures_hidepid/proc/mounts
+++ b/collector/fixtures_hidepid/proc/mounts
@@ -1,0 +1,1 @@
+rootfs / rootfs rw 0 0


### PR DESCRIPTION
On some systems, `/proc/1/mounts` is hidden from non-root users due to
the `hidepid` procfs feature. Attempt to fallback to `/proc/mounts` if
`/proc/1/mounts` is not found.

Fixes: https://github.com/prometheus/node_exporter/issues/1171

Signed-off-by: Ben Kochie <superq@gmail.com>