### PR TITLE
FIX ipmitool sensor discrete values are expressed in hex

### DIFF
--- a/text_collector_examples/ipmitool
+++ b/text_collector_examples/ipmitool
@@ -76,7 +76,7 @@ $3 ~ /RPM/ {
 }
 
 $3 ~ /discrete/ {
-	status[$1] = $2;
+	status[$1] = sprintf("%d", substr($2,3,2));
 	status["metric_count"]++;
 }
 


### PR DESCRIPTION
Hi,
```
# ipmitool sensor | grep discrete
VBAT             | 0x4        | discrete   | 0xxxxx| na        | na        | na        | na        | na        | na        
Chassis Intru    | 0x1        | discrete   | 0xxxxx| na        | na        | na        | na        | na        | na        
PS1 Status       | 0x1        | discrete   | 0xxxxx| na        | na        | na        | na        | na        | na        
PS2 Status       | 0x1        | discrete   | 0xxxxx| na        | na        | na        | na        | na        | na  
```
At least in our deployments, these metrics were all zero prometheus wouldn't accept the hex value. I used substr() to try to make it more portable. With this small fix, we get the right values:
```
# ipmitool sensor | awk -f  node-exporter-ipmitool | grep 'PS'
node_ipmi_status{sensor="PS2 Status"} 1.000000
node_ipmi_status{sensor="PS1 Status"} 1.000000
```