### PR TITLE
add md_info_detail.sh

### DIFF
--- a/text_collector_examples/md_info_detail.sh
+++ b/text_collector_examples/md_info_detail.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Note: This script uses "mdadm --detail" to get some of the metrics, so it must be run as root.
+# It is designed to be run periodically in a cronjob and output to /var/lib/node_exporter/textfile_collector/md_info_detail.prom
+# e.g. Here is an example of a cronjob that will run this script every minute and put the output into
+# /var/lib/node_exporter/textfile_collector/md_info_detail.prom for the node_exporter to serve.
+# $ cat /etc/cron.d/prometheus_md_info_detail
+# * * * * * bash /var/lib/node_exporter/text_collector_examples/md_info_detail.sh > /var/lib/node_exporter/textfile_collector/md_info_detail.prom.$$ && mv /var/lib/node_exporter/textfile_collector/md_info_detail.prom.$$ /var/lib/node_exporter/textfile_collector/md_info_detail.prom
+
+set -eu
+
+for MD_DEVICE in /dev/md/*; do
+  # Subshell to avoid eval'd variables from leaking between iterations
+  (
+    # Resolve symlink to discover device, e.g. /dev/md127
+    MD_DEVICE_NUM=$(readlink -f "${MD_DEVICE}")
+
+    # Remove /dev/ prefix
+    MD_DEVICE_NUM=${MD_DEVICE_NUM#/dev/}
+    MD_DEVICE=${MD_DEVICE#/dev/md/}
+
+    # Query sysfs for info about md device
+    SYSFS_BASE="/sys/devices/virtual/block/${MD_DEVICE_NUM}/md"
+    MD_LAYOUT=$(cat "${SYSFS_BASE}/layout")
+    MD_LEVEL=$(cat "${SYSFS_BASE}/level")
+    MD_METADATA_VERSION=$(cat "${SYSFS_BASE}/metadata_version")
+    MD_NUM_RAID_DISKS=$(cat "${SYSFS_BASE}/raid_disks")
+
+    # Remove 'raid' prefix from RAID level
+    MD_LEVEL=${MD_LEVEL#raid}
+
+    # Output disk metrics
+    for RAID_DISK in ${SYSFS_BASE}/rd[0-9]*; do
+      DISK=$(readlink -f "${RAID_DISK}/block")
+      DISK_DEVICE=$(basename "${DISK}")
+      RAID_DISK_DEVICE=$(basename "${RAID_DISK}")
+      RAID_DISK_INDEX=${RAID_DISK_DEVICE#rd}
+      RAID_DISK_STATE=$(cat "${RAID_DISK}/state")
+
+      DISK_SET=""
+      # Determine disk set using logic from mdadm: https://github.com/neilbrown/mdadm/commit/2c096ebe4b
+      if [[ ${RAID_DISK_STATE} == "in_sync" && ${MD_LEVEL} == 10 && $((MD_LAYOUT & ~0x1ffff)) ]]; then
+        NEAR_COPIES=$((MD_LAYOUT & 0xff))
+        FAR_COPIES=$(((MD_LAYOUT >> 8) & 0xff))
+        COPIES=$((NEAR_COPIES * FAR_COPIES))
+
+        if [[ $((MD_NUM_RAID_DISKS % COPIES == 0)) && $((COPIES <= 26)) ]]; then
+          DISK_SET=$((RAID_DISK_INDEX % COPIES))
+        fi
+      fi
+
+      echo -n "node_md_disk_info{disk_device=\"${DISK_DEVICE}\", md_device=\"${MD_DEVICE_NUM}\""
+      if [[ -n ${DISK_SET} ]]; then
+        SET_LETTERS=({A..Z})
+        echo -n ", md_set=\"${SET_LETTERS[${DISK_SET}]}\""
+      fi
+      echo "} 1"
+    done
+
+    # Get output from mdadm --detail (Note: root/sudo required)
+    MDADM_DETAIL_OUTPUT=$(mdadm --detail /dev/${MD_DEVICE_NUM})
+
+    # Output RAID "Devices" metrics, from the output of "mdadm --detail"
+    while IFS= read -r line ; do
+      if echo $line | grep -q "Devices : "; then
+        MDADM_DETAIL_KEY=$(echo $line | cut -d ":" -f 1 | tr -cd '[a-zA-Z0-9]._-')
+        MDADM_DETAIL_VALUE=$(echo $line | cut -d ":" -f 2- | sed 's:^ ::')
+        echo "node_md_info_${MDADM_DETAIL_KEY}{md_device=\"${MD_DEVICE_NUM}\", md_name=\"${MD_DEVICE}\", raid_level=\"${MD_LEVEL}\", md_num_raid_disks=\"${MD_NUM_RAID_DISKS}\", md_metadata_version=\"${MD_METADATA_VERSION}\"} ${MDADM_DETAIL_VALUE}"
+      fi
+    done  <<< "$MDADM_DETAIL_OUTPUT"
+
+    # Output RAID detail metrics info from the output of "mdadm --detail"
+    # NOTE: Sending this info as labels rather than a separate metric, because some of them can be strings.
+    echo -n "node_md_info{md_device=\"${MD_DEVICE_NUM}\", md_name=\"${MD_DEVICE}\", raid_level=\"${MD_LEVEL}\", md_num_raid_disks=\"${MD_NUM_RAID_DISKS}\", md_metadata_version=\"${MD_METADATA_VERSION}\""
+    while IFS= read -r line ; do
+      if echo $line | egrep -q ":"; then
+        echo -n ", "
+        MDADM_DETAIL_KEY=$(echo $line | cut -d ":" -f 1 | tr -cd '[a-zA-Z0-9]._-')
+        MDADM_DETAIL_VALUE=$(echo $line | cut -d ":" -f 2- | sed 's:^ ::')
+        echo -n "${MDADM_DETAIL_KEY}=\"${MDADM_DETAIL_VALUE}\""
+      fi
+    done  <<< "$MDADM_DETAIL_OUTPUT"
+    echo "} 1"
+
+  )
+done


### PR DESCRIPTION
This text_collector script is based on "md_info.sh", but also uses "mdadm --detail" to collect some additional information about the MD raids on the system.  "mdadm --detail" does require being run as root, but it also include some additional info about the devices in the raid that can be useful for alerting on (e.g. FailedDevices, ActiveDevices, State, etc).

Here's an example of the additional info/metrics this collector will provide...
```
$ sudo bash ./md_info_detail.sh
...
node_md_info_RaidDevices{md_device="md123", md_name="data_0", raid_level="6", md_num_raid_disks="12", md_metadata_version="1.2"} 12
node_md_info_TotalDevices{md_device="md123", md_name="data_0", raid_level="6", md_num_raid_disks="12", md_metadata_version="1.2"} 11
node_md_info_ActiveDevices{md_device="md123", md_name="data_0", raid_level="6", md_num_raid_disks="12", md_metadata_version="1.2"} 11
node_md_info_WorkingDevices{md_device="md123", md_name="data_0", raid_level="6", md_num_raid_disks="12", md_metadata_version="1.2"} 11
node_md_info_FailedDevices{md_device="md123", md_name="data_0", raid_level="6", md_num_raid_disks="12", md_metadata_version="1.2"} 0
node_md_info_SpareDevices{md_device="md123", md_name="data_0", raid_level="6", md_num_raid_disks="12", md_metadata_version="1.2"} 0
node_md_info{md_device="md123", md_name="data_0", raid_level="6", md_num_raid_disks="12", md_metadata_version="1.2", devmd123="", Version="1.2", CreationTime="Wed Jul 23 23:09:04 2014", RaidLevel="raid6", ArraySize="29301207040 (27943.81 GiB 30004.44 GB)", UsedDevSize="2930120704 (2794.38 GiB 3000.44 GB)", RaidDevices="12", TotalDevices="11", Persistence="Superblock is persistent", IntentBitmap="Internal", UpdateTime="Thu Dec 20 01:29:57 2018", State="clean, degraded", ActiveDevices="11", WorkingDevices="11", FailedDevices="0", SpareDevices="0", Layout="left-symmetric", ChunkSize="512K", Name="data", UUID="d3d34cd0:62da82d6:117e8ef4:5826e80c", Events="3035936"} 1
...
```