### PR TITLE
Introduce Collector for Power Supply Class

### DIFF
--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -2393,6 +2393,40 @@ node_nfsd_server_rpcs_total 18628
 # HELP node_nfsd_server_threads Total number of NFSd kernel threads that are running.
 # TYPE node_nfsd_server_threads gauge
 node_nfsd_server_threads 8
+# HELP node_power_supply_capacity capacity value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_capacity gauge
+node_power_supply_capacity{power_supply="BAT0"} 81
+# HELP node_power_supply_cyclecount cyclecount value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_cyclecount gauge
+node_power_supply_cyclecount{power_supply="BAT0"} 0
+# HELP node_power_supply_energy_full energy_full value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_energy_full gauge
+node_power_supply_energy_full{power_supply="BAT0"} 4.507e+07
+# HELP node_power_supply_energy_full_design energy_full_design value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_energy_full_design gauge
+node_power_supply_energy_full_design{power_supply="BAT0"} 4.752e+07
+# HELP node_power_supply_energy_now energy_now value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_energy_now gauge
+node_power_supply_energy_now{power_supply="BAT0"} 3.658e+07
+# HELP node_power_supply_info info of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_info gauge
+node_power_supply_info{power_supply="AC",type="Mains"} 1
+node_power_supply_info{capacity_level="Normal",manufacturer="LGC",model_name="LNV-45N1",power_supply="BAT0",serial_number="38109",status="Discharging",technology="Li-ion",type="Battery"} 1
+# HELP node_power_supply_online online value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_online gauge
+node_power_supply_online{power_supply="AC"} 0
+# HELP node_power_supply_power_now power_now value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_power_now gauge
+node_power_supply_power_now{power_supply="BAT0"} 5.002e+06
+# HELP node_power_supply_present present value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_present gauge
+node_power_supply_present{power_supply="BAT0"} 1
+# HELP node_power_supply_voltage_min_design voltage_min_design value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_voltage_min_design gauge
+node_power_supply_voltage_min_design{power_supply="BAT0"} 1.08e+07
+# HELP node_power_supply_voltage_now voltage_now value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_voltage_now gauge
+node_power_supply_voltage_now{power_supply="BAT0"} 1.166e+07
 # HELP node_pressure_cpu_waiting_seconds_total Total time in seconds that processes have waited for CPU time
 # TYPE node_pressure_cpu_waiting_seconds_total counter
 node_pressure_cpu_waiting_seconds_total 14.036781000000001
@@ -2492,6 +2526,7 @@ node_scrape_collector_success{collector="netdev"} 1
 node_scrape_collector_success{collector="netstat"} 1
 node_scrape_collector_success{collector="nfs"} 1
 node_scrape_collector_success{collector="nfsd"} 1
+node_scrape_collector_success{collector="powersupplyclass"} 1
 node_scrape_collector_success{collector="pressure"} 1
 node_scrape_collector_success{collector="processes"} 1
 node_scrape_collector_success{collector="qdisc"} 1

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2393,6 +2393,40 @@ node_nfsd_server_rpcs_total 18628
 # HELP node_nfsd_server_threads Total number of NFSd kernel threads that are running.
 # TYPE node_nfsd_server_threads gauge
 node_nfsd_server_threads 8
+# HELP node_power_supply_capacity capacity value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_capacity gauge
+node_power_supply_capacity{power_supply="BAT0"} 81
+# HELP node_power_supply_cyclecount cyclecount value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_cyclecount gauge
+node_power_supply_cyclecount{power_supply="BAT0"} 0
+# HELP node_power_supply_energy_full energy_full value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_energy_full gauge
+node_power_supply_energy_full{power_supply="BAT0"} 45.07
+# HELP node_power_supply_energy_full_design energy_full_design value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_energy_full_design gauge
+node_power_supply_energy_full_design{power_supply="BAT0"} 47.52
+# HELP node_power_supply_energy_watthour energy_watthour value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_energy_watthour gauge
+node_power_supply_energy_watthour{power_supply="BAT0"} 36.58
+# HELP node_power_supply_info info of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_info gauge
+node_power_supply_info{power_supply="AC",type="Mains"} 1
+node_power_supply_info{capacity_level="Normal",manufacturer="LGC",model_name="LNV-45N1",power_supply="BAT0",serial_number="38109",status="Discharging",technology="Li-ion",type="Battery"} 1
+# HELP node_power_supply_online online value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_online gauge
+node_power_supply_online{power_supply="AC"} 0
+# HELP node_power_supply_power_watt power_watt value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_power_watt gauge
+node_power_supply_power_watt{power_supply="BAT0"} 5.002
+# HELP node_power_supply_present present value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_present gauge
+node_power_supply_present{power_supply="BAT0"} 1
+# HELP node_power_supply_voltage_min_design voltage_min_design value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_voltage_min_design gauge
+node_power_supply_voltage_min_design{power_supply="BAT0"} 10.8
+# HELP node_power_supply_voltage_volt voltage_volt value of /sys/class/power_supply/<power_supply>.
+# TYPE node_power_supply_voltage_volt gauge
+node_power_supply_voltage_volt{power_supply="BAT0"} 11.66
 # HELP node_pressure_cpu_waiting_seconds_total Total time in seconds that processes have waited for CPU time
 # TYPE node_pressure_cpu_waiting_seconds_total counter
 node_pressure_cpu_waiting_seconds_total 14.036781000000001
@@ -2492,6 +2526,7 @@ node_scrape_collector_success{collector="netdev"} 1
 node_scrape_collector_success{collector="netstat"} 1
 node_scrape_collector_success{collector="nfs"} 1
 node_scrape_collector_success{collector="nfsd"} 1
+node_scrape_collector_success{collector="powersupplyclass"} 1
 node_scrape_collector_success{collector="pressure"} 1
 node_scrape_collector_success{collector="processes"} 1
 node_scrape_collector_success{collector="qdisc"} 1

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -995,6 +995,289 @@ Lines: 1
 1
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/class/power_supply
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/class/power_supply/AC
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/online
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/class/power_supply/AC/power
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/async
+Lines: 1
+disabled
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/autosuspend_delay_ms
+Lines: 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/control
+Lines: 1
+auto
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/runtime_active_kids
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/runtime_active_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/runtime_enabled
+Lines: 1
+disabled
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/runtime_status
+Lines: 1
+unsupported
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/runtime_suspended_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/runtime_usage
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/wakeup
+Lines: 1
+enabled
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/wakeup_abort_count
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/wakeup_active
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/wakeup_active_count
+Lines: 1
+1
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/wakeup_count
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/wakeup_expire_count
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/wakeup_last_time_ms
+Lines: 1
+7888
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/wakeup_max_time_ms
+Lines: 1
+2
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/wakeup_prevent_sleep_time_ms
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/power/wakeup_total_time_ms
+Lines: 1
+2
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/type
+Lines: 1
+Mains
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/AC/uevent
+Lines: 2
+POWER_SUPPLY_NAME=AC
+POWER_SUPPLY_ONLINE=0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/class/power_supply/BAT0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/alarm
+Lines: 1
+2253000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/capacity
+Lines: 1
+81
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/capacity_level
+Lines: 1
+Normal
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/charge_start_threshold
+Lines: 1
+95
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/charge_stop_threshold
+Lines: 1
+100
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/cycle_count
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/energy_full
+Lines: 1
+45070000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/energy_full_design
+Lines: 1
+47520000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/energy_now
+Lines: 1
+36580000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/manufacturer
+Lines: 1
+LGC
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/model_name
+Lines: 1
+LNV-45N1
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/class/power_supply/BAT0/power
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/power/async
+Lines: 1
+disabled
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/power/autosuspend_delay_ms
+Lines: 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/power/control
+Lines: 1
+auto
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/power/runtime_active_kids
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/power/runtime_active_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/power/runtime_enabled
+Lines: 1
+disabled
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/power/runtime_status
+Lines: 1
+unsupported
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/power/runtime_suspended_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/power/runtime_usage
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/power_now
+Lines: 1
+5002000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/present
+Lines: 1
+1
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/serial_number
+Lines: 1
+38109
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/status
+Lines: 1
+Discharging
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/technology
+Lines: 1
+Li-ion
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/type
+Lines: 1
+Battery
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/uevent
+Lines: 16
+POWER_SUPPLY_NAME=BAT0
+POWER_SUPPLY_STATUS=Discharging
+POWER_SUPPLY_PRESENT=1
+POWER_SUPPLY_TECHNOLOGY=Li-ion
+POWER_SUPPLY_CYCLE_COUNT=0
+POWER_SUPPLY_VOLTAGE_MIN_DESIGN=10800000
+POWER_SUPPLY_VOLTAGE_NOW=11660000
+POWER_SUPPLY_POWER_NOW=5002000
+POWER_SUPPLY_ENERGY_FULL_DESIGN=47520000
+POWER_SUPPLY_ENERGY_FULL=45070000
+POWER_SUPPLY_ENERGY_NOW=36580000
+POWER_SUPPLY_CAPACITY=81
+POWER_SUPPLY_CAPACITY_LEVEL=Normal
+POWER_SUPPLY_MODEL_NAME=LNV-45N1
+POWER_SUPPLY_MANUFACTURER=LGC
+POWER_SUPPLY_SERIAL_NUMBER=38109
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/voltage_min_design
+Lines: 1
+10800000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/power_supply/BAT0/voltage_now
+Lines: 1
+11660000
+Mode: 444
 Directory: sys/class/thermal
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/collector/powersupplyclass.go
+++ b/collector/powersupplyclass.go
@@ -1,0 +1,194 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !nopowersupplyclass
+// +build linux
+
+package collector
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/procfs/sysfs"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	powerSupplyClassIgnoredPowerSupplies = kingpin.Flag("collector.powersupply.ignored-supplies", "Regexp of power supplies to ignore for powersupplyclass collector.").Default("^$").String()
+)
+
+type powerSupplyClassCollector struct {
+	subsystem      string
+	ignoredPattern *regexp.Regexp
+	metricDescs    map[string]*prometheus.Desc
+}
+
+func init() {
+	registerCollector("powersupplyclass", defaultEnabled, NewPowerSupplyClassCollector)
+}
+
+func NewPowerSupplyClassCollector() (Collector, error) {
+	pattern := regexp.MustCompile(*powerSupplyClassIgnoredPowerSupplies)
+	return &powerSupplyClassCollector{
+		subsystem:      "power_supply",
+		ignoredPattern: pattern,
+		metricDescs:    map[string]*prometheus.Desc{},
+	}, nil
+}
+
+func (c *powerSupplyClassCollector) Update(ch chan<- prometheus.Metric) error {
+	powerSupplyClass, err := getPowerSupplyClassInfo(c.ignoredPattern)
+	if err != nil {
+		return fmt.Errorf("could not get power_supply class info: %s", err)
+	}
+	for _, powerSupply := range powerSupplyClass {
+
+		for name, value := range map[string]*int64{
+			"authentic":             powerSupply.Authentic,
+			"calibrate":             powerSupply.Calibrate,
+			"capacity":              powerSupply.Capacity,
+			"capacity_alert_max":    powerSupply.CapacityAlertMax,
+			"capacity_alert_min":    powerSupply.CapacityAlertMin,
+			"cyclecount":            powerSupply.CycleCount,
+			"online":                powerSupply.Online,
+			"present":               powerSupply.Present,
+			"time_to_empty_seconds": powerSupply.TimeToEmptyNow,
+			"time_to_full_seconds":  powerSupply.TimeToFullNow,
+		} {
+			if value != nil {
+				pushPowerSupplyMetric(ch, c.subsystem, name, float64(*value), powerSupply.Name, prometheus.GaugeValue)
+			}
+		}
+
+		for name, value := range map[string]*int64{
+			"current_boot":                powerSupply.CurrentBoot,
+			"current_max":                 powerSupply.CurrentMax,
+			"current_ampere":              powerSupply.CurrentNow,
+			"energy_empty":                powerSupply.EnergyEmpty,
+			"energy_empty_design":         powerSupply.EnergyEmptyDesign,
+			"energy_full":                 powerSupply.EnergyFull,
+			"energy_full_design":          powerSupply.EnergyFullDesign,
+			"energy_watthour":             powerSupply.EnergyNow,
+			"voltage_boot":                powerSupply.VoltageBoot,
+			"voltage_max":                 powerSupply.VoltageMax,
+			"voltage_max_design":          powerSupply.VoltageMaxDesign,
+			"voltage_min":                 powerSupply.VoltageMin,
+			"voltage_min_design":          powerSupply.VoltageMinDesign,
+			"voltage_volt":                powerSupply.VoltageNow,
+			"voltage_ocv":                 powerSupply.VoltageOCV,
+			"charge_control_limit":        powerSupply.ChargeControlLimit,
+			"charge_control_limit_max":    powerSupply.ChargeControlLimitMax,
+			"charge_counter":              powerSupply.ChargeCounter,
+			"charge_empty":                powerSupply.ChargeEmpty,
+			"charge_empty_design":         powerSupply.ChargeEmptyDesign,
+			"charge_full":                 powerSupply.ChargeFull,
+			"charge_full_design":          powerSupply.ChargeFullDesign,
+			"charge_ampere":               powerSupply.ChargeNow,
+			"charge_term_current":         powerSupply.ChargeTermCurrent,
+			"constant_charge_current":     powerSupply.ConstantChargeCurrent,
+			"constant_charge_current_max": powerSupply.ConstantChargeCurrentMax,
+			"constant_charge_voltage":     powerSupply.ConstantChargeVoltage,
+			"constant_charge_voltage_max": powerSupply.ConstantChargeVoltageMax,
+			"precharge_current":           powerSupply.PrechargeCurrent,
+			"input_current_limit":         powerSupply.InputCurrentLimit,
+			"power_watt":                  powerSupply.PowerNow,
+		} {
+			if value != nil {
+				pushPowerSupplyMetric(ch, c.subsystem, name, float64(*value)/1e6, powerSupply.Name, prometheus.GaugeValue)
+			}
+		}
+
+		for name, value := range map[string]*int64{
+			"temp_celsius":             powerSupply.Temp,
+			"temp_alert_max_celsius":   powerSupply.TempAlertMax,
+			"temp_alert_min_celsius":   powerSupply.TempAlertMin,
+			"temp_ambient_celsius":     powerSupply.TempAmbient,
+			"temp_ambient_max_celsius": powerSupply.TempAmbientMax,
+			"temp_ambient_min_celsius": powerSupply.TempAmbientMin,
+			"temp_max_celsius":         powerSupply.TempMax,
+			"temp_min_celsius":         powerSupply.TempMin,
+		} {
+			if value != nil {
+				pushPowerSupplyMetric(ch, c.subsystem, name, float64(*value)/10.0, powerSupply.Name, prometheus.GaugeValue)
+			}
+		}
+
+		var (
+			keys   []string
+			values []string
+		)
+		for name, value := range map[string]string{
+			"power_supply":   powerSupply.Name,
+			"capacity_level": powerSupply.CapacityLevel,
+			"charge_type":    powerSupply.ChargeType,
+			"health":         powerSupply.Health,
+			"manufacturer":   powerSupply.Manufacturer,
+			"model_name":     powerSupply.ModelName,
+			"serial_number":  powerSupply.SerialNumber,
+			"status":         powerSupply.Status,
+			"technology":     powerSupply.Technology,
+			"type":           powerSupply.Type,
+			"usb_type":       powerSupply.UsbType,
+			"scope":          powerSupply.Scope,
+		} {
+			if value != "" {
+				keys = append(keys, name)
+				values = append(values, value)
+			}
+		}
+
+		fieldDesc := prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, c.subsystem, "info"),
+			"info of /sys/class/power_supply/<power_supply>.",
+			keys,
+			nil,
+		)
+		ch <- prometheus.MustNewConstMetric(fieldDesc, prometheus.GaugeValue, 1.0, values...)
+
+	}
+
+	return nil
+}
+
+func pushPowerSupplyMetric(ch chan<- prometheus.Metric, subsystem string, name string, value float64, powerSupplyName string, valueType prometheus.ValueType) {
+	fieldDesc := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystem, name),
+		fmt.Sprintf("%s value of /sys/class/power_supply/<power_supply>.", name),
+		[]string{"power_supply"},
+		nil,
+	)
+
+	ch <- prometheus.MustNewConstMetric(fieldDesc, valueType, value, powerSupplyName)
+}
+
+func getPowerSupplyClassInfo(ignore *regexp.Regexp) (sysfs.PowerSupplyClass, error) {
+	fs, err := sysfs.NewFS(*sysPath)
+	if err != nil {
+		return nil, err
+	}
+	powerSupplyClass, err := fs.PowerSupplyClass()
+
+	if err != nil {
+		return powerSupplyClass, fmt.Errorf("error obtaining power_supply class info: %s", err)
+	}
+
+	for device := range powerSupplyClass {
+		if ignore.MatchString(device) {
+			delete(powerSupplyClass, device)
+		}
+	}
+
+	return powerSupplyClass, nil
+}


### PR DESCRIPTION
Use the powerSupplyClass from `procfs` and show metrics about the power supplies from `/sys/class/power_supply` as wished in issue #676.

These changes are based in the commit 6ed1f7e1041181781dd2826d3001075d011a80cc in `procfs` and therefore the depedency is updated.