### PR TITLE
Use description instead of message as field for annotations

### DIFF
--- a/docs/node-mixin/alerts/alerts.libsonnet
+++ b/docs/node-mixin/alerts/alerts.libsonnet
@@ -231,7 +231,7 @@
             },
             annotations: {
               summary: 'Clock skew detected.',
-              message: 'Clock on {{ $labels.instance }} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.',
+              description: 'Clock on {{ $labels.instance }} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.',
             },
           },
           {
@@ -245,7 +245,7 @@
             },
             annotations: {
               summary: 'Clock not synchronising.',
-              message: 'Clock on {{ $labels.instance }} is not synchronising. Ensure NTP is configured on this host.',
+              description: 'Clock on {{ $labels.instance }} is not synchronising. Ensure NTP is configured on this host.',
             },
           },
         ],


### PR DESCRIPTION
These fields should be identical to prevent issues with Alertmanager templates. 