### PR TITLE
collector: use path/filepath for handling file paths

### DIFF
--- a/collector/bonding_linux.go
+++ b/collector/bonding_linux.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -71,21 +71,21 @@ func (c *bondingCollector) Update(ch chan<- prometheus.Metric) error {
 
 func readBondingStats(root string) (status map[string][2]int, err error) {
 	status = map[string][2]int{}
-	masters, err := ioutil.ReadFile(path.Join(root, "bonding_masters"))
+	masters, err := ioutil.ReadFile(filepath.Join(root, "bonding_masters"))
 	if err != nil {
 		return nil, err
 	}
 	for _, master := range strings.Fields(string(masters)) {
-		slaves, err := ioutil.ReadFile(path.Join(root, master, "bonding", "slaves"))
+		slaves, err := ioutil.ReadFile(filepath.Join(root, master, "bonding", "slaves"))
 		if err != nil {
 			return nil, err
 		}
 		sstat := [2]int{0, 0}
 		for _, slave := range strings.Fields(string(slaves)) {
-			state, err := ioutil.ReadFile(path.Join(root, master, fmt.Sprintf("lower_%s", slave), "operstate"))
+			state, err := ioutil.ReadFile(filepath.Join(root, master, fmt.Sprintf("lower_%s", slave), "operstate"))
 			if os.IsNotExist(err) {
 				// some older? kernels use slave_ prefix
-				state, err = ioutil.ReadFile(path.Join(root, master, fmt.Sprintf("slave_%s", slave), "operstate"))
+				state, err = ioutil.ReadFile(filepath.Join(root, master, fmt.Sprintf("slave_%s", slave), "operstate"))
 			}
 			if err != nil {
 				return nil, err

--- a/collector/edac_linux.go
+++ b/collector/edac_linux.go
@@ -17,7 +17,6 @@ package collector
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"regexp"
 
@@ -82,28 +81,28 @@ func (c *edacCollector) Update(ch chan<- prometheus.Metric) error {
 		}
 		controllerNumber := controllerMatch[1]
 
-		value, err := readUintFromFile(path.Join(controller, "ce_count"))
+		value, err := readUintFromFile(filepath.Join(controller, "ce_count"))
 		if err != nil {
 			return fmt.Errorf("couldn't get ce_count for controller %s: %s", controllerNumber, err)
 		}
 		ch <- prometheus.MustNewConstMetric(
 			c.ceCount, prometheus.CounterValue, float64(value), controllerNumber)
 
-		value, err = readUintFromFile(path.Join(controller, "ce_noinfo_count"))
+		value, err = readUintFromFile(filepath.Join(controller, "ce_noinfo_count"))
 		if err != nil {
 			return fmt.Errorf("couldn't get ce_noinfo_count for controller %s: %s", controllerNumber, err)
 		}
 		ch <- prometheus.MustNewConstMetric(
 			c.csRowCECount, prometheus.CounterValue, float64(value), controllerNumber, "unknown")
 
-		value, err = readUintFromFile(path.Join(controller, "ue_count"))
+		value, err = readUintFromFile(filepath.Join(controller, "ue_count"))
 		if err != nil {
 			return fmt.Errorf("couldn't get ue_count for controller %s: %s", controllerNumber, err)
 		}
 		ch <- prometheus.MustNewConstMetric(
 			c.ueCount, prometheus.CounterValue, float64(value), controllerNumber)
 
-		value, err = readUintFromFile(path.Join(controller, "ue_noinfo_count"))
+		value, err = readUintFromFile(filepath.Join(controller, "ue_noinfo_count"))
 		if err != nil {
 			return fmt.Errorf("couldn't get ue_noinfo_count for controller %s: %s", controllerNumber, err)
 		}
@@ -122,14 +121,14 @@ func (c *edacCollector) Update(ch chan<- prometheus.Metric) error {
 			}
 			csrowNumber := csrowMatch[1]
 
-			value, err = readUintFromFile(path.Join(csrow, "ce_count"))
+			value, err = readUintFromFile(filepath.Join(csrow, "ce_count"))
 			if err != nil {
 				return fmt.Errorf("couldn't get ce_count for controller/csrow %s/%s: %s", controllerNumber, csrowNumber, err)
 			}
 			ch <- prometheus.MustNewConstMetric(
 				c.csRowCECount, prometheus.CounterValue, float64(value), controllerNumber, csrowNumber)
 
-			value, err = readUintFromFile(path.Join(csrow, "ue_count"))
+			value, err = readUintFromFile(filepath.Join(csrow, "ue_count"))
 			if err != nil {
 				return fmt.Errorf("couldn't get ue_count for controller/csrow %s/%s: %s", controllerNumber, csrowNumber, err)
 			}

--- a/collector/hwmon_linux.go
+++ b/collector/hwmon_linux.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -138,7 +137,7 @@ func collectSensorData(dir string, data map[string]map[string]string) error {
 
 		for _, t := range hwmonSensorTypes {
 			if t == sensorType {
-				addValueFile(data, sensorType+strconv.Itoa(sensorNum), sensorProperty, path.Join(dir, file.Name()))
+				addValueFile(data, sensorType+strconv.Itoa(sensorNum), sensorProperty, filepath.Join(dir, file.Name()))
 				break
 			}
 		}
@@ -157,8 +156,8 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) er
 	if err != nil {
 		return err
 	}
-	if _, err := os.Stat(path.Join(dir, "device")); err == nil {
-		err := collectSensorData(path.Join(dir, "device"), data)
+	if _, err := os.Stat(filepath.Join(dir, "device")); err == nil {
+		err := collectSensorData(filepath.Join(dir, "device"), data)
 		if err != nil {
 			return err
 		}
@@ -353,10 +352,10 @@ func (c *hwMonCollector) hwmonName(dir string) (string, error) {
 
 	// preference 1: construct a name based on device name, always unique
 
-	devicePath, devErr := filepath.EvalSymlinks(path.Join(dir, "device"))
+	devicePath, devErr := filepath.EvalSymlinks(filepath.Join(dir, "device"))
 	if devErr == nil {
-		devPathPrefix, devName := path.Split(devicePath)
-		_, devType := path.Split(strings.TrimRight(devPathPrefix, "/"))
+		devPathPrefix, devName := filepath.Split(devicePath)
+		_, devType := filepath.Split(strings.TrimRight(devPathPrefix, "/"))
 
 		cleanDevName := cleanMetricName(devName)
 		cleanDevType := cleanMetricName(devType)
@@ -371,7 +370,7 @@ func (c *hwMonCollector) hwmonName(dir string) (string, error) {
 	}
 
 	// preference 2: is there a name file
-	sysnameRaw, nameErr := ioutil.ReadFile(path.Join(dir, "name"))
+	sysnameRaw, nameErr := ioutil.ReadFile(filepath.Join(dir, "name"))
 	if nameErr == nil && string(sysnameRaw) != "" {
 		cleanName := cleanMetricName(string(sysnameRaw))
 		if cleanName != "" {
@@ -388,7 +387,7 @@ func (c *hwMonCollector) hwmonName(dir string) (string, error) {
 	}
 
 	// take the last path element, this will be hwmonX
-	_, name := path.Split(realDir)
+	_, name := filepath.Split(realDir)
 	cleanName := cleanMetricName(name)
 	if cleanName != "" {
 		return cleanName, nil
@@ -399,7 +398,7 @@ func (c *hwMonCollector) hwmonName(dir string) (string, error) {
 // hwmonHumanReadableChipName is similar to the methods in hwmonName, but with
 // different precedences -- we can allow duplicates here.
 func (c *hwMonCollector) hwmonHumanReadableChipName(dir string) (string, error) {
-	sysnameRaw, nameErr := ioutil.ReadFile(path.Join(dir, "name"))
+	sysnameRaw, nameErr := ioutil.ReadFile(filepath.Join(dir, "name"))
 	if nameErr != nil {
 		return "", nameErr
 	}
@@ -418,7 +417,7 @@ func (c *hwMonCollector) Update(ch chan<- prometheus.Metric) error {
 	// Step 1: scan /sys/class/hwmon, resolve all symlinks and call
 	//         updatesHwmon for each folder
 
-	hwmonPathName := path.Join(sysFilePath("class"), "hwmon")
+	hwmonPathName := filepath.Join(sysFilePath("class"), "hwmon")
 
 	hwmonFiles, err := ioutil.ReadDir(hwmonPathName)
 	if err != nil {
@@ -431,7 +430,7 @@ func (c *hwMonCollector) Update(ch chan<- prometheus.Metric) error {
 	}
 
 	for _, hwDir := range hwmonFiles {
-		hwmonXPathName := path.Join(hwmonPathName, hwDir.Name())
+		hwmonXPathName := filepath.Join(hwmonPathName, hwDir.Name())
 
 		if hwDir.Mode()&os.ModeSymlink > 0 {
 			hwDir, err = os.Stat(hwmonXPathName)

--- a/collector/ksmd_linux.go
+++ b/collector/ksmd_linux.go
@@ -17,7 +17,7 @@ package collector
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -62,7 +62,7 @@ func NewKsmdCollector() (Collector, error) {
 // Update implements Collector and exposes kernel and system statistics.
 func (c *ksmdCollector) Update(ch chan<- prometheus.Metric) error {
 	for _, n := range ksmdFiles {
-		val, err := readUintFromFile(sysFilePath(path.Join("kernel/mm/ksm", n)))
+		val, err := readUintFromFile(sysFilePath(filepath.Join("kernel/mm/ksm", n)))
 		if err != nil {
 			return err
 		}

--- a/collector/meminfo_numa_linux.go
+++ b/collector/meminfo_numa_linux.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -86,7 +85,7 @@ func getMemInfoNuma() ([]meminfoMetric, error) {
 		return nil, err
 	}
 	for _, node := range nodes {
-		meminfoFile, err := os.Open(path.Join(node, "meminfo"))
+		meminfoFile, err := os.Open(filepath.Join(node, "meminfo"))
 		if err != nil {
 			return nil, err
 		}
@@ -98,7 +97,7 @@ func getMemInfoNuma() ([]meminfoMetric, error) {
 		}
 		metrics = append(metrics, numaInfo...)
 
-		numastatFile, err := os.Open(path.Join(node, "numastat"))
+		numastatFile, err := os.Open(filepath.Join(node, "numastat"))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Similar to #1228.  Update the remaining collectors to use
'path/filepath' intead of 'path' for manipulating file paths.