### PR TITLE
Clarify ambiguous text collector note

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ that are tied to a machine.
 To use it, set the `--collector.textfile.directory` flag on the Node exporter. The
 collector will parse all files in that directory matching the glob `*.prom`
 using the [text
-format](http://prometheus.io/docs/instrumenting/exposition_formats/). **Note:** Timestamps are not supported.
+format](http://prometheus.io/docs/instrumenting/exposition_formats/). **Note:** The optional timestamp token is not supported.
 
 To atomically push completion time for a cron job:
 ```


### PR DESCRIPTION
The original note was somewhat vague and forced me to trace it back its original author via git blame to understand what had caused the note to be added in the first place. This helps to better clarify the limitation of the text collector.