### PR TITLE
Expose the function to generate tls.Config

### DIFF
--- a/https/tls_config.go
+++ b/https/tls_config.go
@@ -45,10 +45,11 @@ func getTLSConfig(configPath string) (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	return configToTLSConfig(&c.TLSConfig)
+	return ConfigToTLSConfig(&c.TLSConfig)
 }
 
-func configToTLSConfig(c *TLSStruct) (*tls.Config, error) {
+// ConfigToTLSConfig generates the golang tls.Config from the TLSStruct config.
+func ConfigToTLSConfig(c *TLSStruct) (*tls.Config, error) {
 	cfg := &tls.Config{}
 	if len(c.TLSCertPath) == 0 {
 		return nil, errors.New("missing TLSCertPath")


### PR DESCRIPTION
We're looking to reuse this in Cortex to client side encrypt our
connections and not having this exposed is making us copy this entire
function.

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>