### PR TITLE
Fix and simplify checkmetrics make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DOCKER_ARCHS ?= amd64 armv7 arm64 ppc64le s390x
 
 include Makefile.common
 
-PROMTOOL_VERSION ?= 2.5.0
+PROMTOOL_VERSION ?= 2.18.1
 PROMTOOL_URL     ?= https://github.com/prometheus/prometheus/releases/download/v$(PROMTOOL_VERSION)/prometheus-$(PROMTOOL_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 PROMTOOL         ?= $(FIRST_GOPATH)/bin/promtool
 
@@ -129,9 +129,5 @@ test-docker:
 promtool: $(PROMTOOL)
 
 $(PROMTOOL):
-	$(eval PROMTOOL_TMP := $(shell mktemp -d))
-	curl -s -L $(PROMTOOL_URL) | tar -xvzf - -C $(PROMTOOL_TMP)
 	mkdir -p $(FIRST_GOPATH)/bin
-	cp $(PROMTOOL_TMP)/prometheus-$(PROMTOOL_VERSION).$(GO_BUILD_PLATFORM)/promtool $(FIRST_GOPATH)/bin/promtool
-	rm -r $(PROMTOOL_TMP)
-
+	curl -fsS -L $(PROMTOOL_URL) | tar -xvzf - -C $(FIRST_GOPATH)/bin --no-anchored --strip 1 promtool

--- a/checkmetrics.sh
+++ b/checkmetrics.sh
@@ -5,12 +5,10 @@ if [[ ( -z "$1" ) || ( -z "$2" ) ]]; then
     exit 1
 fi
 
-# Only check node_exporter's metrics, as the Prometheus Go client currently
-# exposes a metric with a unit of microseconds.  Once that is fixed, remove
-# this filter.
-lint=$($1 check metrics < $2 2>&1 | grep "node_")
+# Ignore known issues in auto-generated and network specific collectors.
+lint=$($1 check metrics < "$2" 2>&1 | grep -v -E "^node_(entropy|memory|netstat|wifi_station)_")
 
-if [[ ! -z $lint ]]; then
+if [[ -n $lint ]]; then
     echo -e "Some Prometheus metrics do not follow best practices:\n"
     echo "$lint"
 


### PR DESCRIPTION
The checkmetrics target currently uses promtool v2.5.0 which doesn't
include many improvements done over the time. This change also
simplifies the promtool installation, avoiding a temporary directory by
extracting the file directly to the target destination.