### PR TITLE
Use counter type for netstat metrics

### DIFF
--- a/collector/netstat_linux.go
+++ b/collector/netstat_linux.go
@@ -90,7 +90,7 @@ func (c *netStatCollector) Update(ch chan<- prometheus.Metric) error {
 					fmt.Sprintf("Statistic %s.", protocol+name),
 					nil, nil,
 				),
-				prometheus.UntypedValue, v,
+				prometheus.CounterValue, v,
 			)
 		}
 	}


### PR DESCRIPTION
All of the /proc/net/netstat and /proc/net/snmp metrics should be cumulative, so the `counter` type is most appropriate for these.