### PR TITLE
textfile: use opened file's mtime as timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changes
 
 * [BUGFIX]
+* [BUGFIX] Fix node_textfile_mtime_seconds to work properly on symlinks #1326
 * [CHANGE] Renamed `interface` label to `device` in netclass collector #1224
 * [BUGFIX] Add fallback for missing /proc/1/mounts #1172
 * [CHANGE] Add TCPSynRetrans to netstat default filter #1143


### PR DESCRIPTION
Previously, the node_textfile_mtime_seconds metric was based on the Fileinfo.ModTime() of the ioutil.ReadDir() return value. This is based on lstat() and therefore has unintended consequences for symlinks (modification time of the symlink instead of the symlink target is
returned). It is also racy as the lstat() is performed before reading the file.

This commit changes the node_textfile_mtime_seconds metric to be based on a fresh Stat() call on the open file.  This eliminates the race and works as expected for symlinks. Fixes #1324.