### PR TITLE
Docker images for ARM32v7, ARM64v8 and ppc64le

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,8 @@ jobs:
     - run: codespell --skip=".git,./vendor,ttar,go.mod,go.sum" -L uint
 
   build:
-    machine: true
+    machine:
+      image: ubuntu-1604:201903-01
 
     environment:
       DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.11-base
@@ -39,6 +40,7 @@ jobs:
 
     steps:
     - checkout
+    - run: docker run --privileged linuxkit/binfmt:v0.6
     - run: make promu
     - run: promu crossbuild
     - run: promu --config .promu-cgo.yml crossbuild
@@ -49,7 +51,6 @@ jobs:
     - store_artifacts:
         path: .build
         destination: /build
-    - run: ln -s .build/linux-amd64/node_exporter node_exporter
     - run:
         command: |
           if [ -n "$CIRCLE_TAG" ]; then
@@ -72,10 +73,11 @@ jobs:
 
     steps:
     - checkout
-    - setup_remote_docker
+    - setup_remote_docker:
+        version: 18.06.0-ce
+    - run: docker run --privileged linuxkit/binfmt:v0.6
     - attach_workspace:
         at: .
-    - run: ln -s .build/linux-amd64/node_exporter node_exporter
     - run: make docker
     - run: make docker DOCKER_REPO=quay.io/prometheus
     - run: docker images
@@ -83,13 +85,17 @@ jobs:
     - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
     - run: make docker-publish
     - run: make docker-publish DOCKER_REPO=quay.io/prometheus
+    - run: make docker-manifest
+    - run: make docker-manifest DOCKER_REPO=quay.io/prometheus
 
   docker_hub_release_tags:
     executor: golang
 
     steps:
     - checkout
-    - setup_remote_docker
+    - setup_remote_docker:
+        version: 18.06.0-ce
+    - run: docker run --privileged linuxkit/binfmt:v0.6
     - run: mkdir -v -p ${HOME}/bin
     - run: curl -L 'https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2' | tar xvjf - --strip-components 3 -C ${HOME}/bin
     - run: echo 'export PATH=${HOME}/bin:${PATH}' >> ${BASH_ENV}
@@ -102,18 +108,23 @@ jobs:
     - store_artifacts:
         path: .tarballs
         destination: releases
-    - run: ln -s .build/linux-amd64/node_exporter node_exporter
     - run: make docker DOCKER_IMAGE_TAG=$CIRCLE_TAG
     - run: make docker DOCKER_IMAGE_TAG=$CIRCLE_TAG DOCKER_REPO=quay.io/prometheus
     - run: docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
     - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
+    - run: make docker-publish DOCKER_IMAGE_TAG="$CIRCLE_TAG"
+    - run: make docker-publish DOCKER_IMAGE_TAG="$CIRCLE_TAG" DOCKER_REPO=quay.io/prometheus
+    - run: make docker-manifest DOCKER_IMAGE_TAG="$CIRCLE_TAG"
+    - run: make docker-manifest DOCKER_IMAGE_TAG="$CIRCLE_TAG" DOCKER_REPO=quay.io/prometheus
     - run: |
         if [[ "$CIRCLE_TAG" =~ ^v[0-9]+(\.[0-9]+){2}$ ]]; then
           make docker-tag-latest DOCKER_IMAGE_TAG="$CIRCLE_TAG"
           make docker-tag-latest DOCKER_IMAGE_TAG="$CIRCLE_TAG" DOCKER_REPO=quay.io/prometheus
+          make docker-publish DOCKER_IMAGE_TAG="latest"
+          make docker-publish DOCKER_IMAGE_TAG="latest" DOCKER_REPO=quay.io/prometheus
+          make docker-manifest DOCKER_IMAGE_TAG="latest"
+          make docker-manifest DOCKER_IMAGE_TAG="latest" DOCKER_REPO=quay.io/prometheus
         fi
-    - run: make docker-publish
-    - run: make docker-publish DOCKER_REPO=quay.io/prometheus
 
 workflows:
   version: 2

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,6 @@
 .tarballs/
 
 !.build/linux-amd64
+!.build/linux-armv7
+!.build/linux-arm64
+!.build/linux-ppc64le

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM        quay.io/prometheus/busybox:glibc
+ARG ARCH="amd64"
+ARG OS="linux"
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:glibc
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-COPY node_exporter /bin/node_exporter
+ARG ARCH="amd64"
+ARG OS="linux"
+COPY .build/${OS}-${ARCH}/node_exporter /bin/node_exporter
 
 EXPOSE      9100
 USER        nobody

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,7 +1,0 @@
-FROM        ppc64le/busybox:glibc
-
-COPY node_exporter /bin/node_exporter
-
-EXPOSE      9100
-USER        nobody
-ENTRYPOINT  [ "/bin/node_exporter" ]

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@
 # Ensure that 'all' is the default target otherwise it will be the first target from Makefile.common.
 all::
 
+# Needs to be defined before including Makefile.common to auto-generate targets
+DOCKER_ARCHS ?= amd64 armv7 arm64 ppc64le
+
 include Makefile.common
 
 PROMTOOL_VERSION ?= 2.5.0
@@ -22,7 +25,6 @@ PROMTOOL         ?= $(FIRST_GOPATH)/bin/promtool
 
 DOCKER_IMAGE_NAME       ?= node-exporter
 MACH                    ?= $(shell uname -m)
-DOCKERFILE              ?= Dockerfile
 
 STATICCHECK_IGNORE =
 
@@ -114,18 +116,10 @@ checkrules: $(PROMTOOL)
 	@echo ">> checking rules for correctness"
 	find . -name "*rules*.yml" | xargs -I {} $(PROMTOOL) check rules {}
 
-.PHONY: docker
-docker:
-ifeq ($(MACH), ppc64le)
-	$(eval DOCKERFILE=Dockerfile.ppc64le)
-endif
-	@echo ">> building docker image from $(DOCKERFILE)"
-	@docker build --file $(DOCKERFILE) -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
-
 .PHONY: test-docker
 test-docker:
 	@echo ">> testing docker image"
-	./test_image.sh "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" 9100
+	./test_image.sh "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-amd64:$(DOCKER_IMAGE_TAG)" 9100
 
 .PHONY: promtool
 promtool: $(PROMTOOL)

--- a/Makefile.common
+++ b/Makefile.common
@@ -88,6 +88,12 @@ BIN_DIR                 ?= $(shell pwd)
 DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 DOCKER_REPO             ?= prom
 
+DOCKER_ARCHS            ?= amd64
+
+BUILD_DOCKER_ARCHS = $(addprefix common-docker-,$(DOCKER_ARCHS))
+PUBLISH_DOCKER_ARCHS = $(addprefix common-docker-publish-,$(DOCKER_ARCHS))
+TAG_DOCKER_ARCHS = $(addprefix common-docker-tag-latest-,$(DOCKER_ARCHS))
+
 ifeq ($(GOHOSTARCH),amd64)
         ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux freebsd darwin windows))
                 # Only supported on amd64
@@ -197,17 +203,28 @@ common-tarball: promu
 	@echo ">> building release tarball"
 	$(PROMU) tarball --prefix $(PREFIX) $(BIN_DIR)
 
-.PHONY: common-docker
-common-docker:
-	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+.PHONY: common-docker $(BUILD_DOCKER_ARCHS)
+common-docker: $(BUILD_DOCKER_ARCHS)
+$(BUILD_DOCKER_ARCHS): common-docker-%:
+	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(DOCKER_IMAGE_TAG)" \
+		--build-arg ARCH="$*" \
+		--build-arg OS="linux" \
+		.
 
-.PHONY: common-docker-publish
-common-docker-publish:
-	docker push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)"
+.PHONY: common-docker-publish $(PUBLISH_DOCKER_ARCHS)
+common-docker-publish: $(PUBLISH_DOCKER_ARCHS)
+$(PUBLISH_DOCKER_ARCHS): common-docker-publish-%:
+	docker push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(DOCKER_IMAGE_TAG)"
 
-.PHONY: common-docker-tag-latest
-common-docker-tag-latest:
-	docker tag "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):latest"
+.PHONY: common-docker-tag-latest $(TAG_DOCKER_ARCHS)
+common-docker-tag-latest: $(TAG_DOCKER_ARCHS)
+$(TAG_DOCKER_ARCHS): common-docker-tag-latest-%:
+	docker tag "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(DOCKER_IMAGE_TAG)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:latest"
+
+.PHONY: common-docker-manifest
+common-docker-manifest:
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" $(foreach ARCH,$(DOCKER_ARCHS),$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$(ARCH):$(DOCKER_IMAGE_TAG))
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"
 
 .PHONY: promu
 promu: $(PROMU)


### PR DESCRIPTION
See https://github.com/prometheus/prometheus/pull/5031 for context.

Requires the following now repositories to be created:

- promu/node-exporter-arm32v7-linux
- promu/node-exporter-arm64v8-linux
- promu/node-exporter-ppc64le-linux
- quay.io/prometheus/node-exporter-arm32v7-linux
- quay.io/prometheus/node-exporter-arm64v8-linux
- quay.io/prometheus/node-exporter-ppc64le-linux

Fixes https://github.com/prometheus/node_exporter/issues/1034

Requires prometheus/busybox#19