### PR TITLE
mixins: use 5m rate range for better interoperability

### DIFF
--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -12,7 +12,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('CPU Utilisation') +
           g.queryPanel(|||
             (
-              instance:node_cpu_utilisation:rate1m{%(nodeExporterSelector)s}
+              instance:node_cpu_utilisation:rate5m{%(nodeExporterSelector)s}
             *
               instance:node_num_cpu:sum{%(nodeExporterSelector)s}
             )
@@ -47,7 +47,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
         )
         .addPanel(
           g.panel('Memory Saturation (Major Page Faults)') +
-          g.queryPanel('instance:node_vmstat_pgmajfault:rate1m{%(nodeExporterSelector)s}' % $._config, '{{instance}}', legendLink) +
+          g.queryPanel('instance:node_vmstat_pgmajfault:rate5m{%(nodeExporterSelector)s}' % $._config, '{{instance}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes('rps') },
         )
@@ -58,8 +58,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Net Utilisation (Bytes Receive/Transmit)') +
           g.queryPanel(
             [
-              'instance:node_network_receive_bytes_excluding_lo:rate1m{%(nodeExporterSelector)s}' % $._config,
-              'instance:node_network_transmit_bytes_excluding_lo:rate1m{%(nodeExporterSelector)s}' % $._config,
+              'instance:node_network_receive_bytes_excluding_lo:rate5m{%(nodeExporterSelector)s}' % $._config,
+              'instance:node_network_transmit_bytes_excluding_lo:rate5m{%(nodeExporterSelector)s}' % $._config,
             ],
             ['{{instance}} Receive', '{{instance}} Transmit'],
             legendLink,
@@ -84,8 +84,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Net Saturation (Drops Receive/Transmit)') +
           g.queryPanel(
             [
-              'instance:node_network_receive_drop_excluding_lo:rate1m{%(nodeExporterSelector)s}' % $._config,
-              'instance:node_network_transmit_drop_excluding_lo:rate1m{%(nodeExporterSelector)s}' % $._config,
+              'instance:node_network_receive_drop_excluding_lo:rate5m{%(nodeExporterSelector)s}' % $._config,
+              'instance:node_network_transmit_drop_excluding_lo:rate5m{%(nodeExporterSelector)s}' % $._config,
             ],
             ['{{instance}} Receive', '{{instance}} Transmit'],
             legendLink,
@@ -116,8 +116,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
           // TODO: Does the partition by device make sense? Using the most utilized device per
           // instance might make more sense.
           g.queryPanel(|||
-            instance_device:node_disk_io_time_seconds:rate1m{%(nodeExporterSelector)s}
-            / scalar(count(instance_device:node_disk_io_time_seconds:rate1m{%(nodeExporterSelector)s}))
+            instance_device:node_disk_io_time_seconds:rate5m{%(nodeExporterSelector)s}
+            / scalar(count(instance_device:node_disk_io_time_seconds:rate5m{%(nodeExporterSelector)s}))
           ||| % $._config, '{{instance}} {{device}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
@@ -125,8 +125,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
         .addPanel(
           g.panel('Disk IO Saturation') +
           g.queryPanel(|||
-            instance_device:node_disk_io_time_weighted_seconds:rate1m{%(nodeExporterSelector)s}
-            / scalar(count(instance_device:node_disk_io_time_weighted_seconds:rate1m{%(nodeExporterSelector)s}))
+            instance_device:node_disk_io_time_weighted_seconds:rate5m{%(nodeExporterSelector)s}
+            / scalar(count(instance_device:node_disk_io_time_weighted_seconds:rate5m{%(nodeExporterSelector)s}))
           ||| % $._config, '{{instance}} {{device}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
@@ -156,7 +156,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('CPU')
         .addPanel(
           g.panel('CPU Utilisation') +
-          g.queryPanel('instance:node_cpu_utilisation:rate1m{%(nodeExporterSelector)s, instance="$instance"}' % $._config, 'Utilisation') +
+          g.queryPanel('instance:node_cpu_utilisation:rate5m{%(nodeExporterSelector)s, instance="$instance"}' % $._config, 'Utilisation') +
           {
             yaxes: g.yaxes('percentunit'),
             legend+: { show: false },
@@ -182,7 +182,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
         )
         .addPanel(
           g.panel('Memory Saturation (Major Page Faults)') +
-          g.queryPanel('instance:node_vmstat_pgmajfault:rate1m{%(nodeExporterSelector)s, instance="$instance"}' % $._config, 'Major page faults') +
+          g.queryPanel('instance:node_vmstat_pgmajfault:rate5m{%(nodeExporterSelector)s, instance="$instance"}' % $._config, 'Major page faults') +
           {
             yaxes: g.yaxes('short'),
             legend+: { show: false },
@@ -195,8 +195,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Net Utilisation (Bytes Receive/Transmit)') +
           g.queryPanel(
             [
-              'instance:node_network_receive_bytes_excluding_lo:rate1m{%(nodeExporterSelector)s, instance="$instance"}' % $._config,
-              'instance:node_network_transmit_bytes_excluding_lo:rate1m{%(nodeExporterSelector)s, instance="$instance"}' % $._config,
+              'instance:node_network_receive_bytes_excluding_lo:rate5m{%(nodeExporterSelector)s, instance="$instance"}' % $._config,
+              'instance:node_network_transmit_bytes_excluding_lo:rate5m{%(nodeExporterSelector)s, instance="$instance"}' % $._config,
             ],
             ['Receive', 'Transmit'],
           ) +
@@ -219,8 +219,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Net Saturation (Drops Receive/Transmit)') +
           g.queryPanel(
             [
-              'instance:node_network_receive_drop_excluding_lo:rate1m{%(nodeExporterSelector)s, instance="$instance"}' % $._config,
-              'instance:node_network_transmit_drop_excluding_lo:rate1m{%(nodeExporterSelector)s, instance="$instance"}' % $._config,
+              'instance:node_network_receive_drop_excluding_lo:rate5m{%(nodeExporterSelector)s, instance="$instance"}' % $._config,
+              'instance:node_network_transmit_drop_excluding_lo:rate5m{%(nodeExporterSelector)s, instance="$instance"}' % $._config,
             ],
             ['Receive drops', 'Transmit drops'],
           ) +
@@ -244,12 +244,12 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('Disk IO')
         .addPanel(
           g.panel('Disk IO Utilisation') +
-          g.queryPanel('instance_device:node_disk_io_time_seconds:rate1m{%(nodeExporterSelector)s, instance="$instance"}' % $._config, '{{device}}') +
+          g.queryPanel('instance_device:node_disk_io_time_seconds:rate5m{%(nodeExporterSelector)s, instance="$instance"}' % $._config, '{{device}}') +
           { yaxes: g.yaxes('percentunit') },
         )
         .addPanel(
           g.panel('Disk IO Saturation') +
-          g.queryPanel('instance_device:node_disk_io_time_weighted_seconds:rate1m{%(nodeExporterSelector)s, instance="$instance"}' % $._config, '{{device}}') +
+          g.queryPanel('instance_device:node_disk_io_time_weighted_seconds:rate5m{%(nodeExporterSelector)s, instance="$instance"}' % $._config, '{{device}}') +
           { yaxes: g.yaxes('percentunit') },
         )
       )

--- a/docs/node-mixin/rules/rules.libsonnet
+++ b/docs/node-mixin/rules/rules.libsonnet
@@ -17,10 +17,10 @@
           },
           {
             // CPU utilisation is % CPU is not idle.
-            record: 'instance:node_cpu_utilisation:rate1m',
+            record: 'instance:node_cpu_utilisation:rate5m',
             expr: |||
               1 - avg without (cpu, mode) (
-                rate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode="idle"}[1m])
+                rate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode="idle"}[5m])
               )
             ||| % $._config,
           },
@@ -50,55 +50,55 @@
             ||| % $._config,
           },
           {
-            record: 'instance:node_vmstat_pgmajfault:rate1m',
+            record: 'instance:node_vmstat_pgmajfault:rate5m',
             expr: |||
-              rate(node_vmstat_pgmajfault{%(nodeExporterSelector)s}[1m])
+              rate(node_vmstat_pgmajfault{%(nodeExporterSelector)s}[5m])
             ||| % $._config,
           },
           {
             // Disk utilisation (seconds spent, 1 second rate).
-            record: 'instance_device:node_disk_io_time_seconds:rate1m',
+            record: 'instance_device:node_disk_io_time_seconds:rate5m',
             expr: |||
-              rate(node_disk_io_time_seconds_total{%(nodeExporterSelector)s, %(diskDeviceSelector)s}[1m])
+              rate(node_disk_io_time_seconds_total{%(nodeExporterSelector)s, %(diskDeviceSelector)s}[5m])
             ||| % $._config,
           },
           {
             // Disk saturation (weighted seconds spent, 1 second rate).
-            record: 'instance_device:node_disk_io_time_weighted_seconds:rate1m',
+            record: 'instance_device:node_disk_io_time_weighted_seconds:rate5m',
             expr: |||
-              rate(node_disk_io_time_weighted_seconds_total{%(nodeExporterSelector)s, %(diskDeviceSelector)s}[1m])
+              rate(node_disk_io_time_weighted_seconds_total{%(nodeExporterSelector)s, %(diskDeviceSelector)s}[5m])
             ||| % $._config,
           },
           {
-            record: 'instance:node_network_receive_bytes_excluding_lo:rate1m',
+            record: 'instance:node_network_receive_bytes_excluding_lo:rate5m',
             expr: |||
               sum without (device) (
-                rate(node_network_receive_bytes_total{%(nodeExporterSelector)s, device!="lo"}[1m])
+                rate(node_network_receive_bytes_total{%(nodeExporterSelector)s, device!="lo"}[5m])
               )
             ||| % $._config,
           },
           {
-            record: 'instance:node_network_transmit_bytes_excluding_lo:rate1m',
+            record: 'instance:node_network_transmit_bytes_excluding_lo:rate5m',
             expr: |||
               sum without (device) (
-                rate(node_network_transmit_bytes_total{%(nodeExporterSelector)s, device!="lo"}[1m])
+                rate(node_network_transmit_bytes_total{%(nodeExporterSelector)s, device!="lo"}[5m])
               )
             ||| % $._config,
           },
           // TODO: Find out if those drops ever happen on modern switched networks.
           {
-            record: 'instance:node_network_receive_drop_excluding_lo:rate1m',
+            record: 'instance:node_network_receive_drop_excluding_lo:rate5m',
             expr: |||
               sum without (device) (
-                rate(node_network_receive_drop_total{%(nodeExporterSelector)s, device!="lo"}[1m])
+                rate(node_network_receive_drop_total{%(nodeExporterSelector)s, device!="lo"}[5m])
               )
             ||| % $._config,
           },
           {
-            record: 'instance:node_network_transmit_drop_excluding_lo:rate1m',
+            record: 'instance:node_network_transmit_drop_excluding_lo:rate5m',
             expr: |||
               sum without (device) (
-                rate(node_network_transmit_drop_total{%(nodeExporterSelector)s, device!="lo"}[1m])
+                rate(node_network_transmit_drop_total{%(nodeExporterSelector)s, device!="lo"}[5m])
               )
             ||| % $._config,
           },


### PR DESCRIPTION
1m range limits usage of this mixin to environments where
scrape_interval is set to 15s or less. By extending this to 5m mixin
won't loose much value in regards to data, but it will be also more
usable in environments with less frequents scrapes. For example scrape
every 30s is fairly common practice, but data gathered from such
frequency cannot be used with this mixin.

/cc @beorn7

Signed-off-by: paulfantom <pawel@krupa.net.pl>