### PR TITLE
Move regexp to global in meminfo_linux.go

### DIFF
--- a/collector/meminfo_linux.go
+++ b/collector/meminfo_linux.go
@@ -25,6 +25,10 @@ import (
 	"strings"
 )
 
+var (
+	reParens = regexp.MustCompile(`\((.*)\)`)
+)
+
 func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 	file, err := os.Open(procFilePath("meminfo"))
 	if err != nil {
@@ -39,7 +43,6 @@ func parseMemInfo(r io.Reader) (map[string]float64, error) {
 	var (
 		memInfo = map[string]float64{}
 		scanner = bufio.NewScanner(r)
-		re      = regexp.MustCompile(`\((.*)\)`)
 	)
 
 	for scanner.Scan() {
@@ -55,7 +58,7 @@ func parseMemInfo(r io.Reader) (map[string]float64, error) {
 		}
 		key := parts[0][:len(parts[0])-1] // remove trailing : from key
 		// Active(anon) -> Active_anon
-		key = re.ReplaceAllString(key, "_${1}")
+		key = reParens.ReplaceAllString(key, "_${1}")
 		switch len(parts) {
 		case 2: // no unit
 		case 3: // has unit, we presume kB


### PR DESCRIPTION
Compile regexp outside of parsing function in meminfo_linux.go