### PR TITLE
Add init.d script for OpenWrt.

### DIFF
--- a/examples/openwrt-init.d/node_exporter
+++ b/examples/openwrt-init.d/node_exporter
@@ -1,0 +1,13 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+
+USE_PROCD=1
+PROG="/usr/bin/node_exporter"
+OPTIONS="--web.listen-address=:9100"
+
+start_service() {
+	procd_open_instance
+	procd_set_param command "$PROG" "${OPTIONS}"
+	procd_close_instance
+}


### PR DESCRIPTION
MBOI - OpenWrt seems to use a lua script to 'fake' node_exporter; I thought why not run the full node exporter.  They have a 'different' init.d script system to the usual, but very little is needed.

Signed-off-by: Tom Wilkie <tom@grafana.com>