### PR TITLE
Swap usage on darwin from sysctl vm.swapusage #1607

### DIFF
--- a/collector/meminfo_darwin.go
+++ b/collector/meminfo_darwin.go
@@ -16,6 +16,8 @@
 package collector
 
 // #include <mach/mach_host.h>
+// #include <sys/sysctl.h>
+// typedef struct xsw_usage xsw_usage_t;
 import "C"
 
 import (
@@ -43,6 +45,13 @@ func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	swapraw, err := unix.SysctlRaw("vm.swapusage")
+	if err != nil {
+		return nil, err
+	}
+	swap := (*C.xsw_usage_t)(unsafe.Pointer(&swapraw[0]))
+
 	// Syscall removes terminating NUL which we need to cast to uint64
 	total := binary.LittleEndian.Uint64([]byte(totalb + "\x00"))
 
@@ -59,5 +68,8 @@ func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 		"swapped_in_bytes_total":  ps * float64(vmstat.pageins),
 		"swapped_out_bytes_total": ps * float64(vmstat.pageouts),
 		"total_bytes":             float64(total),
+		"swap_used_bytes":         float64(swap.xsu_used),
+		"swap_free_bytes":         float64(swap.xsu_avail),
+		"swap_total_bytes":        float64(swap.xsu_total),
 	}, nil
 }


### PR DESCRIPTION
Exposing swap usage on MacOS.

node_memory_swap_used_bytes
node_memory_swap_free_bytes
node_memory_swap_total_bytes

Just made up the metric names following the lowercase notation of other darwin names, can change them if someone have better suggestions.

This is my first attempt to write anything in go, but the changes seems to work fine so would be nice to have this feature included in future releases.

