### PR TITLE
filesystem_freebsd: Fix label values

### DIFF
--- a/collector/filesystem_freebsd.go
+++ b/collector/filesystem_freebsd.go
@@ -16,8 +16,6 @@
 package collector
 
 import (
-	"bytes"
-
 	"github.com/go-kit/kit/log/level"
 	"golang.org/x/sys/unix"
 )
@@ -42,19 +40,14 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 	}
 	stats := []filesystemStats{}
 	for _, fs := range buf {
-		// We need to work out the lengths of the actual strings here,
-		// otherwuse we will end up with null bytes in our label values.
-		mountpoint_len := bytes.Index(fs.Mntonname[:], []byte{0})
-		mountpoint := string(fs.Mntonname[:mountpoint_len])
+		mountpoint := bytesToString(fs.Mntonname[:])
 		if c.ignoredMountPointsPattern.MatchString(mountpoint) {
 			level.Debug(c.logger).Log("msg", "Ignoring mount point", "mountpoint", mountpoint)
 			continue
 		}
 
-		device_len := bytes.Index(fs.Mntfromname[:], []byte{0})
-		fstype_len := bytes.Index(fs.Fstypename[:], []byte{0})
-		device := string(fs.Mntfromname[:device_len])
-		fstype := string(fs.Fstypename[:fstype_len])
+		device := bytesToString(fs.Mntfromname[:])
+		fstype := bytesToString(fs.Fstypename[:])
 		if c.ignoredFSTypesPattern.MatchString(fstype) {
 			level.Debug(c.logger).Log("msg", "Ignoring fs type", "type", fstype)
 			continue

--- a/collector/helper.go
+++ b/collector/helper.go
@@ -14,6 +14,7 @@
 package collector
 
 import (
+	"bytes"
 	"io/ioutil"
 	"strconv"
 	"strings"
@@ -29,4 +30,17 @@ func readUintFromFile(path string) (uint64, error) {
 		return 0, err
 	}
 	return value, nil
+}
+
+// Take a []byte{} and return a string based on null termination.
+// This is useful for situations where the OS has returned a null terminated
+// string to use.
+// If this function happens to receive a byteArray that contains no nulls, we
+// simply convert the array to a string with no bounding.
+func bytesToString(byteArray []byte) string {
+	n := bytes.IndexByte(byteArray, 0)
+	if n < 0 {
+		return string(byteArray)
+	}
+	return string(byteArray[:n])
 }

--- a/collector/helper_test.go
+++ b/collector/helper_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Prometheus Authors
+// Copyright 2020 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/collector/helper_test.go
+++ b/collector/helper_test.go
@@ -1,0 +1,63 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+)
+
+func TestBytesToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		b        []byte
+		expected string
+	}{
+		{
+			"Single null byte",
+			[]byte{0},
+			"",
+		},
+		{
+			"Empty byte array",
+			[]byte{},
+			"",
+		},
+		{
+			"Not null terminated",
+			[]byte{65, 66, 67},
+			"ABC",
+		},
+		{
+			"Null randomly in array",
+			[]byte{65, 66, 67, 0, 65, 0, 65},
+			"ABC",
+		},
+		{
+			"Array starts with null and contains other valid bytes",
+			[]byte{0, 65, 66, 67, 0},
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		name := tt.name
+		b := tt.b
+		result := bytesToString(b)
+		expected := tt.expected
+
+		if result != expected {
+			t.Errorf("bytesToString(%#v): Name: %s, expected %#v, got %#v)", b, name, expected, result)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1727 

We must know the length of the various filesystem C strings before
turning them from a byte array into a Go string, otherwise our Go
strings could contain null bytes, corrupting the label values.