### PR TITLE
add filesystem pvc label.

### DIFF
--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -39,7 +39,7 @@ var (
 		"Regexp of filesystem types to ignore for filesystem collector.",
 	).Default(defIgnoredFSTypes).String()
 
-	filesystemLabelNames = []string{"device", "mountpoint", "fstype"}
+	filesystemLabelNames = []string{"device", "mountpoint", "fstype", "volumename"}
 )
 
 type filesystemCollector struct {
@@ -51,7 +51,7 @@ type filesystemCollector struct {
 }
 
 type filesystemLabels struct {
-	device, mountPoint, fsType, options string
+	device, mountPoint, fsType, options, volumename string
 }
 
 type filesystemStats struct {
@@ -141,7 +141,7 @@ func (c *filesystemCollector) Update(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.deviceErrorDesc, prometheus.GaugeValue,
-			s.deviceError, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.deviceError, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.volumename,
 		)
 		if s.deviceError > 0 {
 			continue
@@ -149,27 +149,27 @@ func (c *filesystemCollector) Update(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.sizeDesc, prometheus.GaugeValue,
-			s.size, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.size, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.volumename,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.freeDesc, prometheus.GaugeValue,
-			s.free, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.free, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.volumename,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.availDesc, prometheus.GaugeValue,
-			s.avail, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.avail, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.volumename,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.filesDesc, prometheus.GaugeValue,
-			s.files, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.files, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.volumename,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.filesFreeDesc, prometheus.GaugeValue,
-			s.filesFree, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.filesFree, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.volumename,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.roDesc, prometheus.GaugeValue,
-			s.ro, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.ro, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.volumename,
 		)
 	}
 	return nil

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -163,11 +163,20 @@ func parseFilesystemLabels(r io.Reader) ([]filesystemLabels, error) {
 		parts[1] = strings.Replace(parts[1], "\\040", " ", -1)
 		parts[1] = strings.Replace(parts[1], "\\011", "\t", -1)
 
+		mountPoint := parts[1]
+		var pvcName string
+		pvcName = ""
+		if strings.Index(mountPoint, "/pvc-") >= 0 {
+			pvcNameArray := strings.Split(mountPoint,"/")
+			pvcName = pvcNameArray[len(pvcNameArray) - 2]
+		}
+
 		filesystems = append(filesystems, filesystemLabels{
 			device:     parts[0],
-			mountPoint: rootfsStripPrefix(parts[1]),
+			mountPoint: rootfsStripPrefix(mountPoint),
 			fsType:     parts[2],
 			options:    parts[3],
+			volumename:	pvcName,
 		})
 	}
 


### PR DESCRIPTION
add the new label `volumename`, get PVC name from mountpoint.
we can get the pvc size, use the record:
```
record: persistentvolume_free_bytes
expr: kube_persistentvolumeclaim_info * on(volumename) node_filesystem_free_bytes{device=~"/dev/.*",mountpoint=~".*pvc.*/mount"}
```
