### PR TITLE
systemd: check version for availability of SystemState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [ENHANCEMENT] Include additional XFS runtime statistics. #1423
 * [ENHANCEMENT] Report non-fatal collection errors in the exporter metric. #1439
 * [ENHANCEMENT] Expose IPVS firewall mark as a label #1455
+* [ENHANCEMENT] Add check for systemd version before attempting to query certain metrics. #1413
 * [BUGFIX] Renamed label `state` to `name` on `node_systemd_service_restart_total`. #1393
 * [BUGFIX] Fix netdev nil reference on Darwin #1414
 * [BUGFIX] Strip path.rootfs from mountpoint labels #1421


### PR DESCRIPTION
The dbus property 'SystemState' was added in version 212 of systemd.
Check that the version of systemd is higher than 212 before attempting
to query the SystemState property.

https://github.com/systemd/systemd/commit/f755e3b74b94296a534033dd6ae04d9506434210

Resolves issue #291