### PR TITLE
Fix build tags for collectors

### DIFF
--- a/collector/drbd_linux.go
+++ b/collector/drbd_linux.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !nodrbd
+
 package collector
 
 import (

--- a/collector/filesystem_linux_test.go
+++ b/collector/filesystem_linux_test.go
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !nofilesystem
-
 package collector
 
 import (

--- a/collector/kvm_bsd.go
+++ b/collector/kvm_bsd.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !nomeminfo
+// +build !nokvm
 // +build freebsd dragonfly
 
 package collector

--- a/collector/mountstats_linux.go
+++ b/collector/mountstats_linux.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !nomountstats
+
 package collector
 
 import (

--- a/collector/nfs_linux.go
+++ b/collector/nfs_linux.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !nonfs
+
 package collector
 
 import (

--- a/collector/nfsd_linux.go
+++ b/collector/nfsd_linux.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !nonfsd
+
 package collector
 
 import (

--- a/collector/perf_linux.go
+++ b/collector/perf_linux.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !noperf
+
 package collector
 
 import (

--- a/collector/schedstat_linux.go
+++ b/collector/schedstat_linux.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !noshedstat
+
 package collector
 
 import (

--- a/collector/sysctl_bsd.go
+++ b/collector/sysctl_bsd.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // +build freebsd dragonfly openbsd netbsd darwin
-// +build !nomeminfo
+// +build cgo
 
 package collector
 

--- a/collector/wifi_linux.go
+++ b/collector/wifi_linux.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !nowifi
+
 package collector
 
 import (

--- a/collector/xfs_linux.go
+++ b/collector/xfs_linux.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !noxfs
+
 package collector
 
 import (

--- a/collector/zfs_freebsd.go
+++ b/collector/zfs_freebsd.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !nozfs
+
 package collector
 
 import (

--- a/collector/zfs_linux.go
+++ b/collector/zfs_linux.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !nozfs
+
 package collector
 
 import (

--- a/collector/zfs_solaris.go
+++ b/collector/zfs_solaris.go
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 // +build solaris
+// +build !nozfs
 
 package collector
 


### PR DESCRIPTION
Existing build tags for collectors seems out of sync, and when I try to build for `freebsd` with build tag `noboottime noexec nomeminfo nonetdev nozfs nofilesystem` just fails with:

```txt
github.com/prometheus/node_exporter/collector/zfs_freebsd.go:24:12: undefined: bsdSysctl
github.com/prometheus/node_exporter/collector/zfs_freebsd.go:38:14: undefined: bsdSysctl
```

which is not the expected behavior I suppose, because zfs was included even with `nozfs` tag.

This PR is an attempt to fix collectors' build tags, and once merged, users should be able to build with/without specific collectors with correct build tags.

/cc @SuperQ @discordianfish 
