### PR TITLE
Fixes systemd restart counter label from state to name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### **Breaking changes**
 
 * The netdev collector CLI argument `--collector.netdev.ignored-devices` was renamed to `--collector.netdev.device-blacklist` in order to conform with the systemd collector. #1279
+* The label named `state` on `node_systemd_service_restart_total` metrics was changed to `name` to better describe the metric. #1393
 
 
 ### Changes
@@ -10,6 +11,7 @@
 * [CHANGE] Add `--collector.netdev.device-whitelist`. #1279
 * [FEATURE]
 * [ENHANCEMENT]
+* [BUGFIX] Renamed label `state` to `name` on `node_systemd_service_restart_total`. #1393
 
 ## 0.18.1 / 2019-06-04
 

--- a/collector/systemd_linux.go
+++ b/collector/systemd_linux.go
@@ -90,7 +90,7 @@ func NewSystemdCollector() (Collector, error) {
 		"Summary of systemd unit states", []string{"state"}, nil)
 	nRestartsDesc := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "service_restart_total"),
-		"Service unit count of Restart triggers", []string{"state"}, nil)
+		"Service unit count of Restart triggers", []string{"name"}, nil)
 	timerLastTriggerDesc := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "timer_last_trigger_seconds"),
 		"Seconds since epoch of last trigger.", []string{"name"}, nil)


### PR DESCRIPTION
Fixes the `node_systemd_service_restart_total` label for unit name from 'state' to 'name'. State doesn't really make sense here especially considering what the label is being set to:
```
	ch <- prometheus.MustNewConstMetric(
					c.nRestartsDesc, prometheus.CounterValue,
					float64(restartsCount.Value.Value().(uint32)), unit.Name)
```