### PR TITLE
Allow mountstats to work when non-NFS mounts produce errors

### DIFF
--- a/collector/mountstats_linux.go
+++ b/collector/mountstats_linux.go
@@ -514,7 +514,7 @@ func (c *mountStatsCollector) Update(ch chan<- prometheus.Metric) error {
 
 	mountsInfo, err := c.proc.MountInfo()
 	if err != nil {
-		return fmt.Errorf("failed to parse mountinfo: %w", err)
+		level.Warn(c.logger).Log("msg", "failed to parse mountinfo", "err", err)
 	}
 
 	// store all seen nfsDeviceIdentifiers for deduplication


### PR DESCRIPTION
I don't know if this is the right solution but this is error I was getting:

```
2020-04-10T10:01:20.643499-04:00 o0364 node_exporter: level=error ts=2020-04-10T14:01:20.642Z caller=collector.go:161 msg="collector failed" name=mountstats duration_seconds=0.005555337 err="failed to parse mountinfo: couldn't find enough fields in mount string: 108 53 0:34 / /var/lib/nfs/rpc_pipefs rw,relatime - rpc_pipefs sunrpc rw"
```

The majority of my NFS clients failed to produce mountstats metrics because of what procfs considered malformed mounts. I looked at procfs mountinfo and couldn't see of a good way to fix this issue there.

This issue was encountered using this version:

```
 node_exporter --version
node_exporter, version 1.0.0-rc.0 (branch: master, revision: a57f2465794ec60c40674706acc6c2ace12c1358)
  build user:       tdockendorf@pitzer-rw02.OMIT
  build date:       20200327-18:45:58
  go version:       go1.13.8
```