### PR TITLE
Add support for connecting to user systemd instance.

### DIFF
--- a/collector/systemd_linux.go
+++ b/collector/systemd_linux.go
@@ -42,6 +42,7 @@ var (
 	unitWhitelist          = kingpin.Flag("collector.systemd.unit-whitelist", "Regexp of systemd units to whitelist. Units must both match whitelist and not match blacklist to be included.").Default(".+").String()
 	unitBlacklist          = kingpin.Flag("collector.systemd.unit-blacklist", "Regexp of systemd units to blacklist. Units must both match whitelist and not match blacklist to be included.").Default(".+\\.(automount|device|mount|scope|slice)").String()
 	systemdPrivate         = kingpin.Flag("collector.systemd.private", "Establish a private, direct connection to systemd without dbus (Strongly discouraged since it requires root. For testing purposes only).").Hidden().Bool()
+	systemdUser            = kingpin.Flag("collector.systemd.user", "Connect to the user systemd instance.").Bool()
 	enableTaskMetrics      = kingpin.Flag("collector.systemd.enable-task-metrics", "Enables service unit tasks metrics unit_tasks_current and unit_tasks_max").Bool()
 	enableRestartsMetrics  = kingpin.Flag("collector.systemd.enable-restarts-metrics", "Enables service unit metric service_restart_total").Bool()
 	enableStartTimeMetrics = kingpin.Flag("collector.systemd.enable-start-time-metrics", "Enables service unit metric unit_start_time_seconds").Bool()
@@ -404,6 +405,9 @@ func (c *systemdCollector) collectSystemState(conn *dbus.Conn, ch chan<- prometh
 func newSystemdDbusConn() (*dbus.Conn, error) {
 	if *systemdPrivate {
 		return dbus.NewSystemdConnection()
+	}
+	if *systemdUser {
+		return dbus.NewUserConnection()
 	}
 	return dbus.New()
 }

--- a/examples/systemd/README.md
+++ b/examples/systemd/README.md
@@ -7,3 +7,13 @@ It needs a user named `node_exporter`, whose shell should be `/sbin/nologin` and
 It needs a sysconfig file in `/etc/sysconfig/node_exporter`.
 It needs a directory named `/var/lib/node_exporter/textfile_collector`, whose owner should be `node_exporter`:`node_exporter`.
 A sample file can be found in `sysconfig.node_exporter`.
+
+# Systemd User Unit
+
+An example configuration file for running node_exporter as a user and connecting to the user systemd instance is given in `user/node_exporter.service`. To use it, copy the file to one of the user unit search paths, for example `/usr/lib/systemd/user` or  `~/.config/systemd/user`.
+
+Edit the line `ExecStart` and add any additional options.
+
+On Debian based systems, install the `dbus-user-session` package for headless systems or `dbus-x11` for desktop systems.
+
+Reload the systemd configuration `systemctl --user daemon-reload`, enable the unit `systemctl --user enable node_exporter` and start it `systemctl --user start node_exporter`.

--- a/examples/systemd/user/node_exporter.service
+++ b/examples/systemd/user/node_exporter.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=User Node Exporter
+After=dbus.socket
+Requires=dbus.socket
+
+[Service]
+ExecStart=/usr/sbin/node_exporter --collector.systemd --collector.systemd.user
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Add support for the systemd collector to connect to the user systemd instance. This is useful if one wants to monitor the user instead of the system processes. This is done with a new command line option --collector.systemd.user.