### PR TITLE
Makefile: bump to promtool 2.14.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DOCKER_ARCHS ?= amd64 armv7 arm64 ppc64le
 
 include Makefile.common
 
-PROMTOOL_VERSION ?= 2.5.0
+PROMTOOL_VERSION ?= 2.14.0
 PROMTOOL_URL     ?= https://github.com/prometheus/prometheus/releases/download/v$(PROMTOOL_VERSION)/prometheus-$(PROMTOOL_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 PROMTOOL         ?= $(FIRST_GOPATH)/bin/promtool
 


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

This might need a bit more work; some of the newer metrics are being flagged and may have to be whitelisted as they are auto generated from kernel names.