### PR TITLE
Ignore iso9600 filesystem on Linux

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	defIgnoredMountPoints = "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
-	defIgnoredFSTypes     = "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"
+	defIgnoredFSTypes     = "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"
 	mountTimeout          = 30 * time.Second
 )
 


### PR DESCRIPTION
The filesystem is always read-only and is often used as a virtual FS with a "seed" configuration file for a VM in cloud environment.

So, I'm following the logic from #1104 about `squashfs` being read-only and suggest to add `iso9660` to default ignore-list as well.

The trigger for the PR was the fact that the FS never has any free space. So time series about this FS will likely trigger an alert about "seed" partition if the rule about disk space is fstype-agnostic.

/cc @discordianfish 