### PR TITLE
Handle no data from powersupplyclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * [CHANGE]
 * [FEATURE]
 * [ENHANCEMENT]
-* [BUGFIX]
+* [BUGFIX] Handle no data from powersupplyclass
 
 ## 1.0.0 / 2020-05-25
 

--- a/collector/powersupplyclass.go
+++ b/collector/powersupplyclass.go
@@ -18,6 +18,7 @@ package collector
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 
 	"github.com/go-kit/kit/log"
@@ -54,6 +55,9 @@ func NewPowerSupplyClassCollector(logger log.Logger) (Collector, error) {
 func (c *powerSupplyClassCollector) Update(ch chan<- prometheus.Metric) error {
 	powerSupplyClass, err := getPowerSupplyClassInfo(c.ignoredPattern)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return ErrNoData
+		}
 		return fmt.Errorf("could not get power_supply class info: %s", err)
 	}
 	for _, powerSupply := range powerSupplyClass {


### PR DESCRIPTION
Handle the case when /sys/class/power_supply doesn't exist. Fixes
logging error spam.

Requires https://github.com/prometheus/procfs/pull/308

Signed-off-by: Ben Kochie <superq@gmail.com>