### PR TITLE
Remove unused variable readOnly from filesystem_linux.go

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -31,7 +31,6 @@ import (
 const (
 	defIgnoredMountPoints = "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
 	defIgnoredFSTypes     = "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"
-	readOnly              = 0x1 // ST_RDONLY
 	mountTimeout          = 30 * time.Second
 )
 


### PR DESCRIPTION
The pull request #1002 changed the logic used on Linux servers to determine if a filesystem is
read-only. As a result of this change, the variable `readOnly` is now unused and can be removed.

Signed-off-by: Jerome Froelich <jeromefroelich@hotmail.com>