### PR TITLE
Remove max:1 from USE dashboard as it limits the graph

### DIFF
--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -34,8 +34,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
             )
           ||| % $._config, '{{instance}}', legendLink) +
           g.stack +
-          // TODO: Does `max: 1` make sense? The stack can go over 1 in high-load scenarios.
-          { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
+          { yaxes: g.yaxes({ format: 'percentunit' }) },
         )
       )
       .addRow(
@@ -50,7 +49,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
             )
           ||| % $._config, '{{instance}}', legendLink) +
           g.stack +
-          { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
+          { yaxes: g.yaxes({ format: 'percentunit' }) },
         )
         .addPanel(
           g.panel('Memory Saturation (Major Page Faults)') +


### PR DESCRIPTION
As one of the comments in the code already suggests too, I don't think that the `max:1` for these graphs make sense. They limit what the graph can display and I constantly don't see data there.

/cc @beorn7 @SuperQ 

![Screenshot from 2019-10-29 10-32-50](https://user-images.githubusercontent.com/872251/67754967-a16e0c80-fa37-11e9-94b2-b49fc6689338.png)
![Screenshot from 2019-10-29 10-32-57](https://user-images.githubusercontent.com/872251/67754968-a16e0c80-fa37-11e9-97d0-3bf869d1533a.png)
