### PR TITLE
Add unix socket support for supervisord collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [FEATURE] Add new thermal_zone collector #1425
 * [FEATURE] Add new cooling_device metrics to thermal zone collector #1445
 * [FEATURE] Add new softnet collector #1576
+* [FEATURE] Add unix socket support for supervisord collector #262
 * [ENHANCEMENT] Collect InfiniBand port state and physical state #1357
 * [ENHANCEMENT] Include additional XFS runtime statistics. #1423
 * [ENHANCEMENT] Report non-fatal collection errors in the exporter metric. #1439

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@
 * [FEATURE] Add new thermal_zone collector #1425
 * [FEATURE] Add new cooling_device metrics to thermal zone collector #1445
 * [FEATURE] Add new softnet collector #1576
-* [FEATURE] Add unix socket support for supervisord collector #262
 * [ENHANCEMENT] Collect InfiniBand port state and physical state #1357
 * [ENHANCEMENT] Include additional XFS runtime statistics. #1423
 * [ENHANCEMENT] Report non-fatal collection errors in the exporter metric. #1439
@@ -30,6 +29,7 @@
 * [ENHANCEMENT] Add check for systemd version before attempting to query certain metrics. #1413
 * [ENHANCEMENT] Add new counters for flush requests in Linux 5.5 #1548
 * [ENHANCEMENT] The sockstat collector now exposes IPv6 statistics in addition to the existing IPv4 support. #1552
+* [ENHANCEMENT] Add unix socket support for supervisord collector #262
 * [BUGFIX] Renamed label `state` to `name` on `node_systemd_service_restart_total`. #1393
 * [BUGFIX] Fix netdev nil reference on Darwin #1414
 * [BUGFIX] Strip path.rootfs from mountpoint labels #1421

--- a/collector/supervisord.go
+++ b/collector/supervisord.go
@@ -56,7 +56,7 @@ func NewSupervisordCollector(logger log.Logger) (Collector, error) {
 
 	if u, err := url.Parse(*supervisordURL); err == nil && u.Scheme == "unix" {
 		// Fake the URI scheme as http, since net/http.*Transport.roundTrip will complain
-		// about a non-http(s) transports
+		// about a non-http(s) transport.
 		xrpc = xmlrpc.NewClient("http://unix/RPC2")
 		xrpc.HttpClient.Transport = &http.Transport{
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {


### PR DESCRIPTION
For example:
  --collector.supervisord.url=unix:///var/run/supervisor.sock

Fixes prometheus/node_exporter#262

Signed-off-by: Paul Cameron <cameronpm@gmail.com>