### PR TITLE
Systemd refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * The cpufreq metrics now separate the `cpufreq` and `scaling` data based on what the driver provides. #1248
 * The labels for the network_up metric have changed, see issue #1236
 * Bonding collector now uses `mii_status` instead of `operstatus` #1124
+* Several systemd metrics have been turned off by default to improve performance #1254
+  These include unit_tasks_current, unit_tasks_max, service_restart_total, and unit_start_time_seconds
 
 ### Changes
 
@@ -16,6 +18,7 @@
 * [CHANGE] Add TCPSynRetrans to netstat default filter #1143
 * [CHANGE] Add a limit to the number of in-flight requests #1166
 * [CHANGE] Add separate cpufreq and scaling metrics #1248
+* [CHANGE] Several systemd metrics have been turned off by default to improve performance #1254
 * [ENHANCEMENT] Add Infiniband counters #1120
 * [ENHANCEMENT] Move network_up labels into new metric network_info #1236
 * [FEATURE] Add a flag to disable exporter metrics #1148

--- a/collector/systemd_linux.go
+++ b/collector/systemd_linux.go
@@ -121,11 +121,17 @@ func NewSystemdCollector() (Collector, error) {
 
 func (c *systemdCollector) Update(ch chan<- prometheus.Metric) error {
 	begin := time.Now()
-	allUnits, err := c.getAllUnits()
+	conn, err := c.newDbus()
+	if err != nil {
+		return fmt.Errorf("couldn't get dbus connection: %s", err)
+	}
+	defer conn.Close()
+
+	allUnits, err := c.getAllUnits(conn)
 	if err != nil {
 		return fmt.Errorf("couldn't get units: %s", err)
 	}
-	log.Debugf("systemd gathering units took %f", time.Since(begin).Seconds())
+	log.Debugf("systemd getAllUnits took %f", time.Since(begin).Seconds())
 
 	begin = time.Now()
 	summary := summarizeUnits(allUnits)
@@ -134,44 +140,35 @@ func (c *systemdCollector) Update(ch chan<- prometheus.Metric) error {
 
 	begin = time.Now()
 	units := filterUnits(allUnits, c.unitWhitelistPattern, c.unitBlacklistPattern)
-	log.Debugf("systemd filtering units took %f", time.Since(begin).Seconds())
+	log.Debugf("systemd filterUnits took %f", time.Since(begin).Seconds())
 
 	begin = time.Now()
-	c.collectUnitStatusMetrics(ch, units)
+	c.collectUnitStatusMetrics(conn, ch, units)
 	log.Debugf("systemd collectUnitStatusMetrics took %f", time.Since(begin).Seconds())
 
 	begin = time.Now()
-	c.collectUnitStartTimeMetrics(ch, units)
+	c.collectUnitStartTimeMetrics(conn, ch, units)
 	log.Debugf("systemd collectUnitStartTimeMetrics took %f", time.Since(begin).Seconds())
 
 	begin = time.Now()
-	c.collectUnitTasksCurrentMetrics(ch, units)
-	log.Debugf("systemd collectUnitTasksCurrentMetrics took %f", time.Since(begin).Seconds())
+	c.collectUnitTasksMetrics(conn, ch, units)
+	log.Debugf("systemd collectUnitTasksMetrics took %f", time.Since(begin).Seconds())
 
 	begin = time.Now()
-	c.collectUnitTasksMaxMetrics(ch, units)
-	log.Debugf("systemd collectUnitTasksMaxMetrics took %f", time.Since(begin).Seconds())
-
-	begin = time.Now()
-	c.collectTimers(ch, units)
+	c.collectTimers(conn, ch, units)
 	log.Debugf("systemd collectTimers took %f", time.Since(begin).Seconds())
 
 	begin = time.Now()
-	c.collectSockets(ch, units)
+	c.collectSockets(conn, ch, units)
 	log.Debugf("systemd collectSockets took %f", time.Since(begin).Seconds())
 
 	begin = time.Now()
-	systemState, err := c.getSystemState()
-	if err != nil {
-		return fmt.Errorf("couldn't get system state: %s", err)
-	}
-	c.collectSystemState(ch, systemState)
+	err = c.collectSystemState(conn, ch)
 	log.Debugf("systemd collectSystemState took %f", time.Since(begin).Seconds())
-
-	return nil
+	return err
 }
 
-func (c *systemdCollector) collectUnitStatusMetrics(ch chan<- prometheus.Metric, units []unit) {
+func (c *systemdCollector) collectUnitStatusMetrics(conn *dbus.Conn, ch chan<- prometheus.Metric, units []unit) {
 	for _, unit := range units {
 		for _, stateName := range unitStatesName {
 			isActive := 0.0
@@ -182,71 +179,124 @@ func (c *systemdCollector) collectUnitStatusMetrics(ch chan<- prometheus.Metric,
 				c.unitDesc, prometheus.GaugeValue, isActive,
 				unit.Name, stateName)
 		}
-		if strings.HasSuffix(unit.Name, ".service") && unit.nRestarts != nil {
-			ch <- prometheus.MustNewConstMetric(
-				c.nRestartsDesc, prometheus.CounterValue,
-				float64(*unit.nRestarts), unit.Name)
+		if strings.HasSuffix(unit.Name, ".service") {
+			// NRestarts wasn't added until systemd 235.
+			restartsCount, err := conn.GetUnitTypeProperty(unit.Name, "Service", "NRestarts")
+			if err != nil {
+				log.Debugf("couldn't get unit '%s' NRestarts: %s", unit.Name, err)
+			} else {
+				ch <- prometheus.MustNewConstMetric(
+					c.nRestartsDesc, prometheus.CounterValue,
+					float64(restartsCount.Value.Value().(uint32)), unit.Name)
+			}
 		}
 	}
 }
 
-func (c *systemdCollector) collectSockets(ch chan<- prometheus.Metric, units []unit) {
+func (c *systemdCollector) collectSockets(conn *dbus.Conn, ch chan<- prometheus.Metric, units []unit) {
 	for _, unit := range units {
 		if !strings.HasSuffix(unit.Name, ".socket") {
 			continue
 		}
 
+		acceptedConnectionCount, err := conn.GetUnitTypeProperty(unit.Name, "Socket", "NAccepted")
+		if err != nil {
+			log.Debugf("couldn't get unit '%s' NAccepted: %s", unit.Name, err)
+			continue
+		}
 		ch <- prometheus.MustNewConstMetric(
 			c.socketAcceptedConnectionsDesc, prometheus.CounterValue,
-			float64(unit.acceptedConnections), unit.Name)
+			float64(acceptedConnectionCount.Value.Value().(uint32)), unit.Name)
+
+		currentConnectionCount, err := conn.GetUnitTypeProperty(unit.Name, "Socket", "NConnections")
+		if err != nil {
+			log.Debugf("couldn't get unit '%s' NConnections: %s", unit.Name, err)
+			continue
+		}
 		ch <- prometheus.MustNewConstMetric(
 			c.socketCurrentConnectionsDesc, prometheus.GaugeValue,
-			float64(unit.currentConnections), unit.Name)
-		if unit.refusedConnections != nil {
+			float64(currentConnectionCount.Value.Value().(uint32)), unit.Name)
+
+		// NRefused wasn't added until systemd 239.
+		refusedConnectionCount, err := conn.GetUnitTypeProperty(unit.Name, "Socket", "NRefused")
+		if err != nil {
+			log.Debugf("couldn't get unit '%s' NRefused: %s", unit.Name, err)
+		} else {
 			ch <- prometheus.MustNewConstMetric(
 				c.socketRefusedConnectionsDesc, prometheus.GaugeValue,
-				float64(*unit.refusedConnections), unit.Name)
+				float64(refusedConnectionCount.Value.Value().(uint32)), unit.Name)
 		}
 	}
 }
 
-func (c *systemdCollector) collectUnitStartTimeMetrics(ch chan<- prometheus.Metric, units []unit) {
+func (c *systemdCollector) collectUnitStartTimeMetrics(conn *dbus.Conn, ch chan<- prometheus.Metric, units []unit) {
+	var startTimeUsec uint64
+
 	for _, unit := range units {
+		if unit.ActiveState != "active" {
+			startTimeUsec = 0
+		} else {
+			timestampValue, err := conn.GetUnitProperty(unit.Name, "ActiveEnterTimestamp")
+			if err != nil {
+				log.Debugf("couldn't get unit '%s' StartTimeUsec: %s", unit.Name, err)
+				continue
+			}
+			startTimeUsec = timestampValue.Value.Value().(uint64)
+		}
+
 		ch <- prometheus.MustNewConstMetric(
 			c.unitStartTimeDesc, prometheus.GaugeValue,
-			float64(unit.startTimeUsec)/1e6, unit.Name)
+			float64(startTimeUsec)/1e6, unit.Name)
 	}
 }
 
-func (c *systemdCollector) collectUnitTasksCurrentMetrics(ch chan<- prometheus.Metric, units []unit) {
+func (c *systemdCollector) collectUnitTasksMetrics(conn *dbus.Conn, ch chan<- prometheus.Metric, units []unit) {
+	var val uint64
 	for _, unit := range units {
-		if unit.tasksCurrent != nil {
-			ch <- prometheus.MustNewConstMetric(
-				c.unitTasksCurrentDesc, prometheus.GaugeValue,
-				float64(*unit.tasksCurrent), unit.Name)
+		if strings.HasSuffix(unit.Name, ".service") {
+			tasksCurrentCount, err := conn.GetUnitTypeProperty(unit.Name, "Service", "TasksCurrent")
+			if err != nil {
+				log.Debugf("couldn't get unit '%s' TasksCurrent: %s", unit.Name, err)
+			} else {
+				val = tasksCurrentCount.Value.Value().(uint64)
+				// Don't set if tasksCurrent if dbus reports MaxUint64.
+				if val != math.MaxUint64 {
+					ch <- prometheus.MustNewConstMetric(
+						c.unitTasksCurrentDesc, prometheus.GaugeValue,
+						float64(val), unit.Name)
+				}
+			}
+			tasksMaxCount, err := conn.GetUnitTypeProperty(unit.Name, "Service", "TasksMax")
+			if err != nil {
+				log.Debugf("couldn't get unit '%s' TasksMax: %s", unit.Name, err)
+			} else {
+				val = tasksMaxCount.Value.Value().(uint64)
+				// Don't set if tasksMax if dbus reports MaxUint64.
+				if val != math.MaxUint64 {
+					ch <- prometheus.MustNewConstMetric(
+						c.unitTasksMaxDesc, prometheus.GaugeValue,
+						float64(val), unit.Name)
+				}
+			}
 		}
 	}
 }
 
-func (c *systemdCollector) collectUnitTasksMaxMetrics(ch chan<- prometheus.Metric, units []unit) {
-	for _, unit := range units {
-		if unit.tasksMax != nil {
-			ch <- prometheus.MustNewConstMetric(
-				c.unitTasksMaxDesc, prometheus.GaugeValue,
-				float64(*unit.tasksMax), unit.Name)
-		}
-	}
-}
-
-func (c *systemdCollector) collectTimers(ch chan<- prometheus.Metric, units []unit) {
+func (c *systemdCollector) collectTimers(conn *dbus.Conn, ch chan<- prometheus.Metric, units []unit) {
 	for _, unit := range units {
 		if !strings.HasSuffix(unit.Name, ".timer") {
 			continue
 		}
 
+		lastTriggerValue, err := conn.GetUnitTypeProperty(unit.Name, "Timer", "LastTriggerUSec")
+		if err != nil {
+			log.Debugf("couldn't get unit '%s' LastTriggerUSec: %s", unit.Name, err)
+			continue
+		}
+
 		ch <- prometheus.MustNewConstMetric(
 			c.timerLastTriggerDesc, prometheus.GaugeValue,
-			float64(unit.lastTriggerUsec)/1e6, unit.Name)
+			float64(lastTriggerValue.Value.Value().(uint64))/1e6, unit.Name)
 	}
 }
 
@@ -257,12 +307,17 @@ func (c *systemdCollector) collectSummaryMetrics(ch chan<- prometheus.Metric, su
 	}
 }
 
-func (c *systemdCollector) collectSystemState(ch chan<- prometheus.Metric, systemState string) {
+func (c *systemdCollector) collectSystemState(conn *dbus.Conn, ch chan<- prometheus.Metric) error {
+	systemState, err := conn.GetManagerProperty("SystemState")
+	if err != nil {
+		return fmt.Errorf("couldn't get system state: %s", err)
+	}
 	isSystemRunning := 0.0
 	if systemState == `"running"` {
 		isSystemRunning = 1.0
 	}
 	ch <- prometheus.MustNewConstMetric(c.systemRunningDesc, prometheus.GaugeValue, isSystemRunning)
+	return nil
 }
 
 func (c *systemdCollector) newDbus() (*dbus.Conn, error) {
@@ -274,26 +329,10 @@ func (c *systemdCollector) newDbus() (*dbus.Conn, error) {
 
 type unit struct {
 	dbus.UnitStatus
-	lastTriggerUsec     uint64
-	startTimeUsec       uint64
-	tasksCurrent        *uint64
-	tasksMax            *uint64
-	nRestarts           *uint32
-	acceptedConnections uint32
-	currentConnections  uint32
-	refusedConnections  *uint32
 }
 
-func (c *systemdCollector) getAllUnits() ([]unit, error) {
-	conn, err := c.newDbus()
-	if err != nil {
-		return nil, fmt.Errorf("couldn't get dbus connection: %s", err)
-	}
-	defer conn.Close()
-
-	// Filter out any units that are not installed and are pulled in only as dependencies.
+func (c *systemdCollector) getAllUnits(conn *dbus.Conn) ([]unit, error) {
 	allUnits, err := conn.ListUnits()
-
 	if err != nil {
 		return nil, err
 	}
@@ -303,88 +342,6 @@ func (c *systemdCollector) getAllUnits() ([]unit, error) {
 		unit := unit{
 			UnitStatus: status,
 		}
-
-		if strings.HasSuffix(unit.Name, ".timer") {
-			lastTriggerValue, err := conn.GetUnitTypeProperty(unit.Name, "Timer", "LastTriggerUSec")
-			if err != nil {
-				log.Debugf("couldn't get unit '%s' LastTriggerUSec: %s", unit.Name, err)
-				continue
-			}
-
-			unit.lastTriggerUsec = lastTriggerValue.Value.Value().(uint64)
-		}
-		if strings.HasSuffix(unit.Name, ".service") {
-			// NRestarts wasn't added until systemd 235.
-			restartsCount, err := conn.GetUnitTypeProperty(unit.Name, "Service", "NRestarts")
-			if err != nil {
-				log.Debugf("couldn't get unit '%s' NRestarts: %s", unit.Name, err)
-			} else {
-				nRestarts := restartsCount.Value.Value().(uint32)
-				unit.nRestarts = &nRestarts
-			}
-
-			tasksCurrentCount, err := conn.GetUnitTypeProperty(unit.Name, "Service", "TasksCurrent")
-			if err != nil {
-				log.Debugf("couldn't get unit '%s' TasksCurrent: %s", unit.Name, err)
-			} else {
-				val := tasksCurrentCount.Value.Value().(uint64)
-				// Don't set if tasksCurrent if dbus reports MaxUint64.
-				if val != math.MaxUint64 {
-					unit.tasksCurrent = &val
-				}
-			}
-
-			tasksMaxCount, err := conn.GetUnitTypeProperty(unit.Name, "Service", "TasksMax")
-			if err != nil {
-				log.Debugf("couldn't get unit '%s' TasksMax: %s", unit.Name, err)
-			} else {
-				val := tasksMaxCount.Value.Value().(uint64)
-				// Don't set if tasksMax if dbus reports MaxUint64.
-				if val != math.MaxUint64 {
-					unit.tasksMax = &val
-				}
-			}
-
-		}
-
-		if strings.HasSuffix(unit.Name, ".socket") {
-			acceptedConnectionCount, err := conn.GetUnitTypeProperty(unit.Name, "Socket", "NAccepted")
-			if err != nil {
-				log.Debugf("couldn't get unit '%s' NAccepted: %s", unit.Name, err)
-				continue
-			}
-
-			unit.acceptedConnections = acceptedConnectionCount.Value.Value().(uint32)
-
-			currentConnectionCount, err := conn.GetUnitTypeProperty(unit.Name, "Socket", "NConnections")
-			if err != nil {
-				log.Debugf("couldn't get unit '%s' NConnections: %s", unit.Name, err)
-				continue
-			}
-			unit.currentConnections = currentConnectionCount.Value.Value().(uint32)
-
-			// NRefused wasn't added until systemd 239.
-			refusedConnectionCount, err := conn.GetUnitTypeProperty(unit.Name, "Socket", "NRefused")
-			if err != nil {
-				log.Debugf("couldn't get unit '%s' NRefused: %s", unit.Name, err)
-			} else {
-				nRefused := refusedConnectionCount.Value.Value().(uint32)
-				unit.refusedConnections = &nRefused
-			}
-		}
-
-		if unit.ActiveState != "active" {
-			unit.startTimeUsec = 0
-		} else {
-			timestampValue, err := conn.GetUnitProperty(unit.Name, "ActiveEnterTimestamp")
-			if err != nil {
-				log.Debugf("couldn't get unit '%s' StartTimeUsec: %s", unit.Name, err)
-				continue
-			}
-
-			unit.startTimeUsec = timestampValue.Value.Value().(uint64)
-		}
-
 		result = append(result, unit)
 	}
 
@@ -417,14 +374,4 @@ func filterUnits(units []unit, whitelistPattern, blacklistPattern *regexp.Regexp
 	}
 
 	return filtered
-}
-
-func (c *systemdCollector) getSystemState() (state string, err error) {
-	conn, err := c.newDbus()
-	if err != nil {
-		return "", fmt.Errorf("couldn't get dbus connection: %s", err)
-	}
-	state, err = conn.GetManagerProperty("SystemState")
-	conn.Close()
-	return state, err
 }

--- a/collector/systemd_linux_test.go
+++ b/collector/systemd_linux_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/coreos/go-systemd/dbus"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Creates mock UnitLists
@@ -85,26 +84,6 @@ func getUnitListFixtures() [][]unit {
 	fixture2 := []unit{}
 
 	return [][]unit{fixture1, fixture2}
-}
-
-func TestSystemdCollectorDoesntCrash(t *testing.T) {
-	c, err := NewSystemdCollector()
-	if err != nil {
-		t.Fatal(err)
-	}
-	sink := make(chan prometheus.Metric)
-	go func() {
-		for {
-			<-sink
-		}
-	}()
-
-	fixtures := getUnitListFixtures()
-	collector := (c).(*systemdCollector)
-	for _, units := range fixtures {
-		collector.collectUnitStatusMetrics(sink, units)
-		collector.collectSockets(sink, units)
-	}
 }
 
 func TestSystemdIgnoreFilter(t *testing.T) {


### PR DESCRIPTION
The purpose of this change is primarily to address issue #1201.  The
addition of several new systemd metrics in v0.17.0
(pr #1098, #968, #992, #952) caused the overall collection time
to increase by about a factor of 10.  The increase is not due
to any particular change, just a consequence of making a lot
more calls over dbus.

The two main design changes here are (1) turn off many of the dbus
metrics by default and (2) execute dbus calls in parallel to speed up
collection.  This also organizes metric collection closer to how the
data is organized in systemd.  And it gathers metrics which are specific
to "service" unit types in bulk instead of making three separate calls
for TasksMax, TasksCurrent, and NRestarts.  This bulk request also allows
for enabling more service unit data in the future without extra dbus calls,
for example memory usage information (#1036).

The parallelization seems to reduce the original collection time to about
50-60% (with all metrics enabled), and the default behaviour with the
additional metrics disabled brings collection time back in line with
v0.16.0.

Closes: https://github.com/prometheus/node_exporter/issues/1201