### PR TITLE
Catch missing schedstat file

### DIFF
--- a/collector/schedstat_linux.go
+++ b/collector/schedstat_linux.go
@@ -15,8 +15,10 @@ package collector
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs"
 )
@@ -68,6 +70,10 @@ func init() {
 func (c *schedstatCollector) Update(ch chan<- prometheus.Metric) error {
 	stats, err := c.fs.Schedstat()
 	if err != nil {
+		if os.IsNotExist(err) {
+			level.Debug(c.logger).Log("msg", "schedstat file does not exist")
+			return ErrNoData
+		}
 		return err
 	}
 


### PR DESCRIPTION
Suppres error log noise if schedstat file doesn't exist.

Signed-off-by: Ben Kochie <superq@gmail.com>