### PR TITLE
apt.sh: Account for spaces in repository label

### DIFF
--- a/text_collector_examples/apt.sh
+++ b/text_collector_examples/apt.sh
@@ -6,8 +6,8 @@
 
 upgrades="$(/usr/bin/apt-get --just-print upgrade \
   | /usr/bin/awk -F'[()]' \
-      '/^Inst/ { sub("^[^ ]+ ", "", $2); sub("\\[", " ", $2);
-                 sub(" ", "", $2); sub("\\]", "", $2); print $2 }' \
+      '/^Inst/ { sub("^[^ ]+ ", "", $2); gsub(" ","",$2);
+                 sub("\\[", " ", $2); sub("\\]", "", $2); print $2 }' \
   | /usr/bin/sort \
   | /usr/bin/uniq -c \
   | awk '{ gsub(/\\\\/, "\\\\", $2); gsub(/\"/, "\\\"", $2);


### PR DESCRIPTION
Some repositories (eg: proxmox) have labels with spaces in it, which make the script fail.

Example with proxmox (`deb http://download.proxmox.com/debian/pve stretch pve-no-subscription`):
`Label: Proxmox Debian Repository`
```
apt_upgrades_pending{origin="Debian-Security:9/stable",arch="all"} 1
apt_upgrades_pending{origin="Debian-Security:9/stable",arch="amd64"} 6
apt_upgrades_pending{origin="ProxmoxDebian",arch="Repository:stable"} 1
```

After the commit in this PR:
```
apt_upgrades_pending{origin="Debian-Security:9/stable",arch="all"} 1
apt_upgrades_pending{origin="Debian-Security:9/stable",arch="amd64"} 6
apt_upgrades_pending{origin="ProxmoxDebianRepository:stable",arch="amd64"} 1
```
