### PR TITLE
collector: Implement uname collector for FreeBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [ENHANCEMENT] Add Infiniband counters #1120
 * [FEATURE] Add a flag to disable exporter metrics #1148
 * [FEATURE] Add kstat-based Solaris metrics for boottime, cpu and zfs collectors #1197
+* [FEATURE] Add uname collector for FreeBSD #1239
 
 ## 0.17.0 / 2018-11-30
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ stat | Exposes various statistics from `/proc/stat`. This includes boot time, fo
 textfile | Exposes statistics read from local disk. The `--collector.textfile.directory` flag must be set. | _any_
 time | Exposes the current system time. | _any_
 timex | Exposes selected adjtimex(2) system call stats. | Linux
-uname | Exposes system information as provided by the uname system call. | Linux
+uname | Exposes system information as provided by the uname system call. | FreeBSD, Linux
 vmstat | Exposes statistics from `/proc/vmstat`. | Linux
 xfs | Exposes XFS runtime statistics. | Linux (kernel 4.4+)
 zfs | Exposes [ZFS](http://open-zfs.org/) performance statistics. | [Linux](http://zfsonlinux.org/), Solaris

--- a/collector/uname.go
+++ b/collector/uname.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Prometheus Authors
+// Copyright 2019 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/collector/uname.go
+++ b/collector/uname.go
@@ -35,7 +35,14 @@ var unameDesc = prometheus.NewDesc(
 )
 
 type unameCollector struct{}
-type unameOutput map[string]string
+type uname struct {
+	SysName    string
+	Release    string
+	Version    string
+	Machine    string
+	NodeName   string
+	DomainName string
+}
 
 func init() {
 	registerCollector("uname", defaultEnabled, newUnameCollector)
@@ -53,12 +60,12 @@ func (c unameCollector) Update(ch chan<- prometheus.Metric) error {
 	}
 
 	ch <- prometheus.MustNewConstMetric(unameDesc, prometheus.GaugeValue, 1,
-		uname["sysname"],
-		uname["release"],
-		uname["version"],
-		uname["machine"],
-		uname["nodename"],
-		uname["domainname"],
+		uname.SysName,
+		uname.Release,
+		uname.Version,
+		uname.Machine,
+		uname.NodeName,
+		uname.DomainName,
 	)
 
 	return nil

--- a/collector/uname.go
+++ b/collector/uname.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux freebsd
 // +build !nouname
 
 package collector

--- a/collector/uname.go
+++ b/collector/uname.go
@@ -34,6 +34,7 @@ var unameDesc = prometheus.NewDesc(
 )
 
 type unameCollector struct{}
+type unameOutput map[string]string
 
 func init() {
 	registerCollector("uname", defaultEnabled, newUnameCollector)
@@ -42,4 +43,22 @@ func init() {
 // NewUnameCollector returns new unameCollector.
 func newUnameCollector() (Collector, error) {
 	return &unameCollector{}, nil
+}
+
+func (c unameCollector) Update(ch chan<- prometheus.Metric) error {
+	uname, err := getUname()
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(unameDesc, prometheus.GaugeValue, 1,
+		uname["sysname"],
+		uname["release"],
+		uname["version"],
+		uname["machine"],
+		uname["hostname"],
+		uname["domainname"],
+	)
+
+	return nil
 }

--- a/collector/uname.go
+++ b/collector/uname.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux freebsd
+// +build freebsd linux
 // +build !nouname
 
 package collector

--- a/collector/uname.go
+++ b/collector/uname.go
@@ -16,26 +16,30 @@
 package collector
 
 import (
-	"bytes"
-
 	"github.com/prometheus/client_golang/prometheus"
-
-	"golang.org/x/sys/unix"
 )
 
-func (c unameCollector) Update(ch chan<- prometheus.Metric) error {
-	var uname unix.Utsname
-	if err := unix.Uname(&uname); err != nil {
-		return err
-	}
+var unameDesc = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "uname", "info"),
+	"Labeled system information as provided by the uname system call.",
+	[]string{
+		"sysname",
+		"release",
+		"version",
+		"machine",
+		"nodename",
+		"domainname",
+	},
+	nil,
+)
 
-	ch <- prometheus.MustNewConstMetric(unameDesc, prometheus.GaugeValue, 1,
-		string(uname.Sysname[:bytes.IndexByte(uname.Sysname[:], 0)]),
-		string(uname.Release[:bytes.IndexByte(uname.Release[:], 0)]),
-		string(uname.Version[:bytes.IndexByte(uname.Version[:], 0)]),
-		string(uname.Machine[:bytes.IndexByte(uname.Machine[:], 0)]),
-		string(uname.Nodename[:bytes.IndexByte(uname.Nodename[:], 0)]),
-		string(uname.Domainname[:bytes.IndexByte(uname.Domainname[:], 0)]),
-	)
-	return nil
+type unameCollector struct{}
+
+func init() {
+	registerCollector("uname", defaultEnabled, newUnameCollector)
+}
+
+// NewUnameCollector returns new unameCollector.
+func newUnameCollector() (Collector, error) {
+	return &unameCollector{}, nil
 }

--- a/collector/uname.go
+++ b/collector/uname.go
@@ -56,7 +56,7 @@ func (c unameCollector) Update(ch chan<- prometheus.Metric) error {
 		uname["release"],
 		uname["version"],
 		uname["machine"],
-		uname["hostname"],
+		uname["nodename"],
 		uname["domainname"],
 	)
 

--- a/collector/uname_freebsd.go
+++ b/collector/uname_freebsd.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Prometheus Authors
+// Copyright 2019 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/collector/uname_freebsd.go
+++ b/collector/uname_freebsd.go
@@ -22,15 +22,15 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func getUname() (unameOutput, error) {
-	var uname unix.Utsname
-	if err := unix.Uname(&uname); err != nil {
-		return nil, err
+func getUname() (uname, error) {
+	var utsname unix.Utsname
+	if err := unix.Uname(&utsname); err != nil {
+		return uname{}, err
 	}
 
 	// We do a little bit of work here to emulate what happens in the Linux
 	// uname calls since FreeBSD uname doesn't have a Domainname.
-	nodename := string(uname.Nodename[:bytes.IndexByte(uname.Nodename[:], 0)])
+	nodename := string(utsname.Nodename[:bytes.IndexByte(utsname.Nodename[:], 0)])
 	split := strings.SplitN(nodename, ".", 2)
 
 	// We'll always have at least a single element in the array. We assume this
@@ -44,13 +44,13 @@ func getUname() (unameOutput, error) {
 		domainname = split[1]
 	}
 
-	output := unameOutput{
-		"sysname":    string(uname.Sysname[:bytes.IndexByte(uname.Sysname[:], 0)]),
-		"release":    string(uname.Release[:bytes.IndexByte(uname.Release[:], 0)]),
-		"version":    string(uname.Version[:bytes.IndexByte(uname.Version[:], 0)]),
-		"machine":    string(uname.Machine[:bytes.IndexByte(uname.Machine[:], 0)]),
-		"nodename":   hostname,
-		"domainname": domainname,
+	output := uname{
+		SysName:    string(utsname.Sysname[:bytes.IndexByte(utsname.Sysname[:], 0)]),
+		Release:    string(utsname.Release[:bytes.IndexByte(utsname.Release[:], 0)]),
+		Version:    string(utsname.Version[:bytes.IndexByte(utsname.Version[:], 0)]),
+		Machine:    string(utsname.Machine[:bytes.IndexByte(utsname.Machine[:], 0)]),
+		NodeName:   hostname,
+		DomainName: domainname,
 	}
 
 	return output, nil

--- a/collector/uname_freebsd.go
+++ b/collector/uname_freebsd.go
@@ -49,7 +49,7 @@ func getUname() (unameOutput, error) {
 		"release":    string(uname.Release[:bytes.IndexByte(uname.Release[:], 0)]),
 		"version":    string(uname.Version[:bytes.IndexByte(uname.Version[:], 0)]),
 		"machine":    string(uname.Machine[:bytes.IndexByte(uname.Machine[:], 0)]),
-		"hostname":   hostname,
+		"nodename":   hostname,
 		"domainname": domainname,
 	}
 

--- a/collector/uname_linux.go
+++ b/collector/uname_linux.go
@@ -18,24 +18,23 @@ package collector
 import (
 	"bytes"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"golang.org/x/sys/unix"
 )
 
-func (c unameCollector) Update(ch chan<- prometheus.Metric) error {
+func getUname() (unameOutput, error) {
 	var uname unix.Utsname
 	if err := unix.Uname(&uname); err != nil {
-		return err
+		return nil, err
 	}
 
-	ch <- prometheus.MustNewConstMetric(unameDesc, prometheus.GaugeValue, 1,
-		string(uname.Sysname[:bytes.IndexByte(uname.Sysname[:], 0)]),
-		string(uname.Release[:bytes.IndexByte(uname.Release[:], 0)]),
-		string(uname.Version[:bytes.IndexByte(uname.Version[:], 0)]),
-		string(uname.Machine[:bytes.IndexByte(uname.Machine[:], 0)]),
-		string(uname.Nodename[:bytes.IndexByte(uname.Nodename[:], 0)]),
-		string(uname.Domainname[:bytes.IndexByte(uname.Domainname[:], 0)]),
-	)
-	return nil
+	output := unameOutput{
+		"sysname":    string(uname.Sysname[:bytes.IndexByte(uname.Sysname[:], 0)]),
+		"release":    string(uname.Release[:bytes.IndexByte(uname.Release[:], 0)]),
+		"version":    string(uname.Version[:bytes.IndexByte(uname.Version[:], 0)]),
+		"machine":    string(uname.Machine[:bytes.IndexByte(uname.Machine[:], 0)]),
+		"nodename":   string(uname.Nodename[:bytes.IndexByte(uname.Nodename[:], 0)]),
+		"domainname": string(uname.Domainname[:bytes.IndexByte(uname.Domainname[:], 0)]),
+	}
+
+	return output, nil
 }

--- a/collector/uname_linux.go
+++ b/collector/uname_linux.go
@@ -23,17 +23,17 @@ import (
 
 func getUname() (uname, error) {
 	var utsname unix.Utsname
-	if err := unix.Uname(&uname); err != nil {
+	if err := unix.Uname(&utsname); err != nil {
 		return uname{}, err
 	}
 
 	output := uname{
-		"sysname":    string(utsname.Sysname[:bytes.IndexByte(utsname.Sysname[:], 0)]),
-		"release":    string(utsname.Release[:bytes.IndexByte(utsname.Release[:], 0)]),
-		"version":    string(utsname.Version[:bytes.IndexByte(utsname.Version[:], 0)]),
-		"machine":    string(utsname.Machine[:bytes.IndexByte(utsname.Machine[:], 0)]),
-		"nodename":   string(utsname.Nodename[:bytes.IndexByte(utsname.Nodename[:], 0)]),
-		"domainname": string(utsname.Domainname[:bytes.IndexByte(utsname.Domainname[:], 0)]),
+		SysName:    string(utsname.Sysname[:bytes.IndexByte(utsname.Sysname[:], 0)]),
+		Release:    string(utsname.Release[:bytes.IndexByte(utsname.Release[:], 0)]),
+		Version:    string(utsname.Version[:bytes.IndexByte(utsname.Version[:], 0)]),
+		Machine:    string(utsname.Machine[:bytes.IndexByte(utsname.Machine[:], 0)]),
+		NodeName:   string(utsname.Nodename[:bytes.IndexByte(utsname.Nodename[:], 0)]),
+		DomainName: string(utsname.Domainname[:bytes.IndexByte(utsname.Domainname[:], 0)]),
 	}
 
 	return output, nil

--- a/collector/uname_linux.go
+++ b/collector/uname_linux.go
@@ -21,19 +21,19 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func getUname() (unameOutput, error) {
-	var uname unix.Utsname
+func getUname() (uname, error) {
+	var utsname unix.Utsname
 	if err := unix.Uname(&uname); err != nil {
-		return nil, err
+		return uname{}, err
 	}
 
-	output := unameOutput{
-		"sysname":    string(uname.Sysname[:bytes.IndexByte(uname.Sysname[:], 0)]),
-		"release":    string(uname.Release[:bytes.IndexByte(uname.Release[:], 0)]),
-		"version":    string(uname.Version[:bytes.IndexByte(uname.Version[:], 0)]),
-		"machine":    string(uname.Machine[:bytes.IndexByte(uname.Machine[:], 0)]),
-		"nodename":   string(uname.Nodename[:bytes.IndexByte(uname.Nodename[:], 0)]),
-		"domainname": string(uname.Domainname[:bytes.IndexByte(uname.Domainname[:], 0)]),
+	output := uname{
+		"sysname":    string(utsname.Sysname[:bytes.IndexByte(utsname.Sysname[:], 0)]),
+		"release":    string(utsname.Release[:bytes.IndexByte(utsname.Release[:], 0)]),
+		"version":    string(utsname.Version[:bytes.IndexByte(utsname.Version[:], 0)]),
+		"machine":    string(utsname.Machine[:bytes.IndexByte(utsname.Machine[:], 0)]),
+		"nodename":   string(utsname.Nodename[:bytes.IndexByte(utsname.Nodename[:], 0)]),
+		"domainname": string(utsname.Domainname[:bytes.IndexByte(utsname.Domainname[:], 0)]),
 	}
 
 	return output, nil


### PR DESCRIPTION
This PR implements the uname collector for FreeBSD.

  - Breaks out the common part into `uname.go`
  - Adds a `uname` type which is a `struct` of strings named after their `unix.Utsname` counterparts.
    - OS specific methods return the `uname` for consumption by the collector in `uname.go`
  - Leaves the Linux collector in `uname_linux.go`
  - Adds a FreeBSD collector in `uname_freebsd.go`

FreeBSD does not have a `uname.Domainname` like Linux, so we attempt to emulate it in order to enable comparing `node_uname_info` across operating systems. Perhaps a user wants to count all nodes under a specific domainname, etc.

In the event a domain name cannot be split out of the `uname.Nodename`, we set the domainname to `(none)`, which appears to be what happens on Linux when uname doesn't know the domainname for some reason.

I'm not particularly attached to this behaviour, and would be happy to drop the `domainname` label from the FreeBSD uname info if the maintainers preferred.

Tagging @SuperQ and @discordianfish as per contribution guidelines.