### PR TITLE
Fixed inaccurate 'node_network_speed_bytes' when speeds are low

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [BUGFIX] Strip path.rootfs from mountpoint labels #1421
 * [BUGFIX] Fix empty string in path.rootfs #1464
 * [BUGFIX] Fix typo in cpufreq metric names #1510
+* [BUGFIX] Fix network speed math #1580
 
 ## 0.18.1 / 2019-06-04
 

--- a/collector/netclass_linux.go
+++ b/collector/netclass_linux.go
@@ -141,7 +141,7 @@ func (c *netClassCollector) Update(ch chan<- prometheus.Metric) error {
 		}
 
 		if ifaceInfo.Speed != nil {
-			speedBytes := int64(*ifaceInfo.Speed / 8 * 1000 * 1000)
+			speedBytes := int64(*ifaceInfo.Speed * 1000 * 1000 / 8)
 			pushMetric(ch, c.subsystem, "speed_bytes", speedBytes, ifaceInfo.Name, prometheus.GaugeValue)
 		}
 


### PR DESCRIPTION
Integer division and the order of operations when converting Mbps to Bps
results in a loss of accuracy if the interface speeds are set low.
e.g. 100 Mbps is reported as 12000000 Bps, should be 12500000
     10 Mbps is reported as 1000000 Bps, should be 1250000

@SuperQ @discordianfish
This issue may crop up in environments w/ legacy networking equipment (e.g. 10BASE-T or 10BASE-TX), or when explicitly setting interface speeds to something low that wasn't auto-negotiated.