### PR TITLE
Fix num cpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changes
 
+* [ENHANCEMENT] Add `--collector.perf.cpus` to allow setting the CPU list for perf stats.
 * [CHANGE] Add `--collector.netdev.device-whitelist`. #1279
 * [CHANGE] Refactor mdadm collector #1403
 * [CHANGE] Add `mountaddr` label to NFS metrics. #1417

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Depending on the configured value different metrics will be available, for most
 cases `0` will provide the most complete set. For more information see [`man 2
 perf_event_open`](http://man7.org/linux/man-pages/man2/perf_event_open.2.html).
 
+By default, the perf collector will only collect metrics of the CPUs that
+`node_exporter` can run on. If this is insufficient (e.g. if you run `node_exporter` with
+its CPU affinity set to specific CPUs) You can specify a list of alternate CPUs by using the
+`--collector.perf.cpus` flag. For example, to collect metrics on CPUs 2-6, you
+would specify: `--collector.perf --collector.perf.cpus=2-6`.
+
+
 Name     | Description | OS
 ---------|-------------|----
 buddyinfo | Exposes statistics of memory fragments as reported by /proc/buddyinfo. | Linux

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ By default, the perf collector will only collect metrics of the CPUs that
 `node_exporter` can run on. If this is insufficient (e.g. if you run `node_exporter` with
 its CPU affinity set to specific CPUs) You can specify a list of alternate CPUs by using the
 `--collector.perf.cpus` flag. For example, to collect metrics on CPUs 2-6, you
-would specify: `--collector.perf --collector.perf.cpus=2-6`.
+would specify: `--collector.perf --collector.perf.cpus=2-6`. The CPU ids start
+at 0.
 
 
 Name     | Description | OS

--- a/collector/perf_linux.go
+++ b/collector/perf_linux.go
@@ -63,9 +63,12 @@ func isValidCPUString(cpus *string) bool {
 // per CPU.
 func NewPerfCollector() (Collector, error) {
 	collector := &perfCollector{
-		perfHwProfilers:    map[int]perf.HardwareProfiler{},
-		perfSwProfilers:    map[int]perf.SoftwareProfiler{},
-		perfCacheProfilers: map[int]perf.CacheProfiler{},
+		perfHwProfilers:     map[int]perf.HardwareProfiler{},
+		perfSwProfilers:     map[int]perf.SoftwareProfiler{},
+		perfCacheProfilers:  map[int]perf.CacheProfiler{},
+		hwProfilerCpuMap:    map[*perf.HardwareProfiler]int{},
+		swProfilerCpuMap:    map[*perf.SoftwareProfiler]int{},
+		cacheProfilerCpuMap: map[*perf.CacheProfiler]int{},
 	}
 
 	start := 0


### PR DESCRIPTION
`runtime.NumCPU()` returns the number of CPUs that the process can run
on. This number does not necessarily correlate to CPU ids if the
affinity mask of the process is set.

This change maintains the current behavior as default, but also allows
the user to specify a range of CPUids to use instead.

The CPU id is stored as the value of a map keyed on the profiler
object's address.
