### PR TITLE
btrfs_stats: Upgrade to Python 3

### DIFF
--- a/text_collector_examples/btrfs_stats.py
+++ b/text_collector_examples/btrfs_stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Collect per-device btrfs filesystem errors.
 # Designed to work on Debian and Centos 6 (with python2.6).


### PR DESCRIPTION
Python 2.7 will not be maintained past 2020. Therefore upgrade `text_collector_examples/btrfs_stats.py` to Python 3.