### PR TITLE
collector: use path/filepath for handling file paths

### DIFF
--- a/collector/paths.go
+++ b/collector/paths.go
@@ -14,10 +14,10 @@
 package collector
 
 import (
-	"path"
+	"path/filepath"
 
 	"github.com/prometheus/procfs"
-	"gopkg.in/alecthomas/kingpin.v2"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (
@@ -28,13 +28,13 @@ var (
 )
 
 func procFilePath(name string) string {
-	return path.Join(*procPath, name)
+	return filepath.Join(*procPath, name)
 }
 
 func sysFilePath(name string) string {
-	return path.Join(*sysPath, name)
+	return filepath.Join(*sysPath, name)
 }
 
 func rootfsFilePath(name string) string {
-	return path.Join(*rootfsPath, name)
+	return filepath.Join(*rootfsPath, name)
 }


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

It's a nitpick, but this is technically correct:

> The path package should only be used for paths separated by forward slashes, such as the paths in URLs. This package does not deal with Windows paths with drive letters or backslashes; to manipulate operating system paths, use the path/filepath package.

One of the VSCode tools also set the kingpin import name.