### PR TITLE
Wrap errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       image: ubuntu-1604:201903-01
 
     environment:
-      DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.11-base
+      DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.13-base
       REPO_PATH: github.com/prometheus/node_exporter
 
     steps:

--- a/collector/bcache_linux.go
+++ b/collector/bcache_linux.go
@@ -36,7 +36,7 @@ type bcacheCollector struct {
 func NewBcacheCollector() (Collector, error) {
 	fs, err := bcache.NewFS(*sysPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open sysfs: %v", err)
+		return nil, fmt.Errorf("failed to open sysfs: %w", err)
 	}
 
 	return &bcacheCollector{
@@ -49,7 +49,7 @@ func NewBcacheCollector() (Collector, error) {
 func (c *bcacheCollector) Update(ch chan<- prometheus.Metric) error {
 	stats, err := c.fs.Stats()
 	if err != nil {
-		return fmt.Errorf("failed to retrieve bcache stats: %v", err)
+		return fmt.Errorf("failed to retrieve bcache stats: %w", err)
 	}
 
 	for _, s := range stats {

--- a/collector/buddyinfo.go
+++ b/collector/buddyinfo.go
@@ -47,7 +47,7 @@ func NewBuddyinfoCollector() (Collector, error) {
 	)
 	fs, err := procfs.NewFS(*procPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open procfs: %v", err)
+		return nil, fmt.Errorf("failed to open procfs: %w", err)
 	}
 	return &buddyinfoCollector{fs, desc}, nil
 }

--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -47,7 +47,7 @@ func init() {
 func NewCPUCollector() (Collector, error) {
 	fs, err := procfs.NewFS(*procPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open procfs: %v", err)
+		return nil, fmt.Errorf("failed to open procfs: %w", err)
 	}
 	return &cpuCollector{
 		fs:  fs,

--- a/collector/cpufreq_linux.go
+++ b/collector/cpufreq_linux.go
@@ -40,7 +40,7 @@ func init() {
 func NewCPUFreqCollector() (Collector, error) {
 	fs, err := sysfs.NewFS(*sysPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open sysfs: %v", err)
+		return nil, fmt.Errorf("failed to open sysfs: %w", err)
 	}
 
 	return &cpuFreqCollector{

--- a/collector/infiniband_linux.go
+++ b/collector/infiniband_linux.go
@@ -40,7 +40,7 @@ func NewInfiniBandCollector() (Collector, error) {
 
 	i.fs, err = sysfs.NewFS(*sysPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open sysfs: %v", err)
+		return nil, fmt.Errorf("failed to open sysfs: %w", err)
 	}
 
 	// Detailed description for all metrics.

--- a/collector/ipvs_linux.go
+++ b/collector/ipvs_linux.go
@@ -59,7 +59,7 @@ func newIPVSCollector() (*ipvsCollector, error) {
 
 	c.fs, err = procfs.NewFS(*procPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open procfs: %v", err)
+		return nil, fmt.Errorf("failed to open procfs: %w", err)
 	}
 
 	c.connections = typedDesc{prometheus.NewDesc(

--- a/collector/mdadm_linux.go
+++ b/collector/mdadm_linux.go
@@ -94,7 +94,7 @@ func (c *mdadmCollector) Update(ch chan<- prometheus.Metric) error {
 	fs, errFs := procfs.NewFS(*procPath)
 
 	if errFs != nil {
-		return fmt.Errorf("failed to open procfs: %v", errFs)
+		return fmt.Errorf("failed to open procfs: %w", errFs)
 	}
 
 	mdStats, err := fs.MDStat()

--- a/collector/meminfo_openbsd.go
+++ b/collector/meminfo_openbsd.go
@@ -44,7 +44,7 @@ func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 	var uvmexp C.struct_uvmexp
 
 	if _, err := C.sysctl_uvmexp(&uvmexp); err != nil {
-		return nil, fmt.Errorf("sysctl CTL_VM VM_UVMEXP failed: %v", err)
+		return nil, fmt.Errorf("sysctl CTL_VM VM_UVMEXP failed: %w", err)
 	}
 
 	ps := float64(uvmexp.pagesize)

--- a/collector/mountstats_linux.go
+++ b/collector/mountstats_linux.go
@@ -108,12 +108,12 @@ func init() {
 func NewMountStatsCollector() (Collector, error) {
 	fs, err := procfs.NewFS(*procPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open procfs: %v", err)
+		return nil, fmt.Errorf("failed to open procfs: %w", err)
 	}
 
 	proc, err := fs.Self()
 	if err != nil {
-		return nil, fmt.Errorf("failed to open /proc/self: %v", err)
+		return nil, fmt.Errorf("failed to open /proc/self: %w", err)
 	}
 
 	const (
@@ -505,12 +505,12 @@ func NewMountStatsCollector() (Collector, error) {
 func (c *mountStatsCollector) Update(ch chan<- prometheus.Metric) error {
 	mounts, err := c.proc.MountStats()
 	if err != nil {
-		return fmt.Errorf("failed to parse mountstats: %v", err)
+		return fmt.Errorf("failed to parse mountstats: %w", err)
 	}
 
 	mountsInfo, err := c.proc.MountInfo()
 	if err != nil {
-		return fmt.Errorf("failed to parse mountinfo: %v", err)
+		return fmt.Errorf("failed to parse mountinfo: %w", err)
 	}
 
 	// store all seen nfsDeviceIdentifiers for deduplication

--- a/collector/netclass_linux.go
+++ b/collector/netclass_linux.go
@@ -44,7 +44,7 @@ func init() {
 func NewNetClassCollector() (Collector, error) {
 	fs, err := sysfs.NewFS(*sysPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open sysfs: %v", err)
+		return nil, fmt.Errorf("failed to open sysfs: %w", err)
 	}
 	pattern := regexp.MustCompile(*netclassIgnoredDevices)
 	return &netClassCollector{

--- a/collector/netdev_darwin.go
+++ b/collector/netdev_darwin.go
@@ -18,7 +18,7 @@ package collector
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
+	"fmt"
 	"net"
 	"regexp"
 	"strconv"
@@ -32,7 +32,7 @@ func getNetDevStats(ignore *regexp.Regexp, accept *regexp.Regexp) (map[string]ma
 
 	ifs, err := net.Interfaces()
 	if err != nil {
-		return nil, errors.New("net.Interfaces() failed")
+		return nil, fmt.Errorf("net.Interfaces() failed: %w", err)
 	}
 
 	for _, iface := range ifs {

--- a/collector/nfs_linux.go
+++ b/collector/nfs_linux.go
@@ -45,7 +45,7 @@ func init() {
 func NewNfsCollector() (Collector, error) {
 	fs, err := nfs.NewFS(*procPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open procfs: %v", err)
+		return nil, fmt.Errorf("failed to open procfs: %w", err)
 	}
 
 	return &nfsCollector{
@@ -96,7 +96,7 @@ func (c *nfsCollector) Update(ch chan<- prometheus.Metric) error {
 			log.Debugf("Not collecting NFS metrics: %s", err)
 			return nil
 		}
-		return fmt.Errorf("failed to retrieve nfs stats: %v", err)
+		return fmt.Errorf("failed to retrieve nfs stats: %w", err)
 	}
 
 	c.updateNFSNetworkStats(ch, &stats.Network)

--- a/collector/nfsd_linux.go
+++ b/collector/nfsd_linux.go
@@ -41,7 +41,7 @@ const (
 func NewNFSdCollector() (Collector, error) {
 	fs, err := nfs.NewFS(*procPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open procfs: %v", err)
+		return nil, fmt.Errorf("failed to open procfs: %w", err)
 	}
 
 	return &nfsdCollector{
@@ -62,7 +62,7 @@ func (c *nfsdCollector) Update(ch chan<- prometheus.Metric) error {
 			log.Debugf("Not collecting NFSd metrics: %s", err)
 			return nil
 		}
-		return fmt.Errorf("failed to retrieve nfsd stats: %v", err)
+		return fmt.Errorf("failed to retrieve nfsd stats: %w", err)
 	}
 
 	c.updateNFSdReplyCacheStats(ch, &stats.ReplyCache)

--- a/collector/pressure_linux.go
+++ b/collector/pressure_linux.go
@@ -45,7 +45,7 @@ func init() {
 func NewPressureStatsCollector() (Collector, error) {
 	fs, err := procfs.NewFS(*procPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open procfs: %v", err)
+		return nil, fmt.Errorf("failed to open procfs: %w", err)
 	}
 
 	return &pressureStatsCollector{

--- a/collector/processes_linux.go
+++ b/collector/processes_linux.go
@@ -41,7 +41,7 @@ func init() {
 func NewProcessStatCollector() (Collector, error) {
 	fs, err := procfs.NewFS(*procPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open procfs: %v", err)
+		return nil, fmt.Errorf("failed to open procfs: %w", err)
 	}
 	subsystem := "processes"
 	return &processCollector{

--- a/collector/schedstat_linux.go
+++ b/collector/schedstat_linux.go
@@ -49,7 +49,7 @@ var (
 func NewSchedstatCollector() (Collector, error) {
 	fs, err := procfs.NewFS(*procPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open procfs: %v", err)
+		return nil, fmt.Errorf("failed to open procfs: %w", err)
 	}
 
 	return &schedstatCollector{fs: fs}, nil

--- a/collector/sockstat_linux.go
+++ b/collector/sockstat_linux.go
@@ -45,7 +45,7 @@ func NewSockStatCollector() (Collector, error) {
 func (c *sockStatCollector) Update(ch chan<- prometheus.Metric) error {
 	fs, err := procfs.NewFS(*procPath)
 	if err != nil {
-		return fmt.Errorf("failed to open procfs: %v", err)
+		return fmt.Errorf("failed to open procfs: %w", err)
 	}
 
 	// If IPv4 and/or IPv6 are disabled on this kernel, handle it gracefully.
@@ -55,7 +55,7 @@ func (c *sockStatCollector) Update(ch chan<- prometheus.Metric) error {
 	case os.IsNotExist(err):
 		log.Debug("IPv4 sockstat statistics not found, skipping")
 	default:
-		return fmt.Errorf("failed to get IPv4 sockstat data: %v", err)
+		return fmt.Errorf("failed to get IPv4 sockstat data: %w", err)
 	}
 
 	stat6, err := fs.NetSockstat6()
@@ -64,7 +64,7 @@ func (c *sockStatCollector) Update(ch chan<- prometheus.Metric) error {
 	case os.IsNotExist(err):
 		log.Debug("IPv6 sockstat statistics not found, skipping")
 	default:
-		return fmt.Errorf("failed to get IPv6 sockstat data: %v", err)
+		return fmt.Errorf("failed to get IPv6 sockstat data: %w", err)
 	}
 
 	stats := []struct {

--- a/collector/stat_linux.go
+++ b/collector/stat_linux.go
@@ -41,7 +41,7 @@ func init() {
 func NewStatCollector() (Collector, error) {
 	fs, err := procfs.NewFS(*procPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open procfs: %v", err)
+		return nil, fmt.Errorf("failed to open procfs: %w", err)
 	}
 	return &statCollector{
 		fs: fs,

--- a/collector/thermal_zone_linux.go
+++ b/collector/thermal_zone_linux.go
@@ -40,7 +40,7 @@ func init() {
 func NewThermalZoneCollector() (Collector, error) {
 	fs, err := sysfs.NewFS(*sysPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open sysfs: %v", err)
+		return nil, fmt.Errorf("failed to open sysfs: %w", err)
 	}
 
 	return &thermalZoneCollector{

--- a/collector/timex.go
+++ b/collector/timex.go
@@ -160,7 +160,7 @@ func (c *timexCollector) Update(ch chan<- prometheus.Metric) error {
 
 	status, err := unix.Adjtimex(timex)
 	if err != nil {
-		return fmt.Errorf("failed to retrieve adjtimex stats: %v", err)
+		return fmt.Errorf("failed to retrieve adjtimex stats: %w", err)
 	}
 
 	if status == timeError {

--- a/collector/wifi_linux.go
+++ b/collector/wifi_linux.go
@@ -170,13 +170,13 @@ func (c *wifiCollector) Update(ch chan<- prometheus.Metric) error {
 			return nil
 		}
 
-		return fmt.Errorf("failed to access wifi data: %v", err)
+		return fmt.Errorf("failed to access wifi data: %w", err)
 	}
 	defer stat.Close()
 
 	ifis, err := stat.Interfaces()
 	if err != nil {
-		return fmt.Errorf("failed to retrieve wifi interfaces: %v", err)
+		return fmt.Errorf("failed to retrieve wifi interfaces: %w", err)
 	}
 
 	for _, ifi := range ifis {

--- a/collector/xfs_linux.go
+++ b/collector/xfs_linux.go
@@ -33,7 +33,7 @@ func init() {
 func NewXFSCollector() (Collector, error) {
 	fs, err := xfs.NewFS(*procPath, *sysPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open sysfs: %v", err)
+		return nil, fmt.Errorf("failed to open sysfs: %w", err)
 	}
 
 	return &xfsCollector{
@@ -45,7 +45,7 @@ func NewXFSCollector() (Collector, error) {
 func (c *xfsCollector) Update(ch chan<- prometheus.Metric) error {
 	stats, err := c.fs.SysStats()
 	if err != nil {
-		return fmt.Errorf("failed to retrieve XFS stats: %v", err)
+		return fmt.Errorf("failed to retrieve XFS stats: %w", err)
 	}
 
 	for _, s := range stats {


### PR DESCRIPTION
>  In Go 1.13, the fmt.Errorf function supports a new %w verb. When this verb is present, the error returned by fmt.Errorf will have an Unwrap method returning the argument of %w, which must be an error. In all other ways, %w is identical to %v.
https://blog.golang.org/go1.13-errors