### PR TITLE
Extend uname collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ stat | Exposes various statistics from `/proc/stat`. This includes boot time, fo
 textfile | Exposes statistics read from local disk. The `--collector.textfile.directory` flag must be set. | _any_
 time | Exposes the current system time. | _any_
 timex | Exposes selected adjtimex(2) system call stats. | Linux
-uname | Exposes system information as provided by the uname system call. | FreeBSD, Linux
+uname | Exposes system information as provided by the uname system call. | Darwin, FreeBSD, Linux, OpenBSD
 vmstat | Exposes statistics from `/proc/vmstat`. | Linux
 xfs | Exposes XFS runtime statistics. | Linux (kernel 4.4+)
 zfs | Exposes [ZFS](http://open-zfs.org/) performance statistics. | [Linux](http://zfsonlinux.org/), Solaris

--- a/collector/uname.go
+++ b/collector/uname.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build freebsd linux
+// +build darwin freebsd openbsd linux
 // +build !nouname
 
 package collector


### PR DESCRIPTION
@SuperQ - mind taking a look. This partially Fixes #1222 

Adds uname support for Darwin and OpenBSD.

I built and tested the OpenBSD build flag in a vagrant box but didn't have as much luck with dragonfly and netbsd (have no *BSD experience and had trouble with the go tooling setup). 

Cross compiling on mac also fails for those two OS.

Looking at https://github.com/golang/sys/blob/master/unix/ztypes_netbsd_amd64.go#L457 and https://github.com/golang/sys/blob/master/unix/ztypes_dragonfly_amd64.go#L463 I think it might be safe to add those OS but omitted them since I was unable to test them.

Heres the output for the two additions below, I kept the same implementation that was in place for FreeBSD:

`uname && uname -n` : 
```
OpenBSD
openbsd64.expressvpn
```

--------------------
`uname && uname -n`:

```
Darwin
Philips-MacBook-Pro-2.local
```

```
node_uname_info{domainname="local",machine="x86_64",nodename="Philips-MacBook-Pro-2",release="18.6.0",sysname="Darwin",version="Darwin Kernel Version 18.6.0: Thu Apr 25 23:16:27 PDT 2019; root:xnu-4903.261.4~2/RELEASE_X86_64"} 1