### PR TITLE
Enable golint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,10 @@
 run:
   modules-download-mode: vendor
 
+linters:
+  enable:
+  - golint
+
 issues:
   exclude-rules:
   - path: _test.go

--- a/https/tls_config_test.go
+++ b/https/tls_config_test.go
@@ -213,13 +213,13 @@ func TestConfigReloading(t *testing.T) {
 
 	err := TestClientConnection()
 	if err == nil {
-		recordConnectionError(errors.New("Connection accepted but should have failed."))
+		recordConnectionError(errors.New("connection accepted but should have failed"))
 	} else {
 		swapFileContents(goodYAMLPath, badYAMLPath)
 		defer swapFileContents(goodYAMLPath, badYAMLPath)
 		err = TestClientConnection()
 		if err != nil {
-			recordConnectionError(errors.New("Connection failed but should have been accepted."))
+			recordConnectionError(errors.New("connection failed but should have been accepted"))
 		} else {
 
 			recordConnectionError(nil)


### PR DESCRIPTION
* Enable golint in golangci-lint tests.
* Fix up minor linting issues.

Signed-off-by: Ben Kochie <superq@gmail.com>