### PR TITLE
add physical disk "state" to megaraid_pd_info metric

### DIFF
--- a/text_collector_examples/storcli.py
+++ b/text_collector_examples/storcli.py
@@ -148,12 +148,13 @@ def create_metrcis_of_physical_drive(physical_drive, detailed_info_array, contro
     pd_baselabel = 'controller="{}",enclosure="{}",slot="{}"'.format(controller_index, enclosure,
                                                                      slot)
     pd_info_label = pd_baselabel + \
-        ',disk_id="{}",interface="{}",media="{}",model="{}",DG="{}"'.format(
+        ',disk_id="{}",interface="{}",media="{}",model="{}",DG="{}",state="{}"'.format(
             str(physical_drive.get('DID')).strip(),
             str(physical_drive.get('Intf')).strip(),
             str(physical_drive.get('Med')).strip(),
             str(physical_drive.get('Model')).strip(),
-            str(physical_drive.get('DG')).strip())
+            str(physical_drive.get('DG')).strip(),
+            str(physical_drive.get('State')).strip())
 
     drive_identifier = 'Drive /c' + str(controller_index) + '/e' + str(enclosure) + '/s' + str(
         slot)


### PR DESCRIPTION
Signed-off-by: Matt Pursley <mpursley@gmail.com>

This commit adds the physical disk "state" to megaraid_pd_info metric.  Seems like the "state" of a disk is very important to include, as this is the best way to tell if a disk is in a bad state (e.g. failed, unassigned, etc.)

Here's an example of the metric with this label included... 
megaraid_pd_info{controller="1",enclosure="25",slot="3",disk_id="16",interface="SAS",media="HDD",model="ST4000NM0023",DG="0",state="Onln",firmware="GS0F"} 1.0
megaraid_pd_info{controller="1",enclosure="25",slot="4",disk_id="26",interface="SAS",media="HDD",model="ST4000NM0295",DG="0",state="DHS",firmware="DT31"} 1.0

@SuperQ @discordianfish Please review