### PR TITLE
docs/node-mixin: Fix node_memory_swap_io_pages rule

### DIFF
--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -53,8 +53,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         )
         .addPanel(
-          g.panel('Memory Saturation (Swapped Pages)') +
-          g.queryPanel('instance:node_memory_swap_io_pages:rate1m{%(nodeExporterSelector)s}' % $._config, '{{instance}}', legendLink) +
+          g.panel('Memory Saturation (Major Page Faults)') +
+          g.queryPanel('instance:node_vmstat_pgmajfault:rate1m{%(nodeExporterSelector)s}' % $._config, '{{instance}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes('rps') },
         )
@@ -201,8 +201,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
           { yaxes: g.yaxes('percentunit') },
         )
         .addPanel(
-          g.panel('Memory Saturation (pages swapped per second)') +
-          g.queryPanel('instance:node_memory_swap_io_pages:rate1m{%(nodeExporterSelector)s, instance="$instance"}' % $._config, 'Swap IO') +
+          g.panel('Memory Saturation (Major Page Faults)') +
+          g.queryPanel('instance:node_vmstat_pgmajfault:rate1m{%(nodeExporterSelector)s, instance="$instance"}' % $._config, 'Major page faults') +
           {
             yaxes: g.yaxes('short'),
             legend+: { show: false },

--- a/docs/node-mixin/rules/rules.libsonnet
+++ b/docs/node-mixin/rules/rules.libsonnet
@@ -50,13 +50,9 @@
             ||| % $._config,
           },
           {
-            record: 'instance:node_memory_swap_io_pages:rate1m',
+            record: 'instance:node_vmstat_pgmajfault:rate1m',
             expr: |||
-              (
-                rate(node_vmstat_pgpgin{%(nodeExporterSelector)s}[1m])
-              +
-                rate(node_vmstat_pgpgout{%(nodeExporterSelector)s}[1m])
-              )
+              rate(node_vmstat_pgmajfault{%(nodeExporterSelector)s}[1m])
             ||| % $._config,
           },
           {


### PR DESCRIPTION
It's intended to show the rate of swap IOs, but it used the paging
metrics instead.

This commit replaces `node_vmstat_pgpgin` and `node_vmstat_pgpgout` with
`node_vmstat_pswpin` and `node_vmstat_pswpout` in the
`instance:node_memory_swap_io_pages:rate1m` recording rule.

See coreos/kube-prometheus#222.