### PR TITLE
Use Go 1.13 error features

### DIFF
--- a/collector/arp_linux.go
+++ b/collector/arp_linux.go
@@ -84,7 +84,7 @@ func parseARPEntries(data io.Reader) (map[string]uint32, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("failed to parse ARP info: %s", err)
+		return nil, fmt.Errorf("failed to parse ARP info: %w", err)
 	}
 
 	return entries, nil
@@ -93,7 +93,7 @@ func parseARPEntries(data io.Reader) (map[string]uint32, error) {
 func (c *arpCollector) Update(ch chan<- prometheus.Metric) error {
 	entries, err := getARPEntries()
 	if err != nil {
-		return fmt.Errorf("could not get ARP entries: %s", err)
+		return fmt.Errorf("could not get ARP entries: %w", err)
 	}
 
 	for device, entryCount := range entries {

--- a/collector/bonding_linux.go
+++ b/collector/bonding_linux.go
@@ -16,6 +16,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -59,7 +60,7 @@ func (c *bondingCollector) Update(ch chan<- prometheus.Metric) error {
 	statusfile := sysFilePath("class/net")
 	bondingStats, err := readBondingStats(statusfile)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			level.Debug(c.logger).Log("msg", "Not collecting bonding, file does not exist", "file", statusfile)
 			return ErrNoData
 		}
@@ -86,7 +87,7 @@ func readBondingStats(root string) (status map[string][2]int, err error) {
 		sstat := [2]int{0, 0}
 		for _, slave := range strings.Fields(string(slaves)) {
 			state, err := ioutil.ReadFile(filepath.Join(root, master, fmt.Sprintf("lower_%s", slave), "bonding_slave", "mii_status"))
-			if os.IsNotExist(err) {
+			if errors.Is(err, os.ErrNotExist) {
 				// some older? kernels use slave_ prefix
 				state, err = ioutil.ReadFile(filepath.Join(root, master, fmt.Sprintf("slave_%s", slave), "bonding_slave", "mii_status"))
 			}

--- a/collector/btrfs_linux.go
+++ b/collector/btrfs_linux.go
@@ -37,7 +37,7 @@ func init() {
 func NewBtrfsCollector(logger log.Logger) (Collector, error) {
 	fs, err := btrfs.NewFS(*sysPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open sysfs: %v", err)
+		return nil, fmt.Errorf("failed to open sysfs: %w", err)
 	}
 
 	return &btrfsCollector{
@@ -51,7 +51,7 @@ func NewBtrfsCollector(logger log.Logger) (Collector, error) {
 func (c *btrfsCollector) Update(ch chan<- prometheus.Metric) error {
 	stats, err := c.fs.Stats()
 	if err != nil {
-		return fmt.Errorf("failed to retrieve Btrfs stats: %v", err)
+		return fmt.Errorf("failed to retrieve Btrfs stats: %w", err)
 	}
 
 	for _, s := range stats {

--- a/collector/buddyinfo.go
+++ b/collector/buddyinfo.go
@@ -59,7 +59,7 @@ func NewBuddyinfoCollector(logger log.Logger) (Collector, error) {
 func (c *buddyinfoCollector) Update(ch chan<- prometheus.Metric) error {
 	buddyInfo, err := c.fs.BuddyInfo()
 	if err != nil {
-		return fmt.Errorf("couldn't get buddyinfo: %s", err)
+		return fmt.Errorf("couldn't get buddyinfo: %w", err)
 	}
 
 	level.Debug(c.logger).Log("msg", "Set node_buddy", "buddyInfo", buddyInfo)

--- a/collector/diskstats_darwin.go
+++ b/collector/diskstats_darwin.go
@@ -189,7 +189,7 @@ func NewDiskstatsCollector(logger log.Logger) (Collector, error) {
 func (c *diskstatsCollector) Update(ch chan<- prometheus.Metric) error {
 	diskStats, err := iostat.ReadDriveStats()
 	if err != nil {
-		return fmt.Errorf("couldn't get diskstats: %s", err)
+		return fmt.Errorf("couldn't get diskstats: %w", err)
 	}
 
 	for _, stats := range diskStats {

--- a/collector/diskstats_linux.go
+++ b/collector/diskstats_linux.go
@@ -187,7 +187,7 @@ func NewDiskstatsCollector(logger log.Logger) (Collector, error) {
 func (c *diskstatsCollector) Update(ch chan<- prometheus.Metric) error {
 	diskStats, err := getDiskStats()
 	if err != nil {
-		return fmt.Errorf("couldn't get diskstats: %s", err)
+		return fmt.Errorf("couldn't get diskstats: %w", err)
 	}
 
 	for dev, stats := range diskStats {
@@ -203,7 +203,7 @@ func (c *diskstatsCollector) Update(ch chan<- prometheus.Metric) error {
 			}
 			v, err := strconv.ParseFloat(value, 64)
 			if err != nil {
-				return fmt.Errorf("invalid value %s in diskstats: %s", value, err)
+				return fmt.Errorf("invalid value %s in diskstats: %w", value, err)
 			}
 			ch <- c.descs[i].mustNewConstMetric(v, dev)
 		}

--- a/collector/drbd_linux.go
+++ b/collector/drbd_linux.go
@@ -17,6 +17,7 @@ package collector
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -188,7 +189,7 @@ func (c *drbdCollector) Update(ch chan<- prometheus.Metric) error {
 	statsFile := procFilePath("drbd")
 	file, err := os.Open(statsFile)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			level.Debug(c.logger).Log("msg", "stats file does not exist, skipping", "file", statsFile, "err", err)
 			return ErrNoData
 		}

--- a/collector/edac_linux.go
+++ b/collector/edac_linux.go
@@ -86,28 +86,28 @@ func (c *edacCollector) Update(ch chan<- prometheus.Metric) error {
 
 		value, err := readUintFromFile(filepath.Join(controller, "ce_count"))
 		if err != nil {
-			return fmt.Errorf("couldn't get ce_count for controller %s: %s", controllerNumber, err)
+			return fmt.Errorf("couldn't get ce_count for controller %s: %w", controllerNumber, err)
 		}
 		ch <- prometheus.MustNewConstMetric(
 			c.ceCount, prometheus.CounterValue, float64(value), controllerNumber)
 
 		value, err = readUintFromFile(filepath.Join(controller, "ce_noinfo_count"))
 		if err != nil {
-			return fmt.Errorf("couldn't get ce_noinfo_count for controller %s: %s", controllerNumber, err)
+			return fmt.Errorf("couldn't get ce_noinfo_count for controller %s: %w", controllerNumber, err)
 		}
 		ch <- prometheus.MustNewConstMetric(
 			c.csRowCECount, prometheus.CounterValue, float64(value), controllerNumber, "unknown")
 
 		value, err = readUintFromFile(filepath.Join(controller, "ue_count"))
 		if err != nil {
-			return fmt.Errorf("couldn't get ue_count for controller %s: %s", controllerNumber, err)
+			return fmt.Errorf("couldn't get ue_count for controller %s: %w", controllerNumber, err)
 		}
 		ch <- prometheus.MustNewConstMetric(
 			c.ueCount, prometheus.CounterValue, float64(value), controllerNumber)
 
 		value, err = readUintFromFile(filepath.Join(controller, "ue_noinfo_count"))
 		if err != nil {
-			return fmt.Errorf("couldn't get ue_noinfo_count for controller %s: %s", controllerNumber, err)
+			return fmt.Errorf("couldn't get ue_noinfo_count for controller %s: %w", controllerNumber, err)
 		}
 		ch <- prometheus.MustNewConstMetric(
 			c.csRowUECount, prometheus.CounterValue, float64(value), controllerNumber, "unknown")
@@ -126,14 +126,14 @@ func (c *edacCollector) Update(ch chan<- prometheus.Metric) error {
 
 			value, err = readUintFromFile(filepath.Join(csrow, "ce_count"))
 			if err != nil {
-				return fmt.Errorf("couldn't get ce_count for controller/csrow %s/%s: %s", controllerNumber, csrowNumber, err)
+				return fmt.Errorf("couldn't get ce_count for controller/csrow %s/%s: %w", controllerNumber, csrowNumber, err)
 			}
 			ch <- prometheus.MustNewConstMetric(
 				c.csRowCECount, prometheus.CounterValue, float64(value), controllerNumber, csrowNumber)
 
 			value, err = readUintFromFile(filepath.Join(csrow, "ue_count"))
 			if err != nil {
-				return fmt.Errorf("couldn't get ue_count for controller/csrow %s/%s: %s", controllerNumber, csrowNumber, err)
+				return fmt.Errorf("couldn't get ue_count for controller/csrow %s/%s: %w", controllerNumber, csrowNumber, err)
 			}
 			ch <- prometheus.MustNewConstMetric(
 				c.csRowUECount, prometheus.CounterValue, float64(value), controllerNumber, csrowNumber)

--- a/collector/entropy_linux.go
+++ b/collector/entropy_linux.go
@@ -46,7 +46,7 @@ func NewEntropyCollector(logger log.Logger) (Collector, error) {
 func (c *entropyCollector) Update(ch chan<- prometheus.Metric) error {
 	value, err := readUintFromFile(procFilePath("sys/kernel/random/entropy_avail"))
 	if err != nil {
-		return fmt.Errorf("couldn't get entropy_avail: %s", err)
+		return fmt.Errorf("couldn't get entropy_avail: %w", err)
 	}
 	ch <- prometheus.MustNewConstMetric(
 		c.entropyAvail, prometheus.GaugeValue, float64(value))

--- a/collector/filefd_linux.go
+++ b/collector/filefd_linux.go
@@ -46,12 +46,12 @@ func NewFileFDStatCollector(logger log.Logger) (Collector, error) {
 func (c *fileFDStatCollector) Update(ch chan<- prometheus.Metric) error {
 	fileFDStat, err := parseFileFDStats(procFilePath("sys/fs/file-nr"))
 	if err != nil {
-		return fmt.Errorf("couldn't get file-nr: %s", err)
+		return fmt.Errorf("couldn't get file-nr: %w", err)
 	}
 	for name, value := range fileFDStat {
 		v, err := strconv.ParseFloat(value, 64)
 		if err != nil {
-			return fmt.Errorf("invalid value %s in file-nr: %s", value, err)
+			return fmt.Errorf("invalid value %s in file-nr: %w", value, err)
 		}
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -17,6 +17,7 @@ package collector
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -139,7 +140,7 @@ func stuckMountWatcher(mountPoint string, success chan struct{}, logger log.Logg
 
 func mountPointDetails(logger log.Logger) ([]filesystemLabels, error) {
 	file, err := os.Open(procFilePath("1/mounts"))
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		// Fallback to `/proc/mounts` if `/proc/1/mounts` is missing due hidepid.
 		level.Debug(logger).Log("msg", "Reading root mounts failed, falling back to system mounts", "err", err)
 		file, err = os.Open(procFilePath("mounts"))

--- a/collector/hwmon_linux.go
+++ b/collector/hwmon_linux.go
@@ -424,7 +424,7 @@ func (c *hwMonCollector) Update(ch chan<- prometheus.Metric) error {
 
 	hwmonFiles, err := ioutil.ReadDir(hwmonPathName)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			level.Debug(c.logger).Log("msg", "hwmon collector metrics are not available for this system")
 			return ErrNoData
 		}

--- a/collector/infiniband_linux.go
+++ b/collector/infiniband_linux.go
@@ -17,6 +17,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -108,11 +109,11 @@ func (c *infinibandCollector) pushCounter(ch chan<- prometheus.Metric, name stri
 func (c *infinibandCollector) Update(ch chan<- prometheus.Metric) error {
 	devices, err := c.fs.InfiniBandClass()
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			level.Debug(c.logger).Log("msg", "infiniband statistics not found, skipping")
 			return ErrNoData
 		}
-		return fmt.Errorf("error obtaining InfiniBand class info: %s", err)
+		return fmt.Errorf("error obtaining InfiniBand class info: %w", err)
 	}
 
 	for _, device := range devices {

--- a/collector/interrupts_linux.go
+++ b/collector/interrupts_linux.go
@@ -34,13 +34,13 @@ var (
 func (c *interruptsCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	interrupts, err := getInterrupts()
 	if err != nil {
-		return fmt.Errorf("couldn't get interrupts: %s", err)
+		return fmt.Errorf("couldn't get interrupts: %w", err)
 	}
 	for name, interrupt := range interrupts {
 		for cpuNo, value := range interrupt.values {
 			fv, err := strconv.ParseFloat(value, 64)
 			if err != nil {
-				return fmt.Errorf("invalid value %s in interrupts: %s", value, err)
+				return fmt.Errorf("invalid value %s in interrupts: %w", value, err)
 			}
 			ch <- c.desc.mustNewConstMetric(fv, strconv.Itoa(cpuNo), name, interrupt.info, interrupt.devices)
 		}

--- a/collector/interrupts_openbsd.go
+++ b/collector/interrupts_openbsd.go
@@ -101,7 +101,7 @@ var (
 func (c *interruptsCollector) Update(ch chan<- prometheus.Metric) error {
 	interrupts, err := getInterrupts()
 	if err != nil {
-		return fmt.Errorf("couldn't get interrupts: %s", err)
+		return fmt.Errorf("couldn't get interrupts: %w", err)
 	}
 	for dev, interrupt := range interrupts {
 		for cpuNo, value := range interrupt.values {

--- a/collector/ipvs_linux.go
+++ b/collector/ipvs_linux.go
@@ -16,6 +16,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -140,11 +141,11 @@ func (c *ipvsCollector) Update(ch chan<- prometheus.Metric) error {
 	ipvsStats, err := c.fs.IPVSStats()
 	if err != nil {
 		// Cannot access ipvs metrics, report no error.
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			level.Debug(c.logger).Log("msg", "ipvs collector metrics are not available for this system")
 			return ErrNoData
 		}
-		return fmt.Errorf("could not get IPVS stats: %s", err)
+		return fmt.Errorf("could not get IPVS stats: %w", err)
 	}
 	ch <- c.connections.mustNewConstMetric(float64(ipvsStats.Connections))
 	ch <- c.incomingPackets.mustNewConstMetric(float64(ipvsStats.IncomingPackets))
@@ -154,7 +155,7 @@ func (c *ipvsCollector) Update(ch chan<- prometheus.Metric) error {
 
 	backendStats, err := c.fs.IPVSBackendStatus()
 	if err != nil {
-		return fmt.Errorf("could not get backend status: %s", err)
+		return fmt.Errorf("could not get backend status: %w", err)
 	}
 
 	sums := map[string]ipvsBackendStatus{}

--- a/collector/loadavg.go
+++ b/collector/loadavg.go
@@ -48,7 +48,7 @@ func NewLoadavgCollector(logger log.Logger) (Collector, error) {
 func (c *loadavgCollector) Update(ch chan<- prometheus.Metric) error {
 	loads, err := getLoad()
 	if err != nil {
-		return fmt.Errorf("couldn't get load: %s", err)
+		return fmt.Errorf("couldn't get load: %w", err)
 	}
 	for i, load := range loads {
 		level.Debug(c.logger).Log("msg", "return load", "index", i, "load", load)

--- a/collector/loadavg_linux.go
+++ b/collector/loadavg_linux.go
@@ -45,7 +45,7 @@ func parseLoad(data string) (loads []float64, err error) {
 	for i, load := range parts[0:3] {
 		loads[i], err = strconv.ParseFloat(load, 64)
 		if err != nil {
-			return nil, fmt.Errorf("could not parse load '%s': %s", load, err)
+			return nil, fmt.Errorf("could not parse load '%s': %w", load, err)
 		}
 	}
 	return loads, nil

--- a/collector/logind_linux.go
+++ b/collector/logind_linux.go
@@ -92,7 +92,7 @@ func NewLogindCollector(logger log.Logger) (Collector, error) {
 func (lc *logindCollector) Update(ch chan<- prometheus.Metric) error {
 	c, err := newDbus()
 	if err != nil {
-		return fmt.Errorf("unable to connect to dbus: %s", err)
+		return fmt.Errorf("unable to connect to dbus: %w", err)
 	}
 	defer c.conn.Close()
 
@@ -102,12 +102,12 @@ func (lc *logindCollector) Update(ch chan<- prometheus.Metric) error {
 func collectMetrics(ch chan<- prometheus.Metric, c logindInterface) error {
 	seats, err := c.listSeats()
 	if err != nil {
-		return fmt.Errorf("unable to get seats: %s", err)
+		return fmt.Errorf("unable to get seats: %w", err)
 	}
 
 	sessionList, err := c.listSessions()
 	if err != nil {
-		return fmt.Errorf("unable to get sessions: %s", err)
+		return fmt.Errorf("unable to get sessions: %w", err)
 	}
 
 	sessions := make(map[logindSession]float64)

--- a/collector/mdadm_linux.go
+++ b/collector/mdadm_linux.go
@@ -16,6 +16,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -94,21 +95,21 @@ var (
 )
 
 func (c *mdadmCollector) Update(ch chan<- prometheus.Metric) error {
-	fs, errFs := procfs.NewFS(*procPath)
+	fs, err := procfs.NewFS(*procPath)
 
-	if errFs != nil {
-		return fmt.Errorf("failed to open procfs: %w", errFs)
+	if err != nil {
+		return fmt.Errorf("failed to open procfs: %w", err)
 	}
 
 	mdStats, err := fs.MDStat()
 
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			level.Debug(c.logger).Log("msg", "Not collecting mdstat, file does not exist", "file", *procPath)
 			return ErrNoData
 		}
 
-		return fmt.Errorf("error parsing mdstatus: %s", err)
+		return fmt.Errorf("error parsing mdstatus: %w", err)
 	}
 
 	for _, mdStat := range mdStats {

--- a/collector/meminfo.go
+++ b/collector/meminfo.go
@@ -48,7 +48,7 @@ func (c *meminfoCollector) Update(ch chan<- prometheus.Metric) error {
 	var metricType prometheus.ValueType
 	memInfo, err := c.getMemInfo()
 	if err != nil {
-		return fmt.Errorf("couldn't get meminfo: %s", err)
+		return fmt.Errorf("couldn't get meminfo: %w", err)
 	}
 	level.Debug(c.logger).Log("msg", "Set node_mem", "memInfo", memInfo)
 	for k, v := range memInfo {

--- a/collector/meminfo_linux.go
+++ b/collector/meminfo_linux.go
@@ -54,7 +54,7 @@ func parseMemInfo(r io.Reader) (map[string]float64, error) {
 		}
 		fv, err := strconv.ParseFloat(parts[1], 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid value in meminfo: %s", err)
+			return nil, fmt.Errorf("invalid value in meminfo: %w", err)
 		}
 		key := parts[0][:len(parts[0])-1] // remove trailing : from key
 		// Active(anon) -> Active_anon

--- a/collector/meminfo_numa_linux.go
+++ b/collector/meminfo_numa_linux.go
@@ -62,7 +62,7 @@ func NewMeminfoNumaCollector(logger log.Logger) (Collector, error) {
 func (c *meminfoNumaCollector) Update(ch chan<- prometheus.Metric) error {
 	metrics, err := getMemInfoNuma()
 	if err != nil {
-		return fmt.Errorf("couldn't get NUMA meminfo: %s", err)
+		return fmt.Errorf("couldn't get NUMA meminfo: %w", err)
 	}
 	for _, v := range metrics {
 		desc, ok := c.metricDescs[v.metricName]
@@ -137,7 +137,7 @@ func parseMemInfoNuma(r io.Reader) ([]meminfoMetric, error) {
 
 		fv, err := strconv.ParseFloat(parts[3], 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid value in meminfo: %s", err)
+			return nil, fmt.Errorf("invalid value in meminfo: %w", err)
 		}
 		switch l := len(parts); {
 		case l == 4: // no unit
@@ -174,7 +174,7 @@ func parseMemInfoNumaStat(r io.Reader, nodeNumber string) ([]meminfoMetric, erro
 
 		fv, err := strconv.ParseFloat(parts[1], 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid value in numastat: %s", err)
+			return nil, fmt.Errorf("invalid value in numastat: %w", err)
 		}
 
 		numaStat = append(numaStat, meminfoMetric{parts[0] + "_total", prometheus.CounterValue, nodeNumber, fv})

--- a/collector/meminfo_openbsd.go
+++ b/collector/meminfo_openbsd.go
@@ -62,7 +62,7 @@ func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 	}
 
 	if _, err := C.sysctl_bcstats(&bcstats); err != nil {
-		return nil, fmt.Errorf("sysctl CTL_VFS VFS_GENERIC VFS_BCACHESTAT failed: %v", err)
+		return nil, fmt.Errorf("sysctl CTL_VFS VFS_GENERIC VFS_BCACHESTAT failed: %w", err)
 	}
 
 	ps := float64(uvmexp.pagesize)

--- a/collector/memory_bsd.go
+++ b/collector/memory_bsd.go
@@ -43,7 +43,7 @@ func init() {
 func NewMemoryCollector(logger log.Logger) (Collector, error) {
 	tmp32, err := unix.SysctlUint32("vm.stats.vm.v_page_size")
 	if err != nil {
-		return nil, fmt.Errorf("sysctl(vm.stats.vm.v_page_size) failed: %s", err)
+		return nil, fmt.Errorf("sysctl(vm.stats.vm.v_page_size) failed: %w", err)
 	}
 	size := float64(tmp32)
 
@@ -136,7 +136,7 @@ func (c *memoryCollector) Update(ch chan<- prometheus.Metric) error {
 	for _, m := range c.sysctls {
 		v, err := m.Value()
 		if err != nil {
-			return fmt.Errorf("couldn't get memory: %s", err)
+			return fmt.Errorf("couldn't get memory: %w", err)
 		}
 
 		// Most are gauges.
@@ -154,7 +154,7 @@ func (c *memoryCollector) Update(ch chan<- prometheus.Metric) error {
 
 	swapUsed, err := c.kvm.SwapUsedPages()
 	if err != nil {
-		return fmt.Errorf("couldn't get kvm: %s", err)
+		return fmt.Errorf("couldn't get kvm: %w", err)
 	}
 
 	ch <- prometheus.MustNewConstMetric(

--- a/collector/netclass_linux.go
+++ b/collector/netclass_linux.go
@@ -61,7 +61,7 @@ func NewNetClassCollector(logger log.Logger) (Collector, error) {
 func (c *netClassCollector) Update(ch chan<- prometheus.Metric) error {
 	netClass, err := c.getNetClassInfo()
 	if err != nil {
-		return fmt.Errorf("could not get net class info: %s", err)
+		return fmt.Errorf("could not get net class info: %w", err)
 	}
 	for _, ifaceInfo := range netClass {
 		upDesc := prometheus.NewDesc(
@@ -175,7 +175,7 @@ func (c *netClassCollector) getNetClassInfo() (sysfs.NetClass, error) {
 	netClass, err := c.fs.NetClass()
 
 	if err != nil {
-		return netClass, fmt.Errorf("error obtaining net class info: %s", err)
+		return netClass, fmt.Errorf("error obtaining net class info: %w", err)
 	}
 
 	for device := range netClass {

--- a/collector/netdev_common.go
+++ b/collector/netdev_common.go
@@ -95,7 +95,7 @@ func NewNetDevCollector(logger log.Logger) (Collector, error) {
 func (c *netDevCollector) Update(ch chan<- prometheus.Metric) error {
 	netDev, err := getNetDevStats(c.deviceExcludePattern, c.deviceIncludePattern, c.logger)
 	if err != nil {
-		return fmt.Errorf("couldn't get netstats: %s", err)
+		return fmt.Errorf("couldn't get netstats: %w", err)
 	}
 	for dev, devStats := range netDev {
 		for key, value := range devStats {
@@ -111,7 +111,7 @@ func (c *netDevCollector) Update(ch chan<- prometheus.Metric) error {
 			}
 			v, err := strconv.ParseFloat(value, 64)
 			if err != nil {
-				return fmt.Errorf("invalid value %s in netstats: %s", value, err)
+				return fmt.Errorf("invalid value %s in netstats: %w", value, err)
 			}
 			ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, v, dev)
 		}

--- a/collector/nfs_linux.go
+++ b/collector/nfs_linux.go
@@ -16,6 +16,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -97,7 +98,7 @@ func NewNfsCollector(logger log.Logger) (Collector, error) {
 func (c *nfsCollector) Update(ch chan<- prometheus.Metric) error {
 	stats, err := c.fs.ClientRPCStats()
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			level.Debug(c.logger).Log("msg", "Not collecting NFS metrics", "err", err)
 			return ErrNoData
 		}

--- a/collector/nfsd_linux.go
+++ b/collector/nfsd_linux.go
@@ -16,6 +16,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -63,7 +64,7 @@ func NewNFSdCollector(logger log.Logger) (Collector, error) {
 func (c *nfsdCollector) Update(ch chan<- prometheus.Metric) error {
 	stats, err := c.fs.ServerRPCStats()
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			level.Debug(c.logger).Log("msg", "Not collecting NFSd metrics", "err", err)
 			return ErrNoData
 		}

--- a/collector/ntp.go
+++ b/collector/ntp.go
@@ -125,7 +125,7 @@ func (c *ntpCollector) Update(ch chan<- prometheus.Metric) error {
 		Timeout: time.Second, // default `ntpdate` timeout
 	})
 	if err != nil {
-		return fmt.Errorf("couldn't get SNTP reply: %s", err)
+		return fmt.Errorf("couldn't get SNTP reply: %w", err)
 	}
 
 	ch <- c.stratum.mustNewConstMetric(float64(resp.Stratum))

--- a/collector/powersupplyclass.go
+++ b/collector/powersupplyclass.go
@@ -59,7 +59,7 @@ func (c *powerSupplyClassCollector) Update(ch chan<- prometheus.Metric) error {
 		if errors.Is(err, os.ErrNotExist) {
 			return ErrNoData
 		}
-		return fmt.Errorf("could not get power_supply class info: %s", err)
+		return fmt.Errorf("could not get power_supply class info: %w", err)
 	}
 	for _, powerSupply := range powerSupplyClass {
 

--- a/collector/processes_linux.go
+++ b/collector/processes_linux.go
@@ -16,6 +16,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -75,13 +76,13 @@ func NewProcessStatCollector(logger log.Logger) (Collector, error) {
 func (c *processCollector) Update(ch chan<- prometheus.Metric) error {
 	pids, states, threads, err := c.getAllocatedThreads()
 	if err != nil {
-		return fmt.Errorf("unable to retrieve number of allocated threads: %q", err)
+		return fmt.Errorf("unable to retrieve number of allocated threads: %w", err)
 	}
 
 	ch <- prometheus.MustNewConstMetric(c.threadAlloc, prometheus.GaugeValue, float64(threads))
 	maxThreads, err := readUintFromFile(procFilePath("sys/kernel/threads-max"))
 	if err != nil {
-		return fmt.Errorf("unable to retrieve limit number of threads: %q", err)
+		return fmt.Errorf("unable to retrieve limit number of threads: %w", err)
 	}
 	ch <- prometheus.MustNewConstMetric(c.threadLimit, prometheus.GaugeValue, float64(maxThreads))
 
@@ -91,7 +92,7 @@ func (c *processCollector) Update(ch chan<- prometheus.Metric) error {
 
 	pidM, err := readUintFromFile(procFilePath("sys/kernel/pid_max"))
 	if err != nil {
-		return fmt.Errorf("unable to retrieve limit number of maximum pids alloved: %q", err)
+		return fmt.Errorf("unable to retrieve limit number of maximum pids alloved: %w", err)
 	}
 	ch <- prometheus.MustNewConstMetric(c.pidUsed, prometheus.GaugeValue, float64(pids))
 	ch <- prometheus.MustNewConstMetric(c.pidMax, prometheus.GaugeValue, float64(pidM))
@@ -110,7 +111,7 @@ func (c *processCollector) getAllocatedThreads() (int, map[string]int32, int, er
 	for _, pid := range p {
 		stat, err := pid.Stat()
 		// PIDs can vanish between getting the list and getting stats.
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			level.Debug(c.logger).Log("msg", "file not found when retrieving stats for pid", "pid", pid, "err", err)
 			continue
 		}

--- a/collector/schedstat_linux.go
+++ b/collector/schedstat_linux.go
@@ -16,6 +16,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -72,7 +73,7 @@ func init() {
 func (c *schedstatCollector) Update(ch chan<- prometheus.Metric) error {
 	stats, err := c.fs.Schedstat()
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			level.Debug(c.logger).Log("msg", "schedstat file does not exist")
 			return ErrNoData
 		}

--- a/collector/sockstat_linux.go
+++ b/collector/sockstat_linux.go
@@ -16,6 +16,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -55,7 +56,7 @@ func (c *sockStatCollector) Update(ch chan<- prometheus.Metric) error {
 	stat4, err := fs.NetSockstat()
 	switch {
 	case err == nil:
-	case os.IsNotExist(err):
+	case errors.Is(err, os.ErrNotExist):
 		level.Debug(c.logger).Log("msg", "IPv4 sockstat statistics not found, skipping")
 	default:
 		return fmt.Errorf("failed to get IPv4 sockstat data: %w", err)
@@ -64,7 +65,7 @@ func (c *sockStatCollector) Update(ch chan<- prometheus.Metric) error {
 	stat6, err := fs.NetSockstat6()
 	switch {
 	case err == nil:
-	case os.IsNotExist(err):
+	case errors.Is(err, os.ErrNotExist):
 		level.Debug(c.logger).Log("msg", "IPv6 sockstat statistics not found, skipping")
 	default:
 		return fmt.Errorf("failed to get IPv6 sockstat data: %w", err)

--- a/collector/softnet_linux.go
+++ b/collector/softnet_linux.go
@@ -72,7 +72,7 @@ func NewSoftnetCollector(logger log.Logger) (Collector, error) {
 func (c *softnetCollector) Update(ch chan<- prometheus.Metric) error {
 	stats, err := c.fs.NetSoftnetStat()
 	if err != nil {
-		return fmt.Errorf("could not get softnet statistics: %s", err)
+		return fmt.Errorf("could not get softnet statistics: %w", err)
 	}
 
 	for cpuNumber, cpuStats := range stats {

--- a/collector/supervisord.go
+++ b/collector/supervisord.go
@@ -134,7 +134,7 @@ func (c *supervisordCollector) Update(ch chan<- prometheus.Metric) error {
 
 	res, err := xrpc.Call("supervisor.getAllProcessInfo")
 	if err != nil {
-		return fmt.Errorf("unable to call supervisord: %s", err)
+		return fmt.Errorf("unable to call supervisord: %w", err)
 	}
 
 	for _, p := range res.(xmlrpc.Array) {

--- a/collector/systemd_linux.go
+++ b/collector/systemd_linux.go
@@ -175,13 +175,13 @@ func (c *systemdCollector) Update(ch chan<- prometheus.Metric) error {
 	begin := time.Now()
 	conn, err := newSystemdDbusConn()
 	if err != nil {
-		return fmt.Errorf("couldn't get dbus connection: %s", err)
+		return fmt.Errorf("couldn't get dbus connection: %w", err)
 	}
 	defer conn.Close()
 
 	allUnits, err := c.getAllUnits(conn)
 	if err != nil {
-		return fmt.Errorf("couldn't get units: %s", err)
+		return fmt.Errorf("couldn't get units: %w", err)
 	}
 	level.Debug(c.logger).Log("msg", "getAllUnits took", "duration_seconds", time.Since(begin).Seconds())
 
@@ -413,7 +413,7 @@ func (c *systemdCollector) collectSummaryMetrics(ch chan<- prometheus.Metric, su
 func (c *systemdCollector) collectSystemState(conn *dbus.Conn, ch chan<- prometheus.Metric) error {
 	systemState, err := conn.GetManagerProperty("SystemState")
 	if err != nil {
-		return fmt.Errorf("couldn't get system state: %s", err)
+		return fmt.Errorf("couldn't get system state: %w", err)
 	}
 	isSystemRunning := 0.0
 	if systemState == `"running"` {

--- a/collector/tcpstat_linux.go
+++ b/collector/tcpstat_linux.go
@@ -82,7 +82,7 @@ func NewTCPStatCollector(logger log.Logger) (Collector, error) {
 func (c *tcpStatCollector) Update(ch chan<- prometheus.Metric) error {
 	tcpStats, err := getTCPStats(procFilePath("net/tcp"))
 	if err != nil {
-		return fmt.Errorf("couldn't get tcpstats: %s", err)
+		return fmt.Errorf("couldn't get tcpstats: %w", err)
 	}
 
 	// if enabled ipv6 system
@@ -90,7 +90,7 @@ func (c *tcpStatCollector) Update(ch chan<- prometheus.Metric) error {
 	if _, hasIPv6 := os.Stat(tcp6File); hasIPv6 == nil {
 		tcp6Stats, err := getTCPStats(tcp6File)
 		if err != nil {
-			return fmt.Errorf("couldn't get tcp6stats: %s", err)
+			return fmt.Errorf("couldn't get tcp6stats: %w", err)
 		}
 
 		for st, value := range tcp6Stats {

--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -238,14 +238,14 @@ func (c *textFileCollector) processFile(name string, ch chan<- prometheus.Metric
 	path := filepath.Join(c.path, name)
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open textfile data file %q: %v", path, err)
+		return nil, fmt.Errorf("failed to open textfile data file %q: %w", path, err)
 	}
 	defer f.Close()
 
 	var parser expfmt.TextParser
 	families, err := parser.TextToMetricFamilies(f)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse textfile data from %q: %v", path, err)
+		return nil, fmt.Errorf("failed to parse textfile data from %q: %w", path, err)
 	}
 
 	if hasTimestamps(families) {
@@ -267,7 +267,7 @@ func (c *textFileCollector) processFile(name string, ch chan<- prometheus.Metric
 	// a failure does not appear fresh.
 	stat, err := f.Stat()
 	if err != nil {
-		return nil, fmt.Errorf("failed to stat %q: %v", path, err)
+		return nil, fmt.Errorf("failed to stat %q: %w", path, err)
 	}
 
 	t := stat.ModTime()

--- a/collector/udp_queues_linux.go
+++ b/collector/udp_queues_linux.go
@@ -16,6 +16,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -41,7 +42,7 @@ func init() {
 func NewUDPqueuesCollector(logger log.Logger) (Collector, error) {
 	fs, err := procfs.NewFS(*procPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open procfs: %v", err)
+		return nil, fmt.Errorf("failed to open procfs: %w", err)
 	}
 	return &udpQueuesCollector{
 		fs: fs,
@@ -61,10 +62,10 @@ func (c *udpQueuesCollector) Update(ch chan<- prometheus.Metric) error {
 		ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, float64(s4.TxQueueLength), "tx", "v4")
 		ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, float64(s4.RxQueueLength), "rx", "v4")
 	} else {
-		if os.IsNotExist(errIPv4) {
+		if errors.Is(errIPv4, os.ErrNotExist) {
 			level.Debug(c.logger).Log("msg", "not collecting ipv4 based metrics")
 		} else {
-			return fmt.Errorf("couldn't get upd queued bytes: %s", errIPv4)
+			return fmt.Errorf("couldn't get upd queued bytes: %w", errIPv4)
 		}
 	}
 
@@ -73,14 +74,14 @@ func (c *udpQueuesCollector) Update(ch chan<- prometheus.Metric) error {
 		ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, float64(s6.TxQueueLength), "tx", "v6")
 		ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, float64(s6.RxQueueLength), "rx", "v6")
 	} else {
-		if os.IsNotExist(errIPv6) {
+		if errors.Is(errIPv6, os.ErrNotExist) {
 			level.Debug(c.logger).Log("msg", "not collecting ipv6 based metrics")
 		} else {
-			return fmt.Errorf("couldn't get upd6 queued bytes: %s", errIPv6)
+			return fmt.Errorf("couldn't get upd6 queued bytes: %w", errIPv6)
 		}
 	}
 
-	if os.IsNotExist(errIPv4) && os.IsNotExist(errIPv6) {
+	if errors.Is(errIPv4, os.ErrNotExist) && errors.Is(errIPv6, os.ErrNotExist) {
 		return ErrNoData
 	}
 	return nil

--- a/collector/zfs_freebsd.go
+++ b/collector/zfs_freebsd.go
@@ -250,7 +250,7 @@ func (c *zfsCollector) Update(ch chan<- prometheus.Metric) error {
 	for _, m := range c.sysctls {
 		v, err := m.Value()
 		if err != nil {
-			return fmt.Errorf("couldn't get sysctl: %s", err)
+			return fmt.Errorf("couldn't get sysctl: %w", err)
 		}
 
 		ch <- prometheus.MustNewConstMetric(

--- a/collector/zfs_linux.go
+++ b/collector/zfs_linux.go
@@ -187,7 +187,7 @@ func (c *zfsCollector) parsePoolProcfsFile(reader io.Reader, zpoolPath string, h
 
 			value, err := strconv.ParseUint(line[i], 10, 64)
 			if err != nil {
-				return fmt.Errorf("could not parse expected integer value for %q: %v", key, err)
+				return fmt.Errorf("could not parse expected integer value for %q: %w", key, err)
 			}
 			handler(zpoolName, zfsSysctl(key), value)
 		}


### PR DESCRIPTION
* Use `errors.Is()` for unwrapping errors.
* Use `%w` error verb in internal error formatting.

Signed-off-by: Ben Kochie <superq@gmail.com>