### PR TITLE
Added ability to use unix socket instead http connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,8 @@ update_fixtures:
 test-e2e: build collector/fixtures/sys/.unpacked
 	@echo ">> running end-to-end tests"
 	./end-to-end-test.sh
+	@echo ">> running end-to-end tests with unix socket"
+	./end-to-end-test.sh -s
 
 .PHONY: skip-test-e2e
 skip-test-e2e:

--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -144,12 +144,7 @@ EOF
 
   if [ ${keep} -eq 0 ]
   then
-    if [ ${socket} -ne 0 ]; then
-      signal="-15"
-    else
-      signal="-9"
-    fi
-    kill ${signal} "$(cat ${tmpdir}/node_exporter.pid)"
+    kill "$(cat ${tmpdir}/node_exporter.pid)"
     # This silences the "Killed" message
     set +e
     wait "$(cat ${tmpdir}/node_exporter.pid)" > /dev/null 2>&1

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -222,7 +222,6 @@ func main() {
 		os.Chmod(*socketPath, os.FileMode(*socketPermissions))
 		go func() {
 			err = server.Serve(unixListener)
-			println(err)
 			if err != nil && err != http.ErrServerClosed {
 				level.Error(logger).Log("err", err)
 				os.Exit(1)
@@ -231,7 +230,7 @@ func main() {
 
 		<-done
 		level.Info(logger).Log("msg", "Connection closed", "path", *socketPath)
-		unixListener.Close()
+		server.Close()
 		os.Exit(0)
 	}
 }

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -219,7 +219,11 @@ func main() {
 			level.Error(logger).Log("err", err)
 			os.Exit(1)
 		}
-		os.Chmod(*socketPath, os.FileMode(*socketPermissions))
+		err = os.Chmod(*socketPath, os.FileMode(*socketPermissions))
+		if err != nil {
+			level.Error(logger).Log("err", err)
+			os.Exit(1)
+		}
 		go func() {
 			err = server.Serve(unixListener)
 			if err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
- Added parameter `web.socket-path` which sets path to an unix socket file. The program uses http server if the parameter is empty.
- Added parameter `web.socket-permissions` which sets file permissions to an unix socket file. Default value is `0640`.
- e2e tests also checks work of `node_exporter` with unix socket.