### PR TITLE
TLS: only support TLS 1.2 / 1.3

### DIFF
--- a/https/README.md
+++ b/https/README.md
@@ -1,7 +1,10 @@
 # HTTPS Package for Prometheus
 
-The `https` directory contains a Go package and a sample configuration file for running `node_exporter` with HTTPS instead of HTTP.
-When running a server with TLS use the flag `--web.config`
+The `https` directory contains a Go package and a sample configuration file for
+running `node_exporter` with HTTPS instead of HTTP. We currently support TLS 1.3
+and TLS 1.2.
+
+To run a server with TLS, use the flag `--web.config`.
 
 e.g. `./node_exporter --web.config="web-config.yml"`
 If the config is kept within the https directory.

--- a/https/tls_config.go
+++ b/https/tls_config.go
@@ -50,7 +50,9 @@ func getTLSConfig(configPath string) (*tls.Config, error) {
 
 // ConfigToTLSConfig generates the golang tls.Config from the TLSStruct config.
 func ConfigToTLSConfig(c *TLSStruct) (*tls.Config, error) {
-	cfg := &tls.Config{}
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 	if len(c.TLSCertPath) == 0 {
 		return nil, errors.New("missing TLSCertPath")
 	}


### PR DESCRIPTION
TLS 1.0 and 1.1 are considered unsecure, while TLS 1.2 would imply that
we add more configuration variables, e.g. to pick cipher suites. TLS1.3
means that cipher suites are not configurable anyway.

Last releases of Prometheus support TLS 1.3 (since Prometheus 2.13).

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>