### PR TITLE
meminfo: Fix the size mismatch in the swapTotal check mib for BSD.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [CHANGE]
 * [FEATURE]
 * [ENHANCEMENT]
-* [BUGFIX]
+* [BUGFIX] Fix incorrect sysctl call in BSD meminfo collector, resulting in broken swap metrics on FreeBSD #1345
 
 ## 0.18.0 / 2019-05-09
 

--- a/collector/memory_bsd.go
+++ b/collector/memory_bsd.go
@@ -47,7 +47,7 @@ func NewMemoryCollector() (Collector, error) {
 
 	mibSwapTotal := "vm.swap_total"
 	/* swap_total is FreeBSD specific. Fall back to Dfly specific mib if not present. */
-	_, err = unix.SysctlUint32(mibSwapTotal)
+	_, err = unix.SysctlUint64(mibSwapTotal)
 	if err != nil {
 		mibSwapTotal = "vm.swap_size"
 	}


### PR DESCRIPTION
This PR fixes #1344 

The size of the `sysctl` call during the MIB name check was wrong, causing this check to fail on FreeBSD (and probably on DragonFly too, failure was expected there, but probably not this failure).

This PR fixes things so that the size of the sysctl call matches the documented `dataType` of `bsdSysctlTypeUint64` from the array of sysctls.