### PR TITLE
Do not use .PHONY for $(PROMTOOL)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,6 @@ test-docker:
 .PHONY: promtool
 promtool: $(PROMTOOL)
 
-.PHONY: $(PROMTOOL)
 $(PROMTOOL):
 	$(eval PROMTOOL_TMP := $(shell mktemp -d))
 	curl -s -L $(PROMTOOL_URL) | tar -xvzf - -C $(PROMTOOL_TMP)


### PR DESCRIPTION
Adding $(PROMTOOL) to .PHONY makes it impossible to provide an alternative path
to promtool.