### PR TITLE
Update systemd blacklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Bonding collector now uses `mii_status` instead of `operstatus` #1124
 * Several systemd metrics have been turned off by default to improve performance #1254
   These include unit_tasks_current, unit_tasks_max, service_restart_total, and unit_start_time_seconds
+* The systemd collector blacklist now includes automount, device, mount, and slice units by default. #1255
 
 ### Changes
 
@@ -19,6 +20,7 @@
 * [CHANGE] Add a limit to the number of in-flight requests #1166
 * [CHANGE] Add separate cpufreq and scaling metrics #1248
 * [CHANGE] Several systemd metrics have been turned off by default to improve performance #1254
+* [CHANGE] Expand systemd collector blacklist #1255
 * [ENHANCEMENT] Add Infiniband counters #1120
 * [ENHANCEMENT] Move network_up labels into new metric network_info #1236
 * [FEATURE] Add a flag to disable exporter metrics #1148

--- a/collector/systemd_linux.go
+++ b/collector/systemd_linux.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	unitWhitelist          = kingpin.Flag("collector.systemd.unit-whitelist", "Regexp of systemd units to whitelist. Units must both match whitelist and not match blacklist to be included.").Default(".+").String()
-	unitBlacklist          = kingpin.Flag("collector.systemd.unit-blacklist", "Regexp of systemd units to blacklist. Units must both match whitelist and not match blacklist to be included.").Default(".+\\.scope").String()
+	unitBlacklist          = kingpin.Flag("collector.systemd.unit-blacklist", "Regexp of systemd units to blacklist. Units must both match whitelist and not match blacklist to be included.").Default(".+\\.(automount|device|mount|scope|slice)").String()
 	systemdPrivate         = kingpin.Flag("collector.systemd.private", "Establish a private, direct connection to systemd without dbus.").Bool()
 	enableTaskMetrics      = kingpin.Flag("collector.systemd.enable-task-metrics", "Enables service unit tasks metrics unit_tasks_current and unit_tasks_max").Bool()
 	enableRestartsMetrics  = kingpin.Flag("collector.systemd.enable-restarts-metrics", "Enables service unit metric service_restart_total").Bool()


### PR DESCRIPTION
Include additional unit types in the default systemd collector
blacklist.

Closes: https://github.com/prometheus/node_exporter/issues/1251

Signed-off-by: Ben Kochie <superq@gmail.com>