### PR TITLE
Revert "Expose the function to generate tls.Config"

### DIFF
--- a/https/tls_config.go
+++ b/https/tls_config.go
@@ -45,11 +45,10 @@ func getTLSConfig(configPath string) (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ConfigToTLSConfig(&c.TLSConfig)
+	return configToTLSConfig(&c.TLSConfig)
 }
 
-// ConfigToTLSConfig generates the golang tls.Config from the TLSStruct config.
-func ConfigToTLSConfig(c *TLSStruct) (*tls.Config, error) {
+func configToTLSConfig(c *TLSStruct) (*tls.Config, error) {
 	cfg := &tls.Config{}
 	if len(c.TLSCertPath) == 0 {
 		return nil, errors.New("missing TLSCertPath")


### PR DESCRIPTION
Reverts prometheus/node_exporter#1677

There is active disagreement about the PR from a prometheus-team member and having this merged in would be violating the governance (we don't have consensus for this technical change). I would rather wait a week and get consensus than merge it in with disagreement.

I agree that this process can get frustrating, but I would rather if we followed our governance.