### PR TITLE
fix issue where rootfs path strips to the empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [BUGFIX] Fix netdev nil reference on Darwin #1414
 * [BUGFIX] Strip path.rootfs from mountpoint labels #1421
 * [FEATURE] Add new thermal_zone collector #1425
+* [BUGFIX] Fix empty string in path.rootfs #1464
 
 ## 0.18.1 / 2019-06-04
 

--- a/collector/filesystem_linux_test.go
+++ b/collector/filesystem_linux_test.go
@@ -120,6 +120,7 @@ func TestPathRootfs(t *testing.T) {
 
 	expected := map[string]string{
 		// should modify these mountpoints (removes /host, see fixture proc file)
+		"/":              "",
 		"/media/volume1": "",
 		"/media/volume2": "",
 		// should not modify these mountpoints

--- a/collector/fixtures_bindmount/proc/mounts
+++ b/collector/fixtures_bindmount/proc/mounts
@@ -1,3 +1,4 @@
+/dev/nvme1n0 /host ext4 rw,seclabel,relatime,data=ordered 0 0
 /dev/nvme1n1 /host/media/volume1 ext4 rw,seclabel,relatime,data=ordered 0 0
 /dev/nvme1n2 /host/media/volume2 ext4 rw,seclabel,relatime,data=ordered 0 0
 tmpfs /dev/shm tmpfs rw,nosuid,nodev 0 0

--- a/collector/paths.go
+++ b/collector/paths.go
@@ -44,5 +44,9 @@ func rootfsStripPrefix(path string) string {
 	if *rootfsPath == "/" {
 		return path
 	}
-	return strings.TrimPrefix(path, *rootfsPath)
+	stripped := strings.TrimPrefix(path, *rootfsPath)
+	if stripped == "" {
+		return "/"
+	}
+	return stripped
 }


### PR DESCRIPTION
fix for issue #1463 and expanded test case to properly check this

Change-type: patch
Connects-to: #1463
Signed-off-by: Nick Payne <nickp@balena.io>