### PR TITLE
Handle JBOD setup for storcli exporter

### DIFF
--- a/text_collector_examples/storcli.py
+++ b/text_collector_examples/storcli.py
@@ -114,7 +114,6 @@ def handle_megaraid_controller(response):
     if 'Drive Groups' in response.keys():
         add_metric('drive_groups', baselabel, response['Drive Groups'])
         add_metric('virtual_drives', baselabel, response['Virtual Drives'])
-        add_metric('physical_drives', baselabel, response['Physical Drives'])
 
         for virtual_drive in response['VD LIST']:
             vd_position = virtual_drive.get('DG/VD')
@@ -131,6 +130,7 @@ def handle_megaraid_controller(response):
                 str(virtual_drive.get('State')).strip())
             add_metric('vd_info', vd_info_label, 1)
 
+    add_metric('physical_drives', baselabel, response['Physical Drives'])
     if response['Physical Drives'] > 0:
         data = get_storcli_json('/cALL/eALL/sALL show all J')
         drive_info = data['Controllers'][controller_index]['Response Data']

--- a/text_collector_examples/storcli.py
+++ b/text_collector_examples/storcli.py
@@ -48,7 +48,7 @@ def main(args):
 
         for controller in data:
             response = controller['Response Data']
-            
+
             handle_common_controller(response)
             if response['Version']['Driver Name'] == 'megaraid_sas':
                 handle_megaraid_controller(response)
@@ -82,7 +82,7 @@ def handle_sas_controller(response):
     for key, basic_disk_info in response['Physical Device Information'].items():
         if 'Detailed Information' in key:
             continue
-        create_metrcis_of_physical_drive(basic_disk_info[0],
+        create_metrics_of_physical_drive(basic_disk_info[0],
                                          response['Physical Device Information'], controller_index)
 
 
@@ -132,7 +132,7 @@ def handle_megaraid_controller(response):
         data = get_storcli_json('/cALL/eALL/sALL show all J')
         drive_info = data['Controllers'][controller_index]['Response Data']
     for physical_drive in response['PD LIST']:
-        create_metrcis_of_physical_drive(physical_drive, drive_info, controller_index)
+        create_metrics_of_physical_drive(physical_drive, drive_info, controller_index)
 
 
 def get_basic_controller_info(response):
@@ -149,7 +149,7 @@ def get_basic_controller_info(response):
     return (controller_index, baselabel)
 
 
-def create_metrcis_of_physical_drive(physical_drive, detailed_info_array, controller_index):
+def create_metrics_of_physical_drive(physical_drive, detailed_info_array, controller_index):
     enclosure = physical_drive.get('EID:Slt').split(':')[0]
     slot = physical_drive.get('EID:Slt').split(':')[1]
 


### PR DESCRIPTION
If you're using a JBOD setup (`storcli /c0/e1/s1 set jbod`) with 0 drive groups/virtual drives, the exporter crashes and doesn't output physical drives infos

This PR fixes it