### PR TITLE
append test around same metrics name for multiple textfile

### DIFF
--- a/collector/fixtures/textfile/two_metric_files.out
+++ b/collector/fixtures/textfile/two_metric_files.out
@@ -17,3 +17,7 @@ testmetric2_1{foo="bar"} 30
 # HELP testmetric2_2 Metric read from fixtures/textfile/two_metric_files/metrics2.prom
 # TYPE testmetric2_2 untyped
 testmetric2_2{foo="baz"} 40
+# HELP testmetric_samename common metric name
+# TYPE testmetric_samename untyped
+testmetric_samename{foo="1"} 100
+testmetric_samename{foo="2"} 200

--- a/collector/fixtures/textfile/two_metric_files/metrics1.prom
+++ b/collector/fixtures/textfile/two_metric_files/metrics1.prom
@@ -1,2 +1,4 @@
 testmetric1_1{foo="bar"} 10
 testmetric1_2{foo="baz"} 20
+# HELP testmetric_samename common metric name
+testmetric_samename{foo="1"} 100

--- a/collector/fixtures/textfile/two_metric_files/metrics2.prom
+++ b/collector/fixtures/textfile/two_metric_files/metrics2.prom
@@ -1,2 +1,4 @@
 testmetric2_1{foo="bar"} 30
 testmetric2_2{foo="baz"} 40
+# HELP testmetric_samename common metric name
+testmetric_samename{foo="2"} 200


### PR DESCRIPTION
The textfile collector behaves a bit oddly when multiple files have the same metric name.

This is because the automatically generated HELP contains the file name. Metrics that are not the same HELP will result in an error. As a result, if no HELP is explicitly stated, only one of the metrics from multiple files will be output.

If possible, it would be desirable not to include the file in the automatic generation result of HELP, or to make it explicit. I think including this PR would also help users.