### PR TITLE
Fix accidently empty lines in meminfo_linux

### DIFF
--- a/collector/meminfo_linux.go
+++ b/collector/meminfo_linux.go
@@ -45,6 +45,9 @@ func parseMemInfo(r io.Reader) (map[string]float64, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		parts := strings.Fields(line)
+		if len(parts) == 0 {
+			continue
+		}
 		fv, err := strconv.ParseFloat(parts[1], 64)
 		if err != nil {
 			return nil, fmt.Errorf("invalid value in meminfo: %s", err)

--- a/collector/meminfo_linux.go
+++ b/collector/meminfo_linux.go
@@ -45,6 +45,7 @@ func parseMemInfo(r io.Reader) (map[string]float64, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		parts := strings.Fields(line)
+		// Workaround for empty lines occasionally occur in CentOS 6.2 kernel 3.10.90.
 		if len(parts) == 0 {
 			continue
 		}


### PR DESCRIPTION
In CentOS Linux release 6.2 (Final), kernel 3.10.90, node exporter would come across the following error:
```
panic: runtime error: index out of range [1] with length 1

goroutine 1548 [running]:
github.com/prometheus/node_exporter/collector.parseMemInfo(0xbbd920, 0xc0000f4fc8, 0x0, 0xc000000000, 0xc0000f4fc8)
        /Users/alpaca/Projects/prom-agent/vendor/github.com/prometheus/node_exporter/collector/meminfo_linux.go:50 +0x4d6
```

it is caused by empty lines read from /proc/meminfo. No idea why but there is a quick fix.
```
2020/04/10 09:52:49 !!!! DirectMap4k:      585388 kB
2020/04/10 09:52:49 !!!! DirectMap2M:    80119808 kB
2020/04/10 09:52:49 !!!! DirectMap1G:    53477376 kB
2020/04/10 09:52:49 !!!! 
panic: runtime error: index out of range [1] with length 1
```