### PR TITLE
Add --collector.netdev.device-whitelist flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ### **Breaking changes**
 
+* The netdev collector CLI argument `--collector.netdev.ignored-devices` was renamed to `--collector.netdev.device-blacklist` in order to conform with the systemd collector. #1279
+
+
 ### Changes
 
-* [CHANGE]
+* [CHANGE] Add `--collector.netdev.device-whitelist`. #1279
 * [FEATURE]
 * [ENHANCEMENT]
 * [BUGFIX] Fix incorrect sysctl call in BSD meminfo collector, resulting in broken swap metrics on FreeBSD #1345

--- a/collector/netdev_bsd.go
+++ b/collector/netdev_bsd.go
@@ -34,7 +34,7 @@ import (
 */
 import "C"
 
-func getNetDevStats(ignore *regexp.Regexp) (map[string]map[string]string, error) {
+func getNetDevStats(ignore *regexp.Regexp, accept *regexp.Regexp) (map[string]map[string]string, error) {
 	netDev := map[string]map[string]string{}
 
 	var ifap, ifa *C.struct_ifaddrs
@@ -46,7 +46,11 @@ func getNetDevStats(ignore *regexp.Regexp) (map[string]map[string]string, error)
 	for ifa = ifap; ifa != nil; ifa = ifa.ifa_next {
 		if ifa.ifa_addr.sa_family == C.AF_LINK {
 			dev := C.GoString(ifa.ifa_name)
-			if ignore.MatchString(dev) {
+			if ignore != nil && ignore.MatchString(dev) {
+				log.Debugf("Ignoring device: %s", dev)
+				continue
+			}
+			if accept != nil && !accept.MatchString(dev) {
 				log.Debugf("Ignoring device: %s", dev)
 				continue
 			}

--- a/collector/netdev_common.go
+++ b/collector/netdev_common.go
@@ -27,8 +27,8 @@ import (
 )
 
 var (
-	netdevIgnoredDevices = kingpin.Flag("collector.netdev.ignored-devices", "Regexp of net devices to ignore for netdev collector (mutually exclusive to accept-devices).").String()
-	netdevAcceptDevices  = kingpin.Flag("collector.netdev.accept-devices", "Regexp of net devices to accept for netdev colletor (mutually exclusive to ignored-devices).").String()
+	netdevIgnoredDevices = kingpin.Flag("collector.netdev.device-blacklist", "Regexp of net devices to blacklist (mutually exclusive to device-whitelist).").String()
+	netdevAcceptDevices  = kingpin.Flag("collector.netdev.device-whitelist", "Regexp of net devices to whitelist (mutually exclusive to device-blacklist).").String()
 )
 
 type netDevCollector struct {
@@ -45,7 +45,7 @@ func init() {
 // NewNetDevCollector returns a new Collector exposing network device stats.
 func NewNetDevCollector() (Collector, error) {
 	if *netdevIgnoredDevices != "" && *netdevAcceptDevices != "" {
-		return nil, errors.New("ignored-devices & accept-devices are mutually exclusive")
+		return nil, errors.New("device-blacklist & accept-devices are mutually exclusive")
 	}
 
 	var ignorePattern *regexp.Regexp = nil

--- a/collector/netdev_common.go
+++ b/collector/netdev_common.go
@@ -17,6 +17,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -26,12 +27,14 @@ import (
 )
 
 var (
-	netdevIgnoredDevices = kingpin.Flag("collector.netdev.ignored-devices", "Regexp of net devices to ignore for netdev collector.").Default("^$").String()
+	netdevIgnoredDevices = kingpin.Flag("collector.netdev.ignored-devices", "Regexp of net devices to ignore for netdev collector (mutually exclusive to accept-devices).").String()
+	netdevAcceptDevices  = kingpin.Flag("collector.netdev.accept-devices", "Regexp of net devices to accept for netdev colletor (mutually exclusive to ignored-devices).").String()
 )
 
 type netDevCollector struct {
 	subsystem             string
 	ignoredDevicesPattern *regexp.Regexp
+	acceptDevicesPattern  *regexp.Regexp
 	metricDescs           map[string]*prometheus.Desc
 }
 
@@ -41,16 +44,30 @@ func init() {
 
 // NewNetDevCollector returns a new Collector exposing network device stats.
 func NewNetDevCollector() (Collector, error) {
-	pattern := regexp.MustCompile(*netdevIgnoredDevices)
+	if *netdevIgnoredDevices != "" && *netdevAcceptDevices != "" {
+		return nil, errors.New("ignored-devices & accept-devices are mutually exclusive")
+	}
+
+	var ignorePattern *regexp.Regexp = nil
+	if *netdevIgnoredDevices != "" {
+		ignorePattern = regexp.MustCompile(*netdevIgnoredDevices)
+	}
+
+	var acceptPattern *regexp.Regexp = nil
+	if *netdevAcceptDevices != "" {
+		acceptPattern = regexp.MustCompile(*netdevAcceptDevices)
+	}
+
 	return &netDevCollector{
 		subsystem:             "network",
-		ignoredDevicesPattern: pattern,
+		ignoredDevicesPattern: ignorePattern,
+		acceptDevicesPattern:  acceptPattern,
 		metricDescs:           map[string]*prometheus.Desc{},
 	}, nil
 }
 
 func (c *netDevCollector) Update(ch chan<- prometheus.Metric) error {
-	netDev, err := getNetDevStats(c.ignoredDevicesPattern)
+	netDev, err := getNetDevStats(c.ignoredDevicesPattern, c.acceptDevicesPattern)
 	if err != nil {
 		return fmt.Errorf("couldn't get netstats: %s", err)
 	}

--- a/collector/netdev_darwin.go
+++ b/collector/netdev_darwin.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func getNetDevStats(ignore *regexp.Regexp) (map[string]map[string]string, error) {
+func getNetDevStats(ignore *regexp.Regexp, accept *regexp.Regexp) (map[string]map[string]string, error) {
 	netDev := map[string]map[string]string{}
 
 	ifs, err := net.Interfaces()
@@ -43,6 +43,10 @@ func getNetDevStats(ignore *regexp.Regexp) (map[string]map[string]string, error)
 		}
 
 		if ignore.MatchString(iface.Name) {
+			log.Debugf("Ignoring device: %s", iface.Name)
+			continue
+		}
+		if accept != nil && !accept.MatchString(iface.Name) {
 			log.Debugf("Ignoring device: %s", iface.Name)
 			continue
 		}

--- a/collector/netdev_linux_test.go
+++ b/collector/netdev_linux_test.go
@@ -19,14 +19,14 @@ import (
 	"testing"
 )
 
-func TestNetDevStats(t *testing.T) {
+func TestNetDevStatsIgnore(t *testing.T) {
 	file, err := os.Open("fixtures/proc/net/dev")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer file.Close()
 
-	netStats, err := parseNetDevStats(file, regexp.MustCompile("^veth"))
+	netStats, err := parseNetDevStats(file, regexp.MustCompile("^veth"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,6 +55,26 @@ func TestNetDevStats(t *testing.T) {
 		t.Error("want fixture interface ibr10:30 to exist, but it does not")
 	}
 
+	if want, got := "72", netStats["💩0"]["receive_multicast"]; want != got {
+		t.Error("want fixture interface 💩0 to exist, but it does not")
+	}
+}
+
+func TestNetDevStatsAccept(t *testing.T) {
+	file, err := os.Open("fixtures/proc/net/dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	netStats, err := parseNetDevStats(file, nil, regexp.MustCompile("^💩0$"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want, got := 1, len(netStats); want != got {
+		t.Errorf("want count of devices to be %d, got %d", want, got)
+	}
 	if want, got := "72", netStats["💩0"]["receive_multicast"]; want != got {
 		t.Error("want fixture interface 💩0 to exist, but it does not")
 	}

--- a/collector/netdev_openbsd.go
+++ b/collector/netdev_openbsd.go
@@ -31,7 +31,7 @@ import (
 */
 import "C"
 
-func getNetDevStats(ignore *regexp.Regexp) (map[string]map[string]string, error) {
+func getNetDevStats(ignore *regexp.Regexp, accept *regexp.Regexp) (map[string]map[string]string, error) {
 	netDev := map[string]map[string]string{}
 
 	var ifap, ifa *C.struct_ifaddrs
@@ -43,7 +43,11 @@ func getNetDevStats(ignore *regexp.Regexp) (map[string]map[string]string, error)
 	for ifa = ifap; ifa != nil; ifa = ifa.ifa_next {
 		if ifa.ifa_addr.sa_family == C.AF_LINK {
 			dev := C.GoString(ifa.ifa_name)
-			if ignore.MatchString(dev) {
+			if ignore != nil && ignore.MatchString(dev) {
+				log.Debugf("Ignoring device: %s", dev)
+				continue
+			}
+			if accept != nil && !accept.MatchString(dev) {
 				log.Debugf("Ignoring device: %s", dev)
 				continue
 			}


### PR DESCRIPTION
Sometimes it is desired to monitor only one netdev. The golang regexp
does not support a negated regex, so the ignored-devices flag is too
cumbersome for this task.
This change introduces a new flag: accept-devices, which is mutually
exclusive to ignored-devices. This flag allows specifying ONLY the
netdev you'd like.

Signed-off-by: Noam Meltzer <noam@cynerio.co>