### PR TITLE
Add kstat-based Solaris metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [CHANGE] Add a limit to the number of in-flight requests #1166
 * [ENHANCEMENT] Add Infiniband counters #1120
 * [FEATURE] Add a flag to disable exporter metrics #1148
+* [FEATURE] Add kstat-based Solaris metrics for boottime, cpu and zfs collectors #1197
 
 ## 0.17.0 / 2018-11-30
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Name     | Description | OS
 arp | Exposes ARP statistics from `/proc/net/arp`. | Linux
 bcache | Exposes bcache statistics from `/sys/fs/bcache/`. | Linux
 bonding | Exposes the number of configured and active slaves of Linux bonding interfaces. | Linux
-boottime | Exposes system boot time derived from the `kern.boottime` sysctl. | Darwin, Dragonfly, FreeBSD, NetBSD, OpenBSD
+boottime | Exposes system boot time derived from the `kern.boottime` sysctl. | Darwin, Dragonfly, FreeBSD, NetBSD, OpenBSD, Solaris
 conntrack | Shows conntrack statistics (does nothing if no `/proc/sys/net/netfilter/` present). | Linux
-cpu | Exposes CPU statistics | Darwin, Dragonfly, FreeBSD, Linux
+cpu | Exposes CPU statistics | Darwin, Dragonfly, FreeBSD, Linux, Solaris
 diskstats | Exposes disk I/O statistics. | Darwin, Linux
 edac | Exposes error detection and correction statistics. | Linux
 entropy | Exposes available entropy. | Linux

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ timex | Exposes selected adjtimex(2) system call stats. | Linux
 uname | Exposes system information as provided by the uname system call. | Linux
 vmstat | Exposes statistics from `/proc/vmstat`. | Linux
 xfs | Exposes XFS runtime statistics. | Linux (kernel 4.4+)
-zfs | Exposes [ZFS](http://open-zfs.org/) performance statistics. | [Linux](http://zfsonlinux.org/)
+zfs | Exposes [ZFS](http://open-zfs.org/) performance statistics. | [Linux](http://zfsonlinux.org/), Solaris
 
 ### Disabled by default
 

--- a/collector/boot_time_solaris.go
+++ b/collector/boot_time_solaris.go
@@ -51,13 +51,11 @@ func (c *bootTimeCollector) Update(ch chan<- prometheus.Metric) error {
 	defer tok.Close()
 
 	ks, err := tok.Lookup("unix", 0, "system_misc")
-
 	if err != nil {
 		return err
 	}
 
 	v, err := ks.GetNamed("boot_time")
-
 	if err != nil {
 		return err
 	}

--- a/collector/boot_time_solaris.go
+++ b/collector/boot_time_solaris.go
@@ -21,12 +21,12 @@ import (
 	"github.com/siebenmann/go-kstat"
 )
 
-type bootTimeCollector struct{
+type bootTimeCollector struct {
 	boottime typedDesc
 }
 
 func init() {
-        registerCollector("boottime", defaultEnabled, newBootTimeCollector)
+	registerCollector("boottime", defaultEnabled, newBootTimeCollector)
 }
 
 func newBootTimeCollector() (Collector, error) {
@@ -34,7 +34,7 @@ func newBootTimeCollector() (Collector, error) {
 		boottime: typedDesc{
 			prometheus.NewDesc(
 				prometheus.BuildFQName(namespace, "", "boot_time_seconds"),
-					"Unix time of last boot, including microseconds.",
+				"Unix time of last boot, including microseconds.",
 				nil, nil,
 			), prometheus.GaugeValue},
 	}, nil

--- a/collector/boot_time_solaris.go
+++ b/collector/boot_time_solaris.go
@@ -1,0 +1,68 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build solaris
+// +build !noboottime
+
+package collector
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/siebenmann/go-kstat"
+)
+
+type bootTimeCollector struct{
+	boottime typedDesc
+}
+
+func init() {
+        registerCollector("boottime", defaultEnabled, newBootTimeCollector)
+}
+
+func newBootTimeCollector() (Collector, error) {
+	return &bootTimeCollector{
+		boottime: typedDesc{
+			prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, "", "boot_time_seconds"),
+					"Unix time of last boot, including microseconds.",
+				nil, nil,
+			), prometheus.GaugeValue},
+	}, nil
+}
+
+// newBootTimeCollector returns a new Collector exposing system boot time on Solaris systems.
+// Update pushes boot time onto ch
+func (c *bootTimeCollector) Update(ch chan<- prometheus.Metric) error {
+	tok, err := kstat.Open()
+	if err != nil {
+		return err
+	}
+
+	defer tok.Close()
+
+	ks, err := tok.Lookup("unix", 0, "system_misc")
+
+	if err != nil {
+		return err
+	}
+
+	v, err := ks.GetNamed("boot_time")
+
+	if err != nil {
+		return err
+	}
+
+	ch <- c.boottime.mustNewConstMetric(float64(v.UintVal))
+
+	return nil
+}

--- a/collector/cpu_solaris.go
+++ b/collector/cpu_solaris.go
@@ -111,12 +111,12 @@ func (c *cpuCollector) updateCPUfreq(ch chan<- prometheus.Metric) error {
 		if err != nil {
 			return err
 		}
-		cpu_freq_v, err := ksCPUInfo.GetNamed("current_clock_Hz")
+		cpuFreqV, err := ksCPUInfo.GetNamed("current_clock_Hz")
 		if err != nil {
 			return err
 		}
 
-		cpu_freq_max_v, err := ksCPUInfo.GetNamed("clock_MHz")
+		cpuFreqMaxV, err := ksCPUInfo.GetNamed("clock_MHz")
 		if err != nil {
 			return err
 		}
@@ -125,14 +125,14 @@ func (c *cpuCollector) updateCPUfreq(ch chan<- prometheus.Metric) error {
 		ch <- prometheus.MustNewConstMetric(
 			c.cpuFreq,
 			prometheus.GaugeValue,
-			float64(cpu_freq_v.UintVal),
+			float64(cpuFreqV.UintVal),
 			lcpu,
 		)
 		// Multiply by 1e+6 to convert MHz to Hz.
 		ch <- prometheus.MustNewConstMetric(
 			c.cpuFreqMax,
 			prometheus.GaugeValue,
-			float64(cpu_freq_max_v.IntVal)*1e+6,
+			float64(cpuFreqMaxV.IntVal)*1e+6,
 			lcpu,
 		)
 	}

--- a/collector/cpu_solaris.go
+++ b/collector/cpu_solaris.go
@@ -140,10 +140,11 @@ func (c *cpuCollector) updateCPUfreq(ch chan<- prometheus.Metric) (err error) {
 			float64(cpu_freq_v.UintVal),
 			lcpu,
 		)
+		// Multiply by 1e+6 to convert MHz to Hz.
 		ch <- prometheus.MustNewConstMetric(
 			c.cpuFreqMax,
 			prometheus.GaugeValue,
-			float64(cpu_freq_max_v.IntVal)*1000.0,
+			float64(cpu_freq_max_v.IntVal)*1e+6,
 			lcpu,
 		)
 	}

--- a/collector/cpu_solaris.go
+++ b/collector/cpu_solaris.go
@@ -1,0 +1,86 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build solaris
+// +build !nocpu
+
+package collector
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/siebenmann/go-kstat"
+)
+
+// #include <unistd.h>
+import "C"
+
+type cpuCollector struct {
+	cpu typedDesc
+}
+
+func init() {
+	registerCollector("cpu", defaultEnabled, NewCpuCollector)
+}
+
+func NewCpuCollector() (Collector, error) {
+	return &cpuCollector{
+		cpu: typedDesc{nodeCPUSecondsDesc, prometheus.CounterValue},
+	}, nil
+}
+
+func (c *cpuCollector) Update(ch chan<- prometheus.Metric) (err error) {
+	ncpus := C.sysconf(C._SC_NPROCESSORS_ONLN)
+
+	tok, err := kstat.Open()
+	if err != nil {
+		return err
+	}
+
+	defer tok.Close()
+
+	for cpu := 0; cpu < int(ncpus); cpu++ {
+		ks, err := tok.Lookup("cpu", cpu, "sys")
+		if err != nil {
+			return err
+		}
+
+		idle_v, err := ks.GetNamed("cpu_ticks_idle")
+		if err != nil {
+			return err
+		}
+
+		kernel_v, err := ks.GetNamed("cpu_ticks_kernel")
+		if err != nil {
+			return err
+		}
+
+		user_v, err := ks.GetNamed("cpu_ticks_user")
+		if err != nil {
+			return err
+		}
+
+		wait_v, err := ks.GetNamed("cpu_ticks_wait")
+		if err != nil {
+			return err
+		}
+
+		lcpu := strconv.Itoa(cpu)
+		ch <- c.cpu.mustNewConstMetric(float64(idle_v.UintVal), lcpu, "idle")
+		ch <- c.cpu.mustNewConstMetric(float64(kernel_v.UintVal), lcpu, "kernel")
+		ch <- c.cpu.mustNewConstMetric(float64(user_v.UintVal), lcpu, "user")
+		ch <- c.cpu.mustNewConstMetric(float64(wait_v.UintVal), lcpu, "wait")
+	}
+	return err
+}

--- a/collector/cpu_solaris.go
+++ b/collector/cpu_solaris.go
@@ -28,9 +28,9 @@ import (
 import "C"
 
 type cpuCollector struct {
-	cpu		typedDesc
-	cpuFreq		*prometheus.Desc
-	cpuFreqMax	*prometheus.Desc
+	cpu        typedDesc
+	cpuFreq    *prometheus.Desc
+	cpuFreqMax *prometheus.Desc
 }
 
 func init() {
@@ -55,12 +55,12 @@ func NewCpuCollector() (Collector, error) {
 
 func (c *cpuCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	if err := c.updateCPUstats(ch); err != nil {
-                return err
-        }
-        if err := c.updateCPUfreq(ch); err != nil {
-                return err
-        }
-        return nil
+		return err
+	}
+	if err := c.updateCPUfreq(ch); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (c *cpuCollector) updateCPUstats(ch chan<- prometheus.Metric) (err error) {

--- a/collector/loadavg_solaris.go
+++ b/collector/loadavg_solaris.go
@@ -25,21 +25,21 @@ import (
 // #include <sys/param.h>
 import "C"
 
-func kstatToFloat(ks *kstat.KStat, kstat_key string) float64 {
-	kstat_value, err := ks.GetNamed(kstat_key)
+func kstatToFloat(ks *kstat.KStat, kstatKey string) float64 {
+	kstatValue, err := ks.GetNamed(kstatKey)
 
 	if err != nil {
 		panic(err)
 	}
 
-	kstat_loadavg, err := strconv.ParseFloat(
-		fmt.Sprintf("%.2f", float64(kstat_value.UintVal)/C.FSCALE), 64)
+	kstatLoadavg, err := strconv.ParseFloat(
+		fmt.Sprintf("%.2f", float64(kstatValue.UintVal)/C.FSCALE), 64)
 
 	if err != nil {
 		panic(err)
 	}
 
-	return kstat_loadavg
+	return kstatLoadavg
 }
 
 func getLoad() ([]float64, error) {
@@ -56,9 +56,9 @@ func getLoad() ([]float64, error) {
 		panic(err)
 	}
 
-	loadavg_1min := kstatToFloat(ks, "avenrun_1min")
-	loadavg_5min := kstatToFloat(ks, "avenrun_5min")
-	loadavg_15min := kstatToFloat(ks, "avenrun_15min")
+	loadavg1Min := kstatToFloat(ks, "avenrun_1min")
+	loadavg5Min := kstatToFloat(ks, "avenrun_5min")
+	loadavg15Min := kstatToFloat(ks, "avenrun_15min")
 
-	return []float64{loadavg_1min, loadavg_5min, loadavg_15min}, nil
+	return []float64{loadavg1Min, loadavg5Min, loadavg15Min}, nil
 }

--- a/collector/zfs_solaris.go
+++ b/collector/zfs_solaris.go
@@ -191,7 +191,7 @@ func (c *zfsCollector) updateZfsArcStats(ch chan<- prometheus.Metric) error {
 		"hits":           c.arcstatsHits,
 		"misses":         c.arcstatsMisses,
 		"mfu_ghost_hits": c.arcstatsMFUGhostHits,
-		"mfu_ghost_size": c.arcstatsAnonSize,
+		"mfu_ghost_size": c.arcstatsMFUGhostSize,
 		"mfu_size":       c.arcstatsMFUSize,
 		"mru_ghost_hits": c.arcstatsMRUGhostHits,
 		"mru_ghost_size": c.arcstatsMRUGhostSize,

--- a/collector/zfs_solaris.go
+++ b/collector/zfs_solaris.go
@@ -109,19 +109,19 @@ func NewZfsCollector() (Collector, error) {
 			"ZFS ARC data size", nil, nil,
 		),
 		arcstatsDemandDataHits: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_demand_data_hits"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_demand_data_hits_total"),
 			"ZFS ARC demand data hits", nil, nil,
 		),
 		arcstatsDemandDataMisses: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_demand_data_misses"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_demand_data_misses_total"),
 			"ZFS ARC demand data misses", nil, nil,
 		),
 		arcstatsDemandMetadataHits: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_demand_metadata_hits"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_demand_metadata_hits_total"),
 			"ZFS ARC demand metadata hits", nil, nil,
 		),
 		arcstatsDemandMetadataMisses: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_demand_metadata_misses"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_demand_metadata_misses_total"),
 			"ZFS ARC demand metadata misses", nil, nil,
 		),
 		arcstatsHeaderSize: prometheus.NewDesc(
@@ -129,15 +129,15 @@ func NewZfsCollector() (Collector, error) {
 			"ZFS ARC header size", nil, nil,
 		),
 		arcstatsHits: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_hits"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_hits_total"),
 			"ZFS ARC hits", nil, nil,
 		),
 		arcstatsMisses: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_misses"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_misses_total"),
 			"ZFS ARC misses", nil, nil,
 		),
 		arcstatsMFUGhostHits: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mfu_ghost_hits"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mfu_ghost_hits_total"),
 			"ZFS ARC MFU ghost hits", nil, nil,
 		),
 		arcstatsMFUGhostSize: prometheus.NewDesc(
@@ -149,7 +149,7 @@ func NewZfsCollector() (Collector, error) {
 			"ZFS ARC MFU size", nil, nil,
 		),
 		arcstatsMRUGhostHits: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_ghost_hits"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_ghost_hits_total"),
 			"ZFS ARC MRU ghost hits", nil, nil,
 		),
 		arcstatsMRUGhostSize: prometheus.NewDesc(
@@ -173,11 +173,11 @@ func NewZfsCollector() (Collector, error) {
 			"ZFS ARC size", nil, nil,
 		),
 		zfetchstatsHits: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "zfetchstats_hits"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "zfetchstats_hits_total"),
 			"ZFS cache fetch hits", nil, nil,
 		),
 		zfetchstatsMisses: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "zfetchstats_misses"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "zfetchstats_misses_total"),
 			"ZFS cache fetch misses", nil, nil,
 		),
 	}, nil

--- a/collector/zfs_solaris.go
+++ b/collector/zfs_solaris.go
@@ -16,6 +16,8 @@
 package collector
 
 import (
+	"strings"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/siebenmann/go-kstat"
 )
@@ -63,47 +65,47 @@ func init() {
 func NewZfsCollector() (Collector, error) {
 	return &zfsCollector{
 		abdstatsLinearCount: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_linear_count"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_linear_count_total"),
 			"ZFS ARC buffer data linear count", nil, nil,
 		),
 		abdstatsLinearDataSize: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_linear_data_size"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_linear_data_bytes"),
 			"ZFS ARC buffer data linear data size", nil, nil,
 		),
 		abdstatsScatterChunkWaste: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_chunk_waste"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_chunk_waste_bytes"),
 			"ZFS ARC buffer data scatter chunk waste", nil, nil,
 		),
 		abdstatsScatterCount: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_count"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_count_total"),
 			"ZFS ARC buffer data scatter count", nil, nil,
 		),
 		abdstatsScatterDataSize: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_data_size"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_data_bytes"),
 			"ZFS ARC buffer data scatter data size", nil, nil,
 		),
 		abdstatsStructSize: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_struct_size"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_struct_bytes"),
 			"ZFS ARC buffer data struct size", nil, nil,
 		),
 		arcstatsAnonSize: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_anon_size"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_anon_bytes"),
 			"ZFS ARC anon size", nil, nil,
 		),
 		arcstatsC: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_c"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_c_bytes"),
 			"ZFS ARC target size", nil, nil,
 		),
 		arcstatsCMax: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_c_max"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_c_max_bytes"),
 			"ZFS ARC maximum size", nil, nil,
 		),
 		arcstatsCMin: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_c_min"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_c_min_bytes"),
 			"ZFS ARC minimum size", nil, nil,
 		),
 		arcstatsDataSize: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_data_size"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_data_bytes"),
 			"ZFS ARC data size", nil, nil,
 		),
 		arcstatsDemandDataHits: prometheus.NewDesc(
@@ -123,7 +125,7 @@ func NewZfsCollector() (Collector, error) {
 			"ZFS ARC demand metadata misses", nil, nil,
 		),
 		arcstatsHeaderSize: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_hdr_size"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_hdr_bytes"),
 			"ZFS ARC header size", nil, nil,
 		),
 		arcstatsHits: prometheus.NewDesc(
@@ -143,7 +145,7 @@ func NewZfsCollector() (Collector, error) {
 			"ZFS ARC MFU ghost size", nil, nil,
 		),
 		arcstatsMFUSize: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mfu_size"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mfu_bytes"),
 			"ZFS ARC MFU size", nil, nil,
 		),
 		arcstatsMRUGhostHits: prometheus.NewDesc(
@@ -151,23 +153,23 @@ func NewZfsCollector() (Collector, error) {
 			"ZFS ARC MRU ghost hits", nil, nil,
 		),
 		arcstatsMRUGhostSize: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_ghost_size"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_ghost_bytes"),
 			"ZFS ARC MRU ghost size", nil, nil,
 		),
 		arcstatsMRUSize: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_size"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_bytes"),
 			"ZFS ARC MRU size", nil, nil,
 		),
 		arcstatsOtherSize: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_other_size"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_other_bytes"),
 			"ZFS ARC other size", nil, nil,
 		),
 		arcstatsP: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_p"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_p_bytes"),
 			"ZFS ARC MRU target size", nil, nil,
 		),
 		arcstatsSize: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_size"),
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_size_bytes"),
 			"ZFS ARC size", nil, nil,
 		),
 		zfetchstatsHits: prometheus.NewDesc(
@@ -182,6 +184,8 @@ func NewZfsCollector() (Collector, error) {
 }
 
 func (c *zfsCollector) updateZfsAbdStats(ch chan<- prometheus.Metric) error {
+	var metricType prometheus.ValueType
+
 	tok, err := kstat.Open()
 	if err != nil {
 		return err
@@ -207,9 +211,15 @@ func (c *zfsCollector) updateZfsAbdStats(ch chan<- prometheus.Metric) error {
 			return err
 		}
 
+		if strings.HasSuffix(k, "_cnt") {
+			metricType = prometheus.CounterValue
+		} else {
+			metricType = prometheus.GaugeValue
+		}
+
 		ch <- prometheus.MustNewConstMetric(
 			v,
-			prometheus.GaugeValue,
+			metricType,
 			float64(ksZFSInfoValue.UintVal),
 		)
 	}
@@ -218,6 +228,8 @@ func (c *zfsCollector) updateZfsAbdStats(ch chan<- prometheus.Metric) error {
 }
 
 func (c *zfsCollector) updateZfsArcStats(ch chan<- prometheus.Metric) error {
+	var metricType prometheus.ValueType
+
 	tok, err := kstat.Open()
 	if err != nil {
 		return err
@@ -236,9 +248,9 @@ func (c *zfsCollector) updateZfsArcStats(ch chan<- prometheus.Metric) error {
 		"c_max":                  c.arcstatsCMax,
 		"c_min":                  c.arcstatsCMin,
 		"data_size":              c.arcstatsDataSize,
-		"demand_data_hits"  :     c.arcstatsDemandDataHits,
+		"demand_data_hits":       c.arcstatsDemandDataHits,
 		"demand_data_misses":     c.arcstatsDemandDataMisses,
-		"demand_metadata_hits"  : c.arcstatsDemandMetadataHits,
+		"demand_metadata_hits":   c.arcstatsDemandMetadataHits,
 		"demand_metadata_misses": c.arcstatsDemandMetadataMisses,
 		"hdr_size":               c.arcstatsHeaderSize,
 		"hits":                   c.arcstatsHits,
@@ -258,9 +270,15 @@ func (c *zfsCollector) updateZfsArcStats(ch chan<- prometheus.Metric) error {
 			return err
 		}
 
+		if strings.HasSuffix(k, "_hits") || strings.HasSuffix(k, "_misses") {
+			metricType = prometheus.CounterValue
+		} else {
+			metricType = prometheus.GaugeValue
+		}
+
 		ch <- prometheus.MustNewConstMetric(
 			v,
-			prometheus.GaugeValue,
+			metricType,
 			float64(ksZFSInfoValue.UintVal),
 		)
 	}
@@ -289,7 +307,7 @@ func (c *zfsCollector) updateZfsFetchStats(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			v,
-			prometheus.GaugeValue,
+			prometheus.CounterValue,
 			float64(ksZFSInfoValue.UintVal),
 		)
 	}

--- a/collector/zfs_solaris.go
+++ b/collector/zfs_solaris.go
@@ -21,116 +21,116 @@ import (
 )
 
 type zfsCollector struct {
-	abdstatsLinearCount	*prometheus.Desc
-	abdstatsLinearDataSize	*prometheus.Desc
-	abdstatsScatterChunkWaste	*prometheus.Desc
-	abdstatsScatterCount	*prometheus.Desc
-	abdstatsScatterDataSize	*prometheus.Desc
-	abdstatsStructSize	*prometheus.Desc
-	arcstatsAnonSize	*prometheus.Desc
-	arcstatsHeaderSize	*prometheus.Desc
-	arcstatsHits		*prometheus.Desc
-	arcstatsMisses		*prometheus.Desc
-	arcstatsMFUGhostHits	*prometheus.Desc
-	arcstatsMFUGhostSize	*prometheus.Desc
-	arcstatsMFUSize		*prometheus.Desc
-	arcstatsMRUGhostHits	*prometheus.Desc
-	arcstatsMRUGhostSize	*prometheus.Desc
-	arcstatsMRUSize		*prometheus.Desc
-	arcstatsOtherSize	*prometheus.Desc
-	arcstatsSize		*prometheus.Desc
-	zfetchstatsHits		*prometheus.Desc
-	zfetchstatsMisses	*prometheus.Desc
+	abdstatsLinearCount       *prometheus.Desc
+	abdstatsLinearDataSize    *prometheus.Desc
+	abdstatsScatterChunkWaste *prometheus.Desc
+	abdstatsScatterCount      *prometheus.Desc
+	abdstatsScatterDataSize   *prometheus.Desc
+	abdstatsStructSize        *prometheus.Desc
+	arcstatsAnonSize          *prometheus.Desc
+	arcstatsHeaderSize        *prometheus.Desc
+	arcstatsHits              *prometheus.Desc
+	arcstatsMisses            *prometheus.Desc
+	arcstatsMFUGhostHits      *prometheus.Desc
+	arcstatsMFUGhostSize      *prometheus.Desc
+	arcstatsMFUSize           *prometheus.Desc
+	arcstatsMRUGhostHits      *prometheus.Desc
+	arcstatsMRUGhostSize      *prometheus.Desc
+	arcstatsMRUSize           *prometheus.Desc
+	arcstatsOtherSize         *prometheus.Desc
+	arcstatsSize              *prometheus.Desc
+	zfetchstatsHits           *prometheus.Desc
+	zfetchstatsMisses         *prometheus.Desc
 }
 
 const (
-        zfsCollectorSubsystem = "zfs"
+	zfsCollectorSubsystem = "zfs"
 )
 
 func init() {
-        registerCollector("zfs", defaultEnabled, NewZfsCollector)
+	registerCollector("zfs", defaultEnabled, NewZfsCollector)
 }
 
 func NewZfsCollector() (Collector, error) {
 	return &zfsCollector{
-                abdstatsLinearCount: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_linear_count"),
+		abdstatsLinearCount: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_linear_count"),
 			"ZFS ARC buffer data linear count", nil, nil,
 		),
-                abdstatsLinearDataSize: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_linear_data_size"),
+		abdstatsLinearDataSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_linear_data_size"),
 			"ZFS ARC buffer data linear data size", nil, nil,
 		),
-                abdstatsScatterChunkWaste: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_chunk_waste"),
+		abdstatsScatterChunkWaste: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_chunk_waste"),
 			"ZFS ARC buffer data scatter chunk waste", nil, nil,
 		),
-                abdstatsScatterCount: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_count"),
+		abdstatsScatterCount: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_count"),
 			"ZFS ARC buffer data scatter count", nil, nil,
 		),
-                abdstatsScatterDataSize: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_data_size"),
+		abdstatsScatterDataSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_data_size"),
 			"ZFS ARC buffer data scatter data size", nil, nil,
 		),
-                abdstatsStructSize: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_struct_size"),
+		abdstatsStructSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_struct_size"),
 			"ZFS ARC buffer data struct size", nil, nil,
 		),
-                arcstatsAnonSize: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_anon_size"),
+		arcstatsAnonSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_anon_size"),
 			"ZFS ARC anon size", nil, nil,
 		),
-                arcstatsHeaderSize: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_hdr_size"),
+		arcstatsHeaderSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_hdr_size"),
 			"ZFS ARC header size", nil, nil,
 		),
-                arcstatsHits: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_hits"),
+		arcstatsHits: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_hits"),
 			"ZFS ARC hits", nil, nil,
 		),
-                arcstatsMisses: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_misses"),
+		arcstatsMisses: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_misses"),
 			"ZFS ARC misses", nil, nil,
 		),
-                arcstatsMFUGhostHits: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mfu_ghost_hits"),
+		arcstatsMFUGhostHits: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mfu_ghost_hits"),
 			"ZFS ARC MFU ghost hits", nil, nil,
 		),
-                arcstatsMFUGhostSize: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mfu_ghost_size"),
+		arcstatsMFUGhostSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mfu_ghost_size"),
 			"ZFS ARC MFU ghost size", nil, nil,
 		),
-                arcstatsMFUSize: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mfu_size"),
+		arcstatsMFUSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mfu_size"),
 			"ZFS ARC MFU size", nil, nil,
 		),
-                arcstatsMRUGhostHits: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_ghost_hits"),
+		arcstatsMRUGhostHits: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_ghost_hits"),
 			"ZFS ARC MRU ghost hits", nil, nil,
 		),
-                arcstatsMRUGhostSize: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_ghost_size"),
+		arcstatsMRUGhostSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_ghost_size"),
 			"ZFS ARC MRU ghost size", nil, nil,
 		),
-                arcstatsMRUSize: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_size"),
+		arcstatsMRUSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_size"),
 			"ZFS ARC MRU size", nil, nil,
 		),
-                arcstatsOtherSize: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_other_size"),
+		arcstatsOtherSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_other_size"),
 			"ZFS ARC other size", nil, nil,
 		),
-                arcstatsSize: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_size"),
+		arcstatsSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_size"),
 			"ZFS ARC size", nil, nil,
 		),
-                zfetchstatsHits: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "zfetchstats_hits"),
+		zfetchstatsHits: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "zfetchstats_hits"),
 			"ZFS cache fetch hits", nil, nil,
 		),
-                zfetchstatsMisses: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "zfetchstats_misses"),
+		zfetchstatsMisses: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "zfetchstats_misses"),
 			"ZFS cache fetch misses", nil, nil,
 		),
 	}, nil
@@ -138,11 +138,11 @@ func NewZfsCollector() (Collector, error) {
 
 func (c *zfsCollector) updateZfsAbdStats(ch chan<- prometheus.Metric) (err error) {
 	tok, err := kstat.Open()
-        if err != nil {
-                return err
-        }
+	if err != nil {
+		return err
+	}
 
-        defer tok.Close()
+	defer tok.Close()
 
 	ks_zfs_info, err := tok.Lookup("zfs", 0, "abdstats")
 	if err != nil {
@@ -178,7 +178,6 @@ func (c *zfsCollector) updateZfsAbdStats(ch chan<- prometheus.Metric) (err error
 	if err != nil {
 		return err
 	}
-
 
 	ch <- prometheus.MustNewConstMetric(
 		c.abdstatsLinearCount,
@@ -216,11 +215,11 @@ func (c *zfsCollector) updateZfsAbdStats(ch chan<- prometheus.Metric) (err error
 
 func (c *zfsCollector) updateZfsArcStats(ch chan<- prometheus.Metric) (err error) {
 	tok, err := kstat.Open()
-        if err != nil {
-                return err
-        }
+	if err != nil {
+		return err
+	}
 
-        defer tok.Close()
+	defer tok.Close()
 
 	ks_zfs_info, err := tok.Lookup("zfs", 0, "arcstats")
 	if err != nil {
@@ -343,11 +342,11 @@ func (c *zfsCollector) updateZfsArcStats(ch chan<- prometheus.Metric) (err error
 
 func (c *zfsCollector) updateZfsFetchStats(ch chan<- prometheus.Metric) (err error) {
 	tok, err := kstat.Open()
-        if err != nil {
-                return err
-        }
+	if err != nil {
+		return err
+	}
 
-        defer tok.Close()
+	defer tok.Close()
 
 	ks_zfs_info, err := tok.Lookup("zfs", 0, "zfetchstats")
 
@@ -377,14 +376,14 @@ func (c *zfsCollector) updateZfsFetchStats(ch chan<- prometheus.Metric) (err err
 }
 
 func (c *zfsCollector) Update(ch chan<- prometheus.Metric) (err error) {
-        if err := c.updateZfsAbdStats(ch); err != nil {
-                return err
-        }
-        if err := c.updateZfsArcStats(ch); err != nil {
-                return err
-        }
-        if err := c.updateZfsFetchStats(ch); err != nil {
-                return err
-        }
+	if err := c.updateZfsAbdStats(ch); err != nil {
+		return err
+	}
+	if err := c.updateZfsArcStats(ch); err != nil {
+		return err
+	}
+	if err := c.updateZfsFetchStats(ch); err != nil {
+		return err
+	}
 	return nil
 }

--- a/collector/zfs_solaris.go
+++ b/collector/zfs_solaris.go
@@ -21,26 +21,31 @@ import (
 )
 
 type zfsCollector struct {
-	abdstatsLinearCount       *prometheus.Desc
-	abdstatsLinearDataSize    *prometheus.Desc
-	abdstatsScatterChunkWaste *prometheus.Desc
-	abdstatsScatterCount      *prometheus.Desc
-	abdstatsScatterDataSize   *prometheus.Desc
-	abdstatsStructSize        *prometheus.Desc
-	arcstatsAnonSize          *prometheus.Desc
-	arcstatsHeaderSize        *prometheus.Desc
-	arcstatsHits              *prometheus.Desc
-	arcstatsMisses            *prometheus.Desc
-	arcstatsMFUGhostHits      *prometheus.Desc
-	arcstatsMFUGhostSize      *prometheus.Desc
-	arcstatsMFUSize           *prometheus.Desc
-	arcstatsMRUGhostHits      *prometheus.Desc
-	arcstatsMRUGhostSize      *prometheus.Desc
-	arcstatsMRUSize           *prometheus.Desc
-	arcstatsOtherSize         *prometheus.Desc
-	arcstatsSize              *prometheus.Desc
-	zfetchstatsHits           *prometheus.Desc
-	zfetchstatsMisses         *prometheus.Desc
+	abdstatsLinearCount          *prometheus.Desc
+	abdstatsLinearDataSize       *prometheus.Desc
+	abdstatsScatterChunkWaste    *prometheus.Desc
+	abdstatsScatterCount         *prometheus.Desc
+	abdstatsScatterDataSize      *prometheus.Desc
+	abdstatsStructSize           *prometheus.Desc
+	arcstatsAnonSize             *prometheus.Desc
+	arcstatsDataSize             *prometheus.Desc
+	arcstatsDemandDataHits       *prometheus.Desc
+	arcstatsDemandDataMisses     *prometheus.Desc
+	arcstatsDemandMetadataHits   *prometheus.Desc
+	arcstatsDemandMetadataMisses *prometheus.Desc
+	arcstatsHeaderSize           *prometheus.Desc
+	arcstatsHits                 *prometheus.Desc
+	arcstatsMisses               *prometheus.Desc
+	arcstatsMFUGhostHits         *prometheus.Desc
+	arcstatsMFUGhostSize         *prometheus.Desc
+	arcstatsMFUSize              *prometheus.Desc
+	arcstatsMRUGhostHits         *prometheus.Desc
+	arcstatsMRUGhostSize         *prometheus.Desc
+	arcstatsMRUSize              *prometheus.Desc
+	arcstatsOtherSize            *prometheus.Desc
+	arcstatsSize                 *prometheus.Desc
+	zfetchstatsHits              *prometheus.Desc
+	zfetchstatsMisses            *prometheus.Desc
 }
 
 const (
@@ -80,6 +85,26 @@ func NewZfsCollector() (Collector, error) {
 		arcstatsAnonSize: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_anon_size"),
 			"ZFS ARC anon size", nil, nil,
+		),
+		arcstatsDataSize: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_data_size"),
+			"ZFS ARC data size", nil, nil,
+		),
+		arcstatsDemandDataHits: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_demand_data_hits"),
+			"ZFS ARC demand data hits", nil, nil,
+		),
+		arcstatsDemandDataMisses: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_demand_data_misses"),
+			"ZFS ARC demand data misses", nil, nil,
+		),
+		arcstatsDemandMetadataHits: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_demand_metadata_hits"),
+			"ZFS ARC demand metadata hits", nil, nil,
+		),
+		arcstatsDemandMetadataMisses: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_demand_metadata_misses"),
+			"ZFS ARC demand metadata misses", nil, nil,
 		),
 		arcstatsHeaderSize: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_hdr_size"),
@@ -186,17 +211,22 @@ func (c *zfsCollector) updateZfsArcStats(ch chan<- prometheus.Metric) error {
 	}
 
 	for k, v := range map[string]*prometheus.Desc{
-		"anon_size":      c.arcstatsAnonSize,
-		"hdr_size":       c.arcstatsHeaderSize,
-		"hits":           c.arcstatsHits,
-		"misses":         c.arcstatsMisses,
-		"mfu_ghost_hits": c.arcstatsMFUGhostHits,
-		"mfu_ghost_size": c.arcstatsMFUGhostSize,
-		"mfu_size":       c.arcstatsMFUSize,
-		"mru_ghost_hits": c.arcstatsMRUGhostHits,
-		"mru_ghost_size": c.arcstatsMRUGhostSize,
-		"mru_size":       c.arcstatsMRUSize,
-		"size":           c.arcstatsSize,
+		"anon_size":              c.arcstatsAnonSize,
+		"data_size":              c.arcstatsDataSize,
+		"demand_data_hits"  :     c.arcstatsDemandDataHits,
+		"demand_data_misses":     c.arcstatsDemandDataMisses,
+		"demand_metadata_hits"  : c.arcstatsDemandMetadataHits,
+		"demand_metadata_misses": c.arcstatsDemandMetadataMisses,
+		"hdr_size":               c.arcstatsHeaderSize,
+		"hits":                   c.arcstatsHits,
+		"misses":                 c.arcstatsMisses,
+		"mfu_ghost_hits":         c.arcstatsMFUGhostHits,
+		"mfu_ghost_size":         c.arcstatsMFUGhostSize,
+		"mfu_size":               c.arcstatsMFUSize,
+		"mru_ghost_hits":         c.arcstatsMRUGhostHits,
+		"mru_ghost_size":         c.arcstatsMRUGhostSize,
+		"mru_size":               c.arcstatsMRUSize,
+		"size":                   c.arcstatsSize,
 	} {
 		ksZFSInfoValue, err := ksZFSInfo.GetNamed(k)
 		if err != nil {

--- a/collector/zfs_solaris.go
+++ b/collector/zfs_solaris.go
@@ -28,6 +28,9 @@ type zfsCollector struct {
 	abdstatsScatterDataSize      *prometheus.Desc
 	abdstatsStructSize           *prometheus.Desc
 	arcstatsAnonSize             *prometheus.Desc
+	arcstatsC                    *prometheus.Desc
+	arcstatsCMax                 *prometheus.Desc
+	arcstatsCMin                 *prometheus.Desc
 	arcstatsDataSize             *prometheus.Desc
 	arcstatsDemandDataHits       *prometheus.Desc
 	arcstatsDemandDataMisses     *prometheus.Desc
@@ -43,6 +46,7 @@ type zfsCollector struct {
 	arcstatsMRUGhostSize         *prometheus.Desc
 	arcstatsMRUSize              *prometheus.Desc
 	arcstatsOtherSize            *prometheus.Desc
+	arcstatsP                    *prometheus.Desc
 	arcstatsSize                 *prometheus.Desc
 	zfetchstatsHits              *prometheus.Desc
 	zfetchstatsMisses            *prometheus.Desc
@@ -85,6 +89,18 @@ func NewZfsCollector() (Collector, error) {
 		arcstatsAnonSize: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_anon_size"),
 			"ZFS ARC anon size", nil, nil,
+		),
+		arcstatsC: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_c"),
+			"ZFS ARC target size", nil, nil,
+		),
+		arcstatsCMax: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_c_max"),
+			"ZFS ARC maximum size", nil, nil,
+		),
+		arcstatsCMin: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_c_min"),
+			"ZFS ARC minimum size", nil, nil,
 		),
 		arcstatsDataSize: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_data_size"),
@@ -145,6 +161,10 @@ func NewZfsCollector() (Collector, error) {
 		arcstatsOtherSize: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_other_size"),
 			"ZFS ARC other size", nil, nil,
+		),
+		arcstatsP: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_p"),
+			"ZFS ARC MRU target size", nil, nil,
 		),
 		arcstatsSize: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_size"),
@@ -212,6 +232,9 @@ func (c *zfsCollector) updateZfsArcStats(ch chan<- prometheus.Metric) error {
 
 	for k, v := range map[string]*prometheus.Desc{
 		"anon_size":              c.arcstatsAnonSize,
+		"c":                      c.arcstatsC,
+		"c_max":                  c.arcstatsCMax,
+		"c_min":                  c.arcstatsCMin,
 		"data_size":              c.arcstatsDataSize,
 		"demand_data_hits"  :     c.arcstatsDemandDataHits,
 		"demand_data_misses":     c.arcstatsDemandDataMisses,
@@ -226,6 +249,8 @@ func (c *zfsCollector) updateZfsArcStats(ch chan<- prometheus.Metric) error {
 		"mru_ghost_hits":         c.arcstatsMRUGhostHits,
 		"mru_ghost_size":         c.arcstatsMRUGhostSize,
 		"mru_size":               c.arcstatsMRUSize,
+		"other_size":             c.arcstatsOtherSize,
+		"p":                      c.arcstatsP,
 		"size":                   c.arcstatsSize,
 	} {
 		ksZFSInfoValue, err := ksZFSInfo.GetNamed(k)

--- a/collector/zfs_solaris.go
+++ b/collector/zfs_solaris.go
@@ -1,0 +1,390 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build solaris
+
+package collector
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/siebenmann/go-kstat"
+)
+
+type zfsCollector struct {
+	abdstatsLinearCount	*prometheus.Desc
+	abdstatsLinearDataSize	*prometheus.Desc
+	abdstatsScatterChunkWaste	*prometheus.Desc
+	abdstatsScatterCount	*prometheus.Desc
+	abdstatsScatterDataSize	*prometheus.Desc
+	abdstatsStructSize	*prometheus.Desc
+	arcstatsAnonSize	*prometheus.Desc
+	arcstatsHeaderSize	*prometheus.Desc
+	arcstatsHits		*prometheus.Desc
+	arcstatsMisses		*prometheus.Desc
+	arcstatsMFUGhostHits	*prometheus.Desc
+	arcstatsMFUGhostSize	*prometheus.Desc
+	arcstatsMFUSize		*prometheus.Desc
+	arcstatsMRUGhostHits	*prometheus.Desc
+	arcstatsMRUGhostSize	*prometheus.Desc
+	arcstatsMRUSize		*prometheus.Desc
+	arcstatsOtherSize	*prometheus.Desc
+	arcstatsSize		*prometheus.Desc
+	zfetchstatsHits		*prometheus.Desc
+	zfetchstatsMisses	*prometheus.Desc
+}
+
+const (
+        zfsCollectorSubsystem = "zfs"
+)
+
+func init() {
+        registerCollector("zfs", defaultEnabled, NewZfsCollector)
+}
+
+func NewZfsCollector() (Collector, error) {
+	return &zfsCollector{
+                abdstatsLinearCount: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_linear_count"),
+			"ZFS ARC buffer data linear count", nil, nil,
+		),
+                abdstatsLinearDataSize: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_linear_data_size"),
+			"ZFS ARC buffer data linear data size", nil, nil,
+		),
+                abdstatsScatterChunkWaste: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_chunk_waste"),
+			"ZFS ARC buffer data scatter chunk waste", nil, nil,
+		),
+                abdstatsScatterCount: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_count"),
+			"ZFS ARC buffer data scatter count", nil, nil,
+		),
+                abdstatsScatterDataSize: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_scatter_data_size"),
+			"ZFS ARC buffer data scatter data size", nil, nil,
+		),
+                abdstatsStructSize: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "abdstats_struct_size"),
+			"ZFS ARC buffer data struct size", nil, nil,
+		),
+                arcstatsAnonSize: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_anon_size"),
+			"ZFS ARC anon size", nil, nil,
+		),
+                arcstatsHeaderSize: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_hdr_size"),
+			"ZFS ARC header size", nil, nil,
+		),
+                arcstatsHits: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_hits"),
+			"ZFS ARC hits", nil, nil,
+		),
+                arcstatsMisses: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_misses"),
+			"ZFS ARC misses", nil, nil,
+		),
+                arcstatsMFUGhostHits: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mfu_ghost_hits"),
+			"ZFS ARC MFU ghost hits", nil, nil,
+		),
+                arcstatsMFUGhostSize: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mfu_ghost_size"),
+			"ZFS ARC MFU ghost size", nil, nil,
+		),
+                arcstatsMFUSize: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mfu_size"),
+			"ZFS ARC MFU size", nil, nil,
+		),
+                arcstatsMRUGhostHits: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_ghost_hits"),
+			"ZFS ARC MRU ghost hits", nil, nil,
+		),
+                arcstatsMRUGhostSize: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_ghost_size"),
+			"ZFS ARC MRU ghost size", nil, nil,
+		),
+                arcstatsMRUSize: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_mru_size"),
+			"ZFS ARC MRU size", nil, nil,
+		),
+                arcstatsOtherSize: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_other_size"),
+			"ZFS ARC other size", nil, nil,
+		),
+                arcstatsSize: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "arcstats_size"),
+			"ZFS ARC size", nil, nil,
+		),
+                zfetchstatsHits: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "zfetchstats_hits"),
+			"ZFS cache fetch hits", nil, nil,
+		),
+                zfetchstatsMisses: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, zfsCollectorSubsystem, "zfetchstats_misses"),
+			"ZFS cache fetch misses", nil, nil,
+		),
+	}, nil
+}
+
+func (c *zfsCollector) updateZfsAbdStats(ch chan<- prometheus.Metric) (err error) {
+	tok, err := kstat.Open()
+        if err != nil {
+                return err
+        }
+
+        defer tok.Close()
+
+	ks_zfs_info, err := tok.Lookup("zfs", 0, "abdstats")
+	if err != nil {
+		return err
+	}
+
+	zfs_abdstats_linear_count_v, err := ks_zfs_info.GetNamed("linear_cnt")
+	if err != nil {
+		return err
+	}
+
+	zfs_abdstats_linear_data_size_v, err := ks_zfs_info.GetNamed("linear_data_size")
+	if err != nil {
+		return err
+	}
+
+	zfs_abdstats_scatter_chunk_waste_v, err := ks_zfs_info.GetNamed("scatter_chunk_waste")
+	if err != nil {
+		return err
+	}
+
+	zfs_abdstats_scatter_count_v, err := ks_zfs_info.GetNamed("scatter_cnt")
+	if err != nil {
+		return err
+	}
+
+	zfs_abdstats_scatter_data_size_v, err := ks_zfs_info.GetNamed("scatter_data_size")
+	if err != nil {
+		return err
+	}
+
+	zfs_abdstats_struct_size_v, err := ks_zfs_info.GetNamed("struct_size")
+	if err != nil {
+		return err
+	}
+
+
+	ch <- prometheus.MustNewConstMetric(
+		c.abdstatsLinearCount,
+		prometheus.GaugeValue,
+		float64(zfs_abdstats_linear_count_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.abdstatsLinearDataSize,
+		prometheus.GaugeValue,
+		float64(zfs_abdstats_linear_data_size_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.abdstatsScatterChunkWaste,
+		prometheus.GaugeValue,
+		float64(zfs_abdstats_scatter_chunk_waste_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.abdstatsScatterCount,
+		prometheus.GaugeValue,
+		float64(zfs_abdstats_scatter_count_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.abdstatsScatterDataSize,
+		prometheus.GaugeValue,
+		float64(zfs_abdstats_scatter_data_size_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.abdstatsStructSize,
+		prometheus.GaugeValue,
+		float64(zfs_abdstats_struct_size_v.UintVal),
+	)
+
+	return err
+}
+
+func (c *zfsCollector) updateZfsArcStats(ch chan<- prometheus.Metric) (err error) {
+	tok, err := kstat.Open()
+        if err != nil {
+                return err
+        }
+
+        defer tok.Close()
+
+	ks_zfs_info, err := tok.Lookup("zfs", 0, "arcstats")
+	if err != nil {
+		return err
+	}
+
+	zfs_arcstats_anon_size_v, err := ks_zfs_info.GetNamed("anon_size")
+	if err != nil {
+		return err
+	}
+
+	zfs_arcstats_hdr_size_v, err := ks_zfs_info.GetNamed("hdr_size")
+	if err != nil {
+		return err
+	}
+
+	zfs_arcstats_hits_v, err := ks_zfs_info.GetNamed("hits")
+	if err != nil {
+		return err
+	}
+
+	zfs_arcstats_misses_v, err := ks_zfs_info.GetNamed("misses")
+	if err != nil {
+		return err
+	}
+
+	zfs_arcstats_mfu_ghost_hits_v, err := ks_zfs_info.GetNamed("mfu_ghost_hits")
+	if err != nil {
+		return err
+	}
+
+	zfs_arcstats_mfu_ghost_size_v, err := ks_zfs_info.GetNamed("mfu_ghost_size")
+	if err != nil {
+		return err
+	}
+
+	zfs_arcstats_mfu_size_v, err := ks_zfs_info.GetNamed("mfu_size")
+	if err != nil {
+		return err
+	}
+
+	zfs_arcstats_mru_ghost_hits_v, err := ks_zfs_info.GetNamed("mru_ghost_hits")
+	if err != nil {
+		return err
+	}
+
+	zfs_arcstats_mru_ghost_size_v, err := ks_zfs_info.GetNamed("mru_ghost_size")
+	if err != nil {
+		return err
+	}
+
+	zfs_arcstats_mru_size_v, err := ks_zfs_info.GetNamed("mru_size")
+	if err != nil {
+		return err
+	}
+
+	zfs_arcstats_size_v, err := ks_zfs_info.GetNamed("size")
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.arcstatsAnonSize,
+		prometheus.GaugeValue,
+		float64(zfs_arcstats_anon_size_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.arcstatsHeaderSize,
+		prometheus.GaugeValue,
+		float64(zfs_arcstats_hdr_size_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.arcstatsHits,
+		prometheus.GaugeValue,
+		float64(zfs_arcstats_hits_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.arcstatsMisses,
+		prometheus.GaugeValue,
+		float64(zfs_arcstats_misses_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.arcstatsMFUGhostHits,
+		prometheus.GaugeValue,
+		float64(zfs_arcstats_mfu_ghost_hits_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.arcstatsMFUGhostSize,
+		prometheus.GaugeValue,
+		float64(zfs_arcstats_mfu_ghost_size_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.arcstatsMFUSize,
+		prometheus.GaugeValue,
+		float64(zfs_arcstats_mfu_size_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.arcstatsMRUGhostHits,
+		prometheus.GaugeValue,
+		float64(zfs_arcstats_mru_ghost_hits_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.arcstatsMRUGhostSize,
+		prometheus.GaugeValue,
+		float64(zfs_arcstats_mru_ghost_size_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.arcstatsMRUSize,
+		prometheus.GaugeValue,
+		float64(zfs_arcstats_mru_size_v.UintVal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.arcstatsSize,
+		prometheus.GaugeValue,
+		float64(zfs_arcstats_size_v.UintVal),
+	)
+
+	return err
+}
+
+func (c *zfsCollector) updateZfsFetchStats(ch chan<- prometheus.Metric) (err error) {
+	tok, err := kstat.Open()
+        if err != nil {
+                return err
+        }
+
+        defer tok.Close()
+
+	ks_zfs_info, err := tok.Lookup("zfs", 0, "zfetchstats")
+
+	zfs_fetchstats_hits_v, err := ks_zfs_info.GetNamed("hits")
+	if err != nil {
+		return err
+	}
+
+	zfs_fetchstats_misses_v, err := ks_zfs_info.GetNamed("misses")
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.zfetchstatsHits,
+		prometheus.GaugeValue,
+		float64(zfs_fetchstats_hits_v.UintVal),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.zfetchstatsMisses,
+		prometheus.GaugeValue,
+		float64(zfs_fetchstats_misses_v.UintVal),
+	)
+
+	return err
+}
+
+func (c *zfsCollector) Update(ch chan<- prometheus.Metric) (err error) {
+        if err := c.updateZfsAbdStats(ch); err != nil {
+                return err
+        }
+        if err := c.updateZfsArcStats(ch); err != nil {
+                return err
+        }
+        if err := c.updateZfsFetchStats(ch); err != nil {
+                return err
+        }
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
 	github.com/prometheus/common v0.0.0-20181015124227-bcb74de08d37
 	github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d
+	github.com/siebenmann/go-kstat v0.0.0-20160321171754-d34789b79745
 	github.com/sirupsen/logrus v1.1.1 // indirect
 	github.com/soundcloud/go-runit v0.0.0-20150630195641-06ad41a06c4a
 	golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/prometheus/common v0.0.0-20181015124227-bcb74de08d37 h1:Y7YdJ9Xb3MoQO
 github.com/prometheus/common v0.0.0-20181015124227-bcb74de08d37/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d h1:GoAlyOgbOEIFdaDqxJVlbOQ1DtGmZWs/Qau0hIlk+WQ=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/siebenmann/go-kstat v0.0.0-20160321171754-d34789b79745 h1:IuH7WumZNax0D+rEqmy2TyhKCzrtMGqbZO0b8rO00JA=
+github.com/siebenmann/go-kstat v0.0.0-20160321171754-d34789b79745/go.mod h1:G81aIFAMS9ECrwBYR9YxhlPjWgrItd+Kje78O6+uqm8=
 github.com/sirupsen/logrus v1.1.1 h1:VzGj7lhU7KEB9e9gMpAV/v5XT2NVSvLJhJLCWbnkgXg=
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=
 github.com/soundcloud/go-runit v0.0.0-20150630195641-06ad41a06c4a h1:os5OBNhwOwybXZMNLqT96XqtjdTtwRFw2w08uluvNeI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -50,6 +50,8 @@ github.com/prometheus/procfs/nfs
 github.com/prometheus/procfs/sysfs
 github.com/prometheus/procfs/xfs
 github.com/prometheus/procfs/internal/util
+# github.com/siebenmann/go-kstat v0.0.0-20160321171754-d34789b79745
+github.com/siebenmann/go-kstat
 # github.com/sirupsen/logrus v1.1.1
 github.com/sirupsen/logrus
 # github.com/soundcloud/go-runit v0.0.0-20150630195641-06ad41a06c4a


### PR DESCRIPTION
Added `kstat` based Solaris metrics, adds:

 * boottime
 * cpu
 * zfs

Tested on `OpenIndiana Hipster 2018.10`.

Closes: https://github.com/prometheus/node_exporter/issues/1208