### PR TITLE
collector/systemd: use regexp to extract systemd version

### DIFF
--- a/collector/systemd_linux.go
+++ b/collector/systemd_linux.go
@@ -469,7 +469,8 @@ func getSystemdVersion(logger log.Logger) int {
 		level.Warn(logger).Log("msg", "Unable to get systemd version property, defaulting to 0")
 		return 0
 	}
-	version = strings.Replace(version, "\"", "", 2)
+	re := regexp.MustCompile(`[0-9][0-9][0-9]`)
+	version = re.FindString(version)
 	v, err := strconv.Atoi(version)
 	if err != nil {
 		level.Warn(logger).Log("msg", "Got invalid systemd version", "version", version)


### PR DESCRIPTION
It should be backward compatible and work with version strings reported by systemd >=241.

Fixes #1646

Signed-off-by: paulfantom <pawel@krupa.net.pl>