### PR TITLE
Early init of procfs

### DIFF
--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -26,6 +26,7 @@ import (
 )
 
 type cpuCollector struct {
+	fs                 procfs.FS
 	cpu                *prometheus.Desc
 	cpuGuest           *prometheus.Desc
 	cpuCoreThrottle    *prometheus.Desc
@@ -38,7 +39,12 @@ func init() {
 
 // NewCPUCollector returns a new Collector exposing kernel/system statistics.
 func NewCPUCollector() (Collector, error) {
+	fs, err := procfs.NewFS(*procPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open procfs: %v", err)
+	}
 	return &cpuCollector{
+		fs:  fs,
 		cpu: nodeCPUSecondsDesc,
 		cpuGuest: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "guest_seconds_total"),
@@ -149,11 +155,7 @@ func (c *cpuCollector) updateThermalThrottle(ch chan<- prometheus.Metric) error 
 
 // updateStat reads /proc/stat through procfs and exports cpu related metrics.
 func (c *cpuCollector) updateStat(ch chan<- prometheus.Metric) error {
-	fs, err := procfs.NewFS(*procPath)
-	if err != nil {
-		return fmt.Errorf("failed to open procfs: %v", err)
-	}
-	stats, err := fs.NewStat()
+	stats, err := c.fs.NewStat()
 	if err != nil {
 		return err
 	}

--- a/collector/ipvs_linux.go
+++ b/collector/ipvs_linux.go
@@ -58,7 +58,7 @@ func newIPVSCollector() (*ipvsCollector, error) {
 
 	c.fs, err = procfs.NewFS(*procPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open procfs: %v", err)
 	}
 
 	c.connections = typedDesc{prometheus.NewDesc(

--- a/collector/processes_linux.go
+++ b/collector/processes_linux.go
@@ -63,29 +63,29 @@ func NewProcessStatCollector() (Collector, error) {
 		),
 	}, nil
 }
-func (t *processCollector) Update(ch chan<- prometheus.Metric) error {
+func (c *processCollector) Update(ch chan<- prometheus.Metric) error {
 	pids, states, threads, err := getAllocatedThreads()
 	if err != nil {
 		return fmt.Errorf("unable to retrieve number of allocated threads: %q", err)
 	}
 
-	ch <- prometheus.MustNewConstMetric(t.threadAlloc, prometheus.GaugeValue, float64(threads))
+	ch <- prometheus.MustNewConstMetric(c.threadAlloc, prometheus.GaugeValue, float64(threads))
 	maxThreads, err := readUintFromFile(procFilePath("sys/kernel/threads-max"))
 	if err != nil {
 		return fmt.Errorf("unable to retrieve limit number of threads: %q", err)
 	}
-	ch <- prometheus.MustNewConstMetric(t.threadLimit, prometheus.GaugeValue, float64(maxThreads))
+	ch <- prometheus.MustNewConstMetric(c.threadLimit, prometheus.GaugeValue, float64(maxThreads))
 
 	for state := range states {
-		ch <- prometheus.MustNewConstMetric(t.procsState, prometheus.GaugeValue, float64(states[state]), state)
+		ch <- prometheus.MustNewConstMetric(c.procsState, prometheus.GaugeValue, float64(states[state]), state)
 	}
 
 	pidM, err := readUintFromFile(procFilePath("sys/kernel/pid_max"))
 	if err != nil {
 		return fmt.Errorf("unable to retrieve limit number of maximum pids alloved: %q", err)
 	}
-	ch <- prometheus.MustNewConstMetric(t.pidUsed, prometheus.GaugeValue, float64(pids))
-	ch <- prometheus.MustNewConstMetric(t.pidMax, prometheus.GaugeValue, float64(pidM))
+	ch <- prometheus.MustNewConstMetric(c.pidUsed, prometheus.GaugeValue, float64(pids))
+	ch <- prometheus.MustNewConstMetric(c.pidMax, prometheus.GaugeValue, float64(pidM))
 
 	return nil
 }

--- a/collector/processes_linux_test.go
+++ b/collector/processes_linux_test.go
@@ -18,7 +18,8 @@ package collector
 import (
 	"testing"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/prometheus/procfs"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 func TestReadProcessStatus(t *testing.T) {
@@ -26,7 +27,12 @@ func TestReadProcessStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := 1
-	pids, states, threads, err := getAllocatedThreads()
+	fs, err := procfs.NewFS(*procPath)
+	if err != nil {
+		t.Errorf("failed to open procfs: %v", err)
+	}
+	c := processCollector{fs: fs}
+	pids, states, threads, err := c.getAllocatedThreads()
 	if err != nil {
 		t.Fatalf("Cannot retrieve data from procfs getAllocatedThreads function: %v ", err)
 	}


### PR DESCRIPTION
Initialize the proc or sys fs once per collector instead of doing it on every update of the metrics.