### PR TITLE
Fixed capitalization of linux in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ifeq ($(GOOS), linux)
 	PROMU_CONF ?= .promu.yml
 else
 	ifndef GOOS
-		ifeq ($(GOHOSTOS), Linux)
+		ifeq ($(GOHOSTOS), linux)
 			PROMU_CONF ?= .promu.yml
 		else
 			PROMU_CONF ?= .promu-cgo.yml


### PR DESCRIPTION
In #1232 the Makefile was cleaned up but it looks like the `ifeq ($(OS_detected), Linux)` wasn't correctly changed to match `linux` when using `GOHOSTOS`.

@SuperQ @pgier 