### PR TITLE
fix codespell warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - checkout
     - run: sudo pip install codespell
-    - run: codespell --skip=".git,./vendor,ttar,go.mod,go.sum" -L uint
+    - run: codespell --skip=".git,./vendor,ttar,go.mod,go.sum" -L uint,packages\',uptodate
 
   build:
     machine:

--- a/text_collector_examples/md_info_detail.sh
+++ b/text_collector_examples/md_info_detail.sh
@@ -59,7 +59,7 @@ for MD_DEVICE in /dev/md/*; do
 
     # Output RAID "Devices", "Size" and "Event" metrics, from the output of "mdadm --detail"
     while IFS= read -r line ; do
-      # Filter out these keys that have numberic values that increment up
+      # Filter out these keys that have numeric values that increment up
       if echo "$line" | grep -E -q "Devices :|Array Size :| Used Dev Size :|Events :"; then
         MDADM_DETAIL_KEY=$(echo "$line" | cut -d ":" -f 1 | tr -cd '[a-zA-Z0-9]._-')
         MDADM_DETAIL_VALUE=$(echo "$line" | cut -d ":" -f 2 | cut -d " " -f 2 | sed 's:^ ::')


### PR DESCRIPTION
The latest codespell update appears to be finding some new issues.  This change fixes or ignores those errors as appropriate.