### PR TITLE
Adapt https/web-config.yml

### DIFF
--- a/https/web-config.yml
+++ b/https/web-config.yml
@@ -1,11 +1,6 @@
-tls_config:
-  # Certificate and key files for server to use to authenticate to client
-  cert_file: <filename>
-  key_file: <filename>
+# Minimal TLS configuration example. Additionally, a certificate and a key file
+# are needed.
+tls_server_config:
+  cert_file: server.crt
+  key_file: server.key
 
-  # Server policy for client authentication. Maps to ClientAuth Policies
-  # For more detail on clientAuth options: [ClientAuthType](https://golang.org/pkg/crypto/tls/#ClientAuthType)
-  [ client_auth_type: <string> | default = "NoClientCert" ]
-
-  # CA certificate for client certificate authentication to the server
-  [ client_ca_file: <filename> ]


### PR DESCRIPTION
Currently web-config is not a valid yaml and is an incomplete reference.

Keep the reference in README.md and create a minimalist web-config.yml
that acts as an exemple.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>