### PR TITLE
docs/node-mixin: alert on desynchronised clock

### DIFF
--- a/docs/node-mixin/alerts/alerts.libsonnet
+++ b/docs/node-mixin/alerts/alerts.libsonnet
@@ -197,6 +197,44 @@
               severity: 'warning',
             },
           },
+          {
+            alert: 'NodeClockSkewDetected',
+            expr: |||
+              (
+                node_timex_offset_seconds > 0.05
+              and
+                deriv(node_timex_offset_seconds[5m]) >= 0
+              )
+              or
+              (
+                node_timex_offset_seconds < 0.05
+              and
+                deriv(node_timex_offset_seconds[5m]) <= 0
+              )
+            ||| % $._config,
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Clock skew detected.',
+              message: 'Clock on {{ $labels.instance }} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.',
+            },
+          },
+          {
+            alert: 'NodeClockNotSynchronising',
+            expr: |||
+              min_over_time(node_timex_sync_status[5m]) == 0
+            ||| % $._config,
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Clock not synchronising.',
+              message: 'Clock on {{ $labels.instance }} is not synchronising. Ensure NTP is configured on this host.',
+            },
+          },
         ],
       },
     ],


### PR DESCRIPTION
Add alert to detect the desynchronized clock.

300s is an arbitrary number based on maximum possible desynchronization between nodes for Kerberos setup. I am keen on lowering it based on some other data, but I couldn't find any better source.

For example OpenShift is using same alert but with a much tighter target of `0.05s`.

/cc @beorn7 @metalmatze