### PR TITLE
docs/node-mixin/dashboards: do not mix tabs and spaces

### DIFF
--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -16,7 +16,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
             *
               instance:node_num_cpu:sum{%(nodeExporterSelector)s}
             )
-	    / scalar(sum(instance:node_num_cpu:sum{%(nodeExporterSelector)s}))
+            / scalar(sum(instance:node_num_cpu:sum{%(nodeExporterSelector)s}))
           ||| % $._config, '{{instance}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },


### PR DESCRIPTION
This is completely breaking node-mixins as `jsonnetfmt` panics with:
```
$ jsonnetfmt -i use.libsonnet 
STATIC ERROR: use.libsonnet:20:11: text block syntax requires new line after |||.
```

/cc @beorn7 @s-urbaniak @metalmatze 