### PR TITLE
Fix up powersupplyclass error

### DIFF
--- a/collector/powersupplyclass.go
+++ b/collector/powersupplyclass.go
@@ -17,6 +17,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -55,7 +56,7 @@ func NewPowerSupplyClassCollector(logger log.Logger) (Collector, error) {
 func (c *powerSupplyClassCollector) Update(ch chan<- prometheus.Metric) error {
 	powerSupplyClass, err := getPowerSupplyClassInfo(c.ignoredPattern)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return ErrNoData
 		}
 		return fmt.Errorf("could not get power_supply class info: %s", err)
@@ -188,7 +189,7 @@ func getPowerSupplyClassInfo(ignore *regexp.Regexp) (sysfs.PowerSupplyClass, err
 	powerSupplyClass, err := fs.PowerSupplyClass()
 
 	if err != nil {
-		return powerSupplyClass, fmt.Errorf("error obtaining power_supply class info: %s", err)
+		return powerSupplyClass, fmt.Errorf("error obtaining power_supply class info: %w", err)
 	}
 
 	for device := range powerSupplyClass {


### PR DESCRIPTION
* Remove internal wrapping of PowerSupplyClass error.
* Switch to errors.Is().

Signed-off-by: Ben Kochie <superq@gmail.com>