### PR TITLE
Add process metrics for systemd services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [FEATURE] Add uname collector for FreeBSD #1239
 * [FEATURE] Add diskstats collector for OpenBSD #1250
 * [CHANGE] Bonding state uses mii_status #1124
+* [FEATURE] Add a flag to enable process metrics for systemd services #1289
 
 ## 0.17.0 / 2018-11-30
 


### PR DESCRIPTION
Adding process metrics for systemd services.

New flag is introduced, which is disabled by default:

```
      --collector.systemd.enable-process-metrics
                                Enables service unit process metrics
```

I don't think it should affect performance too much, as it just reads procfs.

I ran it on my machine, with debug log:
```
DEBU[0011] OK: cpufreq collector succeeded after 0.030662s.  source="collector.go:135"
DEBU[0011] systemd collectUnitStatusMetrics took 0.020729  source="systemd_linux.go:160"
DEBU[0011] systemd collectUnitProcessMetrics took 0.023599  source="systemd_linux.go:169"
DEBU[0011] OK: systemd collector succeeded after 0.038093s.  source="collector.go:135"
```

This is how metrics look for a couple of systemd services on my machine:

```
# HELP node_systemd_bluetooth_process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE node_systemd_bluetooth_process_cpu_seconds_total counter
node_systemd_bluetooth_process_cpu_seconds_total 0.01
# HELP node_systemd_bluetooth_process_max_fds Maximum number of open file descriptors.
# TYPE node_systemd_bluetooth_process_max_fds gauge
node_systemd_bluetooth_process_max_fds 1024
# HELP node_systemd_bluetooth_process_resident_memory_bytes Resident memory size in bytes.
# TYPE node_systemd_bluetooth_process_resident_memory_bytes gauge
node_systemd_bluetooth_process_resident_memory_bytes 5.050368e+06
# HELP node_systemd_bluetooth_process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE node_systemd_bluetooth_process_start_time_seconds gauge
node_systemd_bluetooth_process_start_time_seconds 1.55275885647e+09
# HELP node_systemd_bluetooth_process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE node_systemd_bluetooth_process_virtual_memory_bytes gauge
node_systemd_bluetooth_process_virtual_memory_bytes 5.1048448e+07
# HELP node_systemd_bluetooth_process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE node_systemd_bluetooth_process_virtual_memory_max_bytes gauge
node_systemd_bluetooth_process_virtual_memory_max_bytes -1
```
```
# HELP node_systemd_dbus_process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE node_systemd_dbus_process_cpu_seconds_total counter
node_systemd_dbus_process_cpu_seconds_total 0.97
# HELP node_systemd_dbus_process_max_fds Maximum number of open file descriptors.
# TYPE node_systemd_dbus_process_max_fds gauge
node_systemd_dbus_process_max_fds 65536
# HELP node_systemd_dbus_process_resident_memory_bytes Resident memory size in bytes.
# TYPE node_systemd_dbus_process_resident_memory_bytes gauge
node_systemd_dbus_process_resident_memory_bytes 4.206592e+06
# HELP node_systemd_dbus_process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE node_systemd_dbus_process_start_time_seconds gauge
node_systemd_dbus_process_start_time_seconds 1.55275885478e+09
# HELP node_systemd_dbus_process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE node_systemd_dbus_process_virtual_memory_bytes gauge
node_systemd_dbus_process_virtual_memory_bytes 3.8178816e+07
# HELP node_systemd_dbus_process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE node_systemd_dbus_process_virtual_memory_max_bytes gauge
```