### PR TITLE
Update systemd example readme file

### DIFF
--- a/examples/systemd/README.md
+++ b/examples/systemd/README.md
@@ -5,4 +5,5 @@ If you are using distribution packages or the copr repository, you don't need to
 The unit file in this directory is to be put into `/etc/systemd/system`.
 It needs a user named `node_exporter`, whose shell should be `/sbin/nologin` and should not have any special privileges.
 It needs a sysconfig file in `/etc/sysconfig/node_exporter`.
+It needs a directory named `/var/lib/node_exporter/textfile_collector`, whose owner should be `node_exporter`:`node_exporter`.
 A sample file can be found in `sysconfig.node_exporter`.


### PR DESCRIPTION
The readme file does not mention the need to create a folder named
/var/lib/node_exporter/textfile_collector as a step. Lack of this
folder results errors for node_exporter service which is visible
in systemd status output. These errors possibly harmless but it is
not good to have them still.

$ sudo systemctl status node_exporter
--- snipped ---
Apr 04 14:51:35 ubuntu node_exporter[14713]: level=info ts=2020-04-04T14:51:35.584Z caller=node_exporter.go:190 msg="Listening on" address=:9100
Apr 04 15:05:34 ubuntu node_exporter[14876]: level=error ts=2020-04-04T15:05:34.464Z caller=textfile.go:197 collector=textfile msg="failed to read textfile collector directory" path=/var/lib/node_exporter/textfile_collector=textfile msg="failed to read textfile collector directory" path=/var/lib/node_exporter/textfile_collector err="open /var/lib/node_exporter/textfile_collector: no such file or directory"
--- snipped ---