### PR TITLE
report core throttles for each CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changes
 
+* [CHANGE] Report cpu_core_throttles for all CPUs.  Add label "cpu". #1479
 * [CHANGE] Add `--collector.netdev.device-whitelist`. #1279
 * [CHANGE] Refactor mdadm collector #1403
 * [CHANGE] Add `mountaddr` label to NFS metrics. #1417

--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -184,12 +184,12 @@ node_cooling_device_cur_state{name="0",type="Processor"} 0
 # HELP node_cooling_device_max_state Maximum throttle state of the cooling device
 # TYPE node_cooling_device_max_state gauge
 node_cooling_device_max_state{name="0",type="Processor"} 3
-# HELP node_cpu_core_throttles_total Number of times this cpu core has been throttled.
+# HELP node_cpu_core_throttles_total Number of times this cpu has been throttled.
 # TYPE node_cpu_core_throttles_total counter
-node_cpu_core_throttles_total{core="0",package="0"} 5
-node_cpu_core_throttles_total{core="0",package="1"} 0
-node_cpu_core_throttles_total{core="1",package="0"} 0
-node_cpu_core_throttles_total{core="1",package="1"} 9
+node_cpu_core_throttles_total{core="0",cpu="0",package="0"} 5
+node_cpu_core_throttles_total{core="0",cpu="2",package="1"} 0
+node_cpu_core_throttles_total{core="1",cpu="1",package="0"} 0
+node_cpu_core_throttles_total{core="1",cpu="3",package="1"} 9
 # HELP node_cpu_guest_seconds_total Seconds the cpus spent in guests (VMs) for each mode.
 # TYPE node_cpu_guest_seconds_total counter
 node_cpu_guest_seconds_total{cpu="0",mode="nice"} 0.01

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -184,12 +184,12 @@ node_cooling_device_cur_state{name="0",type="Processor"} 0
 # HELP node_cooling_device_max_state Maximum throttle state of the cooling device
 # TYPE node_cooling_device_max_state gauge
 node_cooling_device_max_state{name="0",type="Processor"} 3
-# HELP node_cpu_core_throttles_total Number of times this cpu core has been throttled.
+# HELP node_cpu_core_throttles_total Number of times this cpu has been throttled.
 # TYPE node_cpu_core_throttles_total counter
-node_cpu_core_throttles_total{core="0",package="0"} 5
-node_cpu_core_throttles_total{core="0",package="1"} 0
-node_cpu_core_throttles_total{core="1",package="0"} 0
-node_cpu_core_throttles_total{core="1",package="1"} 9
+node_cpu_core_throttles_total{core="0",cpu="0",package="0"} 5
+node_cpu_core_throttles_total{core="0",cpu="2",package="1"} 0
+node_cpu_core_throttles_total{core="1",cpu="1",package="0"} 0
+node_cpu_core_throttles_total{core="1",cpu="3",package="1"} 9
 # HELP node_cpu_guest_seconds_total Seconds the cpus spent in guests (VMs) for each mode.
 # TYPE node_cpu_guest_seconds_total counter
 node_cpu_guest_seconds_total{cpu="0",mode="nice"} 0.01


### PR DESCRIPTION
It's possible for two cpus in the same core to have a different
value for the core_throttle_count, so this change reports a
cpu_core_throttles metric for each cpu and not just each core.
Hyperthreading systems have two cpus per core.

Fixes #1472