### PR TITLE
Make TLSConfig constructor public

### DIFF
--- a/https/tls_config.go
+++ b/https/tls_config.go
@@ -35,7 +35,8 @@ type TLSStruct struct {
 	ClientCAs   string `yaml:"clientCAs"`
 }
 
-func getTLSConfig(configPath string) (*tls.Config, error) {
+// GetTLSConfig unmarshals TLS configuration at the given configPath and returns a *tls.Config.
+func GetTLSConfig(configPath string) (*tls.Config, error) {
 	content, err := ioutil.ReadFile(configPath)
 	if err != nil {
 		return nil, err
@@ -110,14 +111,14 @@ func Listen(server *http.Server, tlsConfigPath string) error {
 		return server.ListenAndServe()
 	}
 	var err error
-	server.TLSConfig, err = getTLSConfig(tlsConfigPath)
+	server.TLSConfig, err = GetTLSConfig(tlsConfigPath)
 	if err != nil {
 		return err
 	}
 	// Set the GetConfigForClient method of the HTTPS server so that the config
 	// and certs are reloaded on new connections.
 	server.TLSConfig.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
-		return getTLSConfig(tlsConfigPath)
+		return GetTLSConfig(tlsConfigPath)
 	}
 	return server.ListenAndServeTLS("", "")
 }


### PR DESCRIPTION
Signed-off-by: Dustin Hooten <dhooten@splunk.com>

This PR makes the TLSConfig constructor public so that we can vendor it into other prometheus repos to keep TLS configuration consistent.

Specifically, @sharadgaur and I plan to add a TLS option to Alertmanager's gossip protocol (continuing work on https://github.com/prometheus/alertmanager/pull/1819).

It has already been suggested in a comment on the above PR draft that this code should be used as part of that effort: https://github.com/prometheus/alertmanager/pull/1819#discussion_r270594077