### PR TITLE
Add NodeDiskSaturated alerting rule to node-mixin

### DIFF
--- a/docs/node-mixin/alerts/alerts.libsonnet
+++ b/docs/node-mixin/alerts/alerts.libsonnet
@@ -184,6 +184,20 @@
               description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} transmit errors in the last two minutes.',
             },
           },
+          {
+            alert: 'NodeDiskSaturated',
+            expr: |||
+              instance_device:node_disk_io_time_weighted_seconds:rate1m{%(diskAlertSelector)s} > 2
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Disk is saturated.',
+              description: '{{ $labels.instance }} disk {{ $labels.device }} weighted number of seconds spent doing I/Os is {{ printf "%d" $value }}.',
+            },
+          },
         ],
       },
     ],

--- a/docs/node-mixin/config.libsonnet
+++ b/docs/node-mixin/config.libsonnet
@@ -22,6 +22,10 @@
     // them here, e.g. 'device!="tmpfs"'.
     diskDeviceSelector: 'device!=""',
 
+    // Labels to add to disk alerts. For example, if you wanted to
+    // target only a specific device, you could use 'device="sda"`.
+    diskAlertSelector: '',
+
     // Some of the alerts are meant to fire if a critical failure of a
     // node is imminent (e.g. the disk is about to run full). In a
     // true “cloud native” setup, failures of a single node should be


### PR DESCRIPTION
The degree to which a disk has extra work it can't service. This value
should ideally not exceed 1. Beyond this value would indicate that work
is getting queued up. In cloud environments this is also likely to be
amplified by providers throttling operations if I/O exceeds allocated
IOPs.

'diskAlertSelector' added to support adjustment of alert scope.
    
Signed-off-by: trotttrotttrott <trott@odaacabeef.com>

~~By default this is only applied to "sda" devices as they're typically
the root volume of a Linux machine. Root volumes are targeted in
particular because often the cause for saturation is a single workload.
In a k8s context, this will likely cause issues for co-located
workloads. A common solution is to assign the saturating workload to a
PVC so its disk usage is isolated and the PVC disk can be tuned
accordingly.~~

~~Signed-off-by: trotttrotttrott <chris.trott@grafana.com>~~

@SuperQ @discordianfish wanted to put this out there as it's something I'm experimenting with alerting on. Seemed like it would be useful for other folks using the mixin.