### PR TITLE
remove "-n" flag from /usr/bin/awk in ipmitool text collector example

### DIFF
--- a/text_collector_examples/ipmitool
+++ b/text_collector_examples/ipmitool
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -nf
+#!/usr/bin/awk -f
 
 #
 # Converts output of `ipmitool sensor` to prometheus format.


### PR DESCRIPTION
This flag causes no ipmi data to be emitted and an error log is generated on each invocation: "awk: not an option: -nf".

I was unable to locate a "-n" flag in the mawk or gawk man pages, so I tested it by manually changing the script on a running Debian buster system.  The issue was resolved and metrics were emitted.

@SuperQ @discordianfish 