### PR TITLE
yum.sh: yum update monitor

### DIFF
--- a/text_collector_examples/yum.sh
+++ b/text_collector_examples/yum.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Description: Expose metrics from yum updates.
+#
+# Author: Slawomir Gonet <slawek@otwiera.cz>
+# 
+# Based on apt.sh by Ben Kochie <superq@gmail.com>
+
+upgrades=$(/usr/bin/yum -q check-updates | awk 'BEGIN { mute=1 } /Obsoleting Packages/ { mute=0 } mute { print }' | egrep '^\w+\.\w+' | awk '{print $3}' | sort | uniq -c | awk '{print "yum_upgrades_pending{origin=\""$2"\"} "$1}')
+
+echo '# HELP yum_upgrades_pending Yum package pending updates by origin.'
+echo '# TYPE yum_upgrades_pending gauge'
+if [[ -n "${upgrades}" ]] ; then
+  echo "${upgrades}"
+else
+  echo 'yum_upgrades_pending{origin=""} 0'
+fi
+


### PR DESCRIPTION
Added example of simple yum update monitor for CentOS. Based on `apt.sh`.

```
[root ~]# cat /etc/redhat-release 
CentOS Linux release 7.2.1511 (Core)
[root ~]# ./yum.sh
# HELP yum_upgrades_pending Yum package pending updates by origin.
# TYPE yum_upgrades_pending gauge
yum_updates_pending{origin="base"} 128
yum_updates_pending{origin="updates"} 14
```