### PR TITLE
Fix invalid metric name panic reading powercap dir

### DIFF
--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2080,7 +2080,7 @@ node_network_receive_bytes_total{device="lxcbr0"} 0
 node_network_receive_bytes_total{device="tun0"} 1888
 node_network_receive_bytes_total{device="veth4B09XN"} 648
 node_network_receive_bytes_total{device="wlan0"} 1.0437182923e+10
-node_network_receive_bytes_total{device="í ½í²©0"} 5.7750104e+07
+node_network_receive_bytes_total{device="💩0"} 5.7750104e+07
 # HELP node_network_receive_compressed_total Network device statistic receive_compressed.
 # TYPE node_network_receive_compressed_total counter
 node_network_receive_compressed_total{device="docker0"} 0
@@ -2092,7 +2092,7 @@ node_network_receive_compressed_total{device="lxcbr0"} 0
 node_network_receive_compressed_total{device="tun0"} 0
 node_network_receive_compressed_total{device="veth4B09XN"} 0
 node_network_receive_compressed_total{device="wlan0"} 0
-node_network_receive_compressed_total{device="í ½í²©0"} 0
+node_network_receive_compressed_total{device="💩0"} 0
 # HELP node_network_receive_drop_total Network device statistic receive_drop.
 # TYPE node_network_receive_drop_total counter
 node_network_receive_drop_total{device="docker0"} 0
@@ -2104,7 +2104,7 @@ node_network_receive_drop_total{device="lxcbr0"} 0
 node_network_receive_drop_total{device="tun0"} 0
 node_network_receive_drop_total{device="veth4B09XN"} 0
 node_network_receive_drop_total{device="wlan0"} 0
-node_network_receive_drop_total{device="í ½í²©0"} 0
+node_network_receive_drop_total{device="💩0"} 0
 # HELP node_network_receive_errs_total Network device statistic receive_errs.
 # TYPE node_network_receive_errs_total counter
 node_network_receive_errs_total{device="docker0"} 0
@@ -2116,7 +2116,7 @@ node_network_receive_errs_total{device="lxcbr0"} 0
 node_network_receive_errs_total{device="tun0"} 0
 node_network_receive_errs_total{device="veth4B09XN"} 0
 node_network_receive_errs_total{device="wlan0"} 0
-node_network_receive_errs_total{device="í ½í²©0"} 0
+node_network_receive_errs_total{device="💩0"} 0
 # HELP node_network_receive_fifo_total Network device statistic receive_fifo.
 # TYPE node_network_receive_fifo_total counter
 node_network_receive_fifo_total{device="docker0"} 0
@@ -2128,7 +2128,7 @@ node_network_receive_fifo_total{device="lxcbr0"} 0
 node_network_receive_fifo_total{device="tun0"} 0
 node_network_receive_fifo_total{device="veth4B09XN"} 0
 node_network_receive_fifo_total{device="wlan0"} 0
-node_network_receive_fifo_total{device="í ½í²©0"} 0
+node_network_receive_fifo_total{device="💩0"} 0
 # HELP node_network_receive_frame_total Network device statistic receive_frame.
 # TYPE node_network_receive_frame_total counter
 node_network_receive_frame_total{device="docker0"} 0
@@ -2140,7 +2140,7 @@ node_network_receive_frame_total{device="lxcbr0"} 0
 node_network_receive_frame_total{device="tun0"} 0
 node_network_receive_frame_total{device="veth4B09XN"} 0
 node_network_receive_frame_total{device="wlan0"} 0
-node_network_receive_frame_total{device="í ½í²©0"} 0
+node_network_receive_frame_total{device="💩0"} 0
 # HELP node_network_receive_multicast_total Network device statistic receive_multicast.
 # TYPE node_network_receive_multicast_total counter
 node_network_receive_multicast_total{device="docker0"} 0
@@ -2152,7 +2152,7 @@ node_network_receive_multicast_total{device="lxcbr0"} 0
 node_network_receive_multicast_total{device="tun0"} 0
 node_network_receive_multicast_total{device="veth4B09XN"} 0
 node_network_receive_multicast_total{device="wlan0"} 0
-node_network_receive_multicast_total{device="í ½í²©0"} 72
+node_network_receive_multicast_total{device="💩0"} 72
 # HELP node_network_receive_packets_total Network device statistic receive_packets.
 # TYPE node_network_receive_packets_total counter
 node_network_receive_packets_total{device="docker0"} 1.065585e+06
@@ -2164,7 +2164,7 @@ node_network_receive_packets_total{device="lxcbr0"} 0
 node_network_receive_packets_total{device="tun0"} 24
 node_network_receive_packets_total{device="veth4B09XN"} 8
 node_network_receive_packets_total{device="wlan0"} 1.3899359e+07
-node_network_receive_packets_total{device="í ½í²©0"} 105557
+node_network_receive_packets_total{device="💩0"} 105557
 # HELP node_network_speed_bytes speed_bytes value of /sys/class/net/<iface>.
 # TYPE node_network_speed_bytes gauge
 node_network_speed_bytes{device="eth0"} 1.25e+08
@@ -2179,7 +2179,7 @@ node_network_transmit_bytes_total{device="lxcbr0"} 2.630299e+06
 node_network_transmit_bytes_total{device="tun0"} 67120
 node_network_transmit_bytes_total{device="veth4B09XN"} 1.943284e+06
 node_network_transmit_bytes_total{device="wlan0"} 2.85164936e+09
-node_network_transmit_bytes_total{device="í ½í²©0"} 4.04570255e+08
+node_network_transmit_bytes_total{device="💩0"} 4.04570255e+08
 # HELP node_network_transmit_carrier_total Network device statistic transmit_carrier.
 # TYPE node_network_transmit_carrier_total counter
 node_network_transmit_carrier_total{device="docker0"} 0
@@ -2191,7 +2191,7 @@ node_network_transmit_carrier_total{device="lxcbr0"} 0
 node_network_transmit_carrier_total{device="tun0"} 0
 node_network_transmit_carrier_total{device="veth4B09XN"} 0
 node_network_transmit_carrier_total{device="wlan0"} 0
-node_network_transmit_carrier_total{device="í ½í²©0"} 0
+node_network_transmit_carrier_total{device="💩0"} 0
 # HELP node_network_transmit_colls_total Network device statistic transmit_colls.
 # TYPE node_network_transmit_colls_total counter
 node_network_transmit_colls_total{device="docker0"} 0
@@ -2203,7 +2203,7 @@ node_network_transmit_colls_total{device="lxcbr0"} 0
 node_network_transmit_colls_total{device="tun0"} 0
 node_network_transmit_colls_total{device="veth4B09XN"} 0
 node_network_transmit_colls_total{device="wlan0"} 0
-node_network_transmit_colls_total{device="í ½í²©0"} 0
+node_network_transmit_colls_total{device="💩0"} 0
 # HELP node_network_transmit_compressed_total Network device statistic transmit_compressed.
 # TYPE node_network_transmit_compressed_total counter
 node_network_transmit_compressed_total{device="docker0"} 0
@@ -2215,7 +2215,7 @@ node_network_transmit_compressed_total{device="lxcbr0"} 0
 node_network_transmit_compressed_total{device="tun0"} 0
 node_network_transmit_compressed_total{device="veth4B09XN"} 0
 node_network_transmit_compressed_total{device="wlan0"} 0
-node_network_transmit_compressed_total{device="í ½í²©0"} 0
+node_network_transmit_compressed_total{device="💩0"} 0
 # HELP node_network_transmit_drop_total Network device statistic transmit_drop.
 # TYPE node_network_transmit_drop_total counter
 node_network_transmit_drop_total{device="docker0"} 0
@@ -2227,7 +2227,7 @@ node_network_transmit_drop_total{device="lxcbr0"} 0
 node_network_transmit_drop_total{device="tun0"} 0
 node_network_transmit_drop_total{device="veth4B09XN"} 0
 node_network_transmit_drop_total{device="wlan0"} 0
-node_network_transmit_drop_total{device="í ½í²©0"} 0
+node_network_transmit_drop_total{device="💩0"} 0
 # HELP node_network_transmit_errs_total Network device statistic transmit_errs.
 # TYPE node_network_transmit_errs_total counter
 node_network_transmit_errs_total{device="docker0"} 0
@@ -2239,7 +2239,7 @@ node_network_transmit_errs_total{device="lxcbr0"} 0
 node_network_transmit_errs_total{device="tun0"} 0
 node_network_transmit_errs_total{device="veth4B09XN"} 0
 node_network_transmit_errs_total{device="wlan0"} 0
-node_network_transmit_errs_total{device="í ½í²©0"} 0
+node_network_transmit_errs_total{device="💩0"} 0
 # HELP node_network_transmit_fifo_total Network device statistic transmit_fifo.
 # TYPE node_network_transmit_fifo_total counter
 node_network_transmit_fifo_total{device="docker0"} 0
@@ -2251,7 +2251,7 @@ node_network_transmit_fifo_total{device="lxcbr0"} 0
 node_network_transmit_fifo_total{device="tun0"} 0
 node_network_transmit_fifo_total{device="veth4B09XN"} 0
 node_network_transmit_fifo_total{device="wlan0"} 0
-node_network_transmit_fifo_total{device="í ½í²©0"} 0
+node_network_transmit_fifo_total{device="💩0"} 0
 # HELP node_network_transmit_packets_total Network device statistic transmit_packets.
 # TYPE node_network_transmit_packets_total counter
 node_network_transmit_packets_total{device="docker0"} 1.929779e+06
@@ -2263,7 +2263,7 @@ node_network_transmit_packets_total{device="lxcbr0"} 28339
 node_network_transmit_packets_total{device="tun0"} 934
 node_network_transmit_packets_total{device="veth4B09XN"} 10640
 node_network_transmit_packets_total{device="wlan0"} 1.17262e+07
-node_network_transmit_packets_total{device="í ½í²©0"} 304261
+node_network_transmit_packets_total{device="💩0"} 304261
 # HELP node_network_transmit_queue_length transmit_queue_length value of /sys/class/net/<iface>.
 # TYPE node_network_transmit_queue_length gauge
 node_network_transmit_queue_length{device="eth0"} 1000
@@ -2421,7 +2421,7 @@ node_nfsd_reply_cache_hits_total 0
 # HELP node_nfsd_reply_cache_misses_total Total number of NFSd Reply Cache an operation that requires caching (idempotent).
 # TYPE node_nfsd_reply_cache_misses_total counter
 node_nfsd_reply_cache_misses_total 6
-# HELP node_nfsd_reply_cache_nocache_total Total number of NFSd Reply Cache non-idempotent operations (rename/delete/â€¦).
+# HELP node_nfsd_reply_cache_nocache_total Total number of NFSd Reply Cache non-idempotent operations (rename/delete/…).
 # TYPE node_nfsd_reply_cache_nocache_total counter
 node_nfsd_reply_cache_nocache_total 18622
 # HELP node_nfsd_requests_total Total number NFSd Requests by method and protocol.

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -232,24 +232,12 @@ node_cooling_device_cur_state{name="0",type="Processor"} 0
 # HELP node_cooling_device_max_state Maximum throttle state of the cooling device
 # TYPE node_cooling_device_max_state gauge
 node_cooling_device_max_state{name="0",type="Processor"} 3
-# HELP node_cpu_bug_info The `bugs` field of CPU information from /proc/cpuinfo.
-# TYPE node_cpu_bug_info gauge
-node_cpu_bug_info{bug="cpu_meltdown"} 1
-node_cpu_bug_info{bug="mds"} 1
-node_cpu_bug_info{bug="spectre_v1"} 1
-node_cpu_bug_info{bug="spectre_v2"} 1
 # HELP node_cpu_core_throttles_total Number of times this cpu core has been throttled.
 # TYPE node_cpu_core_throttles_total counter
 node_cpu_core_throttles_total{core="0",package="0"} 5
 node_cpu_core_throttles_total{core="0",package="1"} 0
 node_cpu_core_throttles_total{core="1",package="0"} 0
 node_cpu_core_throttles_total{core="1",package="1"} 9
-# HELP node_cpu_flag_info The `flags` field of CPU information from /proc/cpuinfo.
-# TYPE node_cpu_flag_info gauge
-node_cpu_flag_info{flag="aes"} 1
-node_cpu_flag_info{flag="avx"} 1
-node_cpu_flag_info{flag="avx2"} 1
-node_cpu_flag_info{flag="constant_tsc"} 1
 # HELP node_cpu_guest_seconds_total Seconds the cpus spent in guests (VMs) for each mode.
 # TYPE node_cpu_guest_seconds_total counter
 node_cpu_guest_seconds_total{cpu="0",mode="nice"} 0.01
@@ -1967,9 +1955,6 @@ node_netstat_Tcp_InErrs 5
 # HELP node_netstat_Tcp_InSegs Statistic TcpInSegs.
 # TYPE node_netstat_Tcp_InSegs untyped
 node_netstat_Tcp_InSegs 5.7252008e+07
-# HELP node_netstat_Tcp_OutRsts Statistic TcpOutRsts.
-# TYPE node_netstat_Tcp_OutRsts untyped
-node_netstat_Tcp_OutRsts 1003
 # HELP node_netstat_Tcp_OutSegs Statistic TcpOutSegs.
 # TYPE node_netstat_Tcp_OutSegs untyped
 node_netstat_Tcp_OutSegs 5.4915039e+07
@@ -2578,18 +2563,10 @@ node_procs_blocked 0
 # HELP node_procs_running Number of processes in runnable state.
 # TYPE node_procs_running gauge
 node_procs_running 2
-# HELP node_qdisc_backlog Number of bytes currently in queue to be sent.
-# TYPE node_qdisc_backlog gauge
-node_qdisc_backlog{device="eth0",kind="pfifo_fast"} 0
-node_qdisc_backlog{device="wlan0",kind="fq"} 0
 # HELP node_qdisc_bytes_total Number of bytes sent.
 # TYPE node_qdisc_bytes_total counter
 node_qdisc_bytes_total{device="eth0",kind="pfifo_fast"} 83
 node_qdisc_bytes_total{device="wlan0",kind="fq"} 42
-# HELP node_qdisc_current_queue_length Number of packets currently in queue to be sent.
-# TYPE node_qdisc_current_queue_length gauge
-node_qdisc_current_queue_length{device="eth0",kind="pfifo_fast"} 0
-node_qdisc_current_queue_length{device="wlan0",kind="fq"} 0
 # HELP node_qdisc_drops_total Number of packets dropped.
 # TYPE node_qdisc_drops_total counter
 node_qdisc_drops_total{device="eth0",kind="pfifo_fast"} 0
@@ -2606,12 +2583,9 @@ node_qdisc_packets_total{device="wlan0",kind="fq"} 42
 # TYPE node_qdisc_requeues_total counter
 node_qdisc_requeues_total{device="eth0",kind="pfifo_fast"} 2
 node_qdisc_requeues_total{device="wlan0",kind="fq"} 1
-# HELP node_rapl_core_joules_total Current RAPL core value in joules
-# TYPE node_rapl_core_joules_total counter
-node_rapl_core_joules_total{index="0"} 118821.284256
-# HELP node_rapl_package_joules_total Current RAPL package value in joules
-# TYPE node_rapl_package_joules_total counter
-node_rapl_package_joules_total{index="0"} 240422.366267
+# HELP node_rapl_joules_total Current RAPL package value in joules
+# TYPE node_rapl_joules_total counter
+node_rapl_joules_total{index="0",name="package"} 240422.366267
 # HELP node_schedstat_running_seconds_total Number of seconds CPU spent running a process.
 # TYPE node_schedstat_running_seconds_total counter
 node_schedstat_running_seconds_total{cpu="0"} 2.045936778163039e+06

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -232,12 +232,24 @@ node_cooling_device_cur_state{name="0",type="Processor"} 0
 # HELP node_cooling_device_max_state Maximum throttle state of the cooling device
 # TYPE node_cooling_device_max_state gauge
 node_cooling_device_max_state{name="0",type="Processor"} 3
+# HELP node_cpu_bug_info The `bugs` field of CPU information from /proc/cpuinfo.
+# TYPE node_cpu_bug_info gauge
+node_cpu_bug_info{bug="cpu_meltdown"} 1
+node_cpu_bug_info{bug="mds"} 1
+node_cpu_bug_info{bug="spectre_v1"} 1
+node_cpu_bug_info{bug="spectre_v2"} 1
 # HELP node_cpu_core_throttles_total Number of times this cpu core has been throttled.
 # TYPE node_cpu_core_throttles_total counter
 node_cpu_core_throttles_total{core="0",package="0"} 5
 node_cpu_core_throttles_total{core="0",package="1"} 0
 node_cpu_core_throttles_total{core="1",package="0"} 0
 node_cpu_core_throttles_total{core="1",package="1"} 9
+# HELP node_cpu_flag_info The `flags` field of CPU information from /proc/cpuinfo.
+# TYPE node_cpu_flag_info gauge
+node_cpu_flag_info{flag="aes"} 1
+node_cpu_flag_info{flag="avx"} 1
+node_cpu_flag_info{flag="avx2"} 1
+node_cpu_flag_info{flag="constant_tsc"} 1
 # HELP node_cpu_guest_seconds_total Seconds the cpus spent in guests (VMs) for each mode.
 # TYPE node_cpu_guest_seconds_total counter
 node_cpu_guest_seconds_total{cpu="0",mode="nice"} 0.01
@@ -1955,6 +1967,9 @@ node_netstat_Tcp_InErrs 5
 # HELP node_netstat_Tcp_InSegs Statistic TcpInSegs.
 # TYPE node_netstat_Tcp_InSegs untyped
 node_netstat_Tcp_InSegs 5.7252008e+07
+# HELP node_netstat_Tcp_OutRsts Statistic TcpOutRsts.
+# TYPE node_netstat_Tcp_OutRsts untyped
+node_netstat_Tcp_OutRsts 1003
 # HELP node_netstat_Tcp_OutSegs Statistic TcpOutSegs.
 # TYPE node_netstat_Tcp_OutSegs untyped
 node_netstat_Tcp_OutSegs 5.4915039e+07
@@ -2065,7 +2080,7 @@ node_network_receive_bytes_total{device="lxcbr0"} 0
 node_network_receive_bytes_total{device="tun0"} 1888
 node_network_receive_bytes_total{device="veth4B09XN"} 648
 node_network_receive_bytes_total{device="wlan0"} 1.0437182923e+10
-node_network_receive_bytes_total{device="💩0"} 5.7750104e+07
+node_network_receive_bytes_total{device="í ½í²©0"} 5.7750104e+07
 # HELP node_network_receive_compressed_total Network device statistic receive_compressed.
 # TYPE node_network_receive_compressed_total counter
 node_network_receive_compressed_total{device="docker0"} 0
@@ -2077,7 +2092,7 @@ node_network_receive_compressed_total{device="lxcbr0"} 0
 node_network_receive_compressed_total{device="tun0"} 0
 node_network_receive_compressed_total{device="veth4B09XN"} 0
 node_network_receive_compressed_total{device="wlan0"} 0
-node_network_receive_compressed_total{device="💩0"} 0
+node_network_receive_compressed_total{device="í ½í²©0"} 0
 # HELP node_network_receive_drop_total Network device statistic receive_drop.
 # TYPE node_network_receive_drop_total counter
 node_network_receive_drop_total{device="docker0"} 0
@@ -2089,7 +2104,7 @@ node_network_receive_drop_total{device="lxcbr0"} 0
 node_network_receive_drop_total{device="tun0"} 0
 node_network_receive_drop_total{device="veth4B09XN"} 0
 node_network_receive_drop_total{device="wlan0"} 0
-node_network_receive_drop_total{device="💩0"} 0
+node_network_receive_drop_total{device="í ½í²©0"} 0
 # HELP node_network_receive_errs_total Network device statistic receive_errs.
 # TYPE node_network_receive_errs_total counter
 node_network_receive_errs_total{device="docker0"} 0
@@ -2101,7 +2116,7 @@ node_network_receive_errs_total{device="lxcbr0"} 0
 node_network_receive_errs_total{device="tun0"} 0
 node_network_receive_errs_total{device="veth4B09XN"} 0
 node_network_receive_errs_total{device="wlan0"} 0
-node_network_receive_errs_total{device="💩0"} 0
+node_network_receive_errs_total{device="í ½í²©0"} 0
 # HELP node_network_receive_fifo_total Network device statistic receive_fifo.
 # TYPE node_network_receive_fifo_total counter
 node_network_receive_fifo_total{device="docker0"} 0
@@ -2113,7 +2128,7 @@ node_network_receive_fifo_total{device="lxcbr0"} 0
 node_network_receive_fifo_total{device="tun0"} 0
 node_network_receive_fifo_total{device="veth4B09XN"} 0
 node_network_receive_fifo_total{device="wlan0"} 0
-node_network_receive_fifo_total{device="💩0"} 0
+node_network_receive_fifo_total{device="í ½í²©0"} 0
 # HELP node_network_receive_frame_total Network device statistic receive_frame.
 # TYPE node_network_receive_frame_total counter
 node_network_receive_frame_total{device="docker0"} 0
@@ -2125,7 +2140,7 @@ node_network_receive_frame_total{device="lxcbr0"} 0
 node_network_receive_frame_total{device="tun0"} 0
 node_network_receive_frame_total{device="veth4B09XN"} 0
 node_network_receive_frame_total{device="wlan0"} 0
-node_network_receive_frame_total{device="💩0"} 0
+node_network_receive_frame_total{device="í ½í²©0"} 0
 # HELP node_network_receive_multicast_total Network device statistic receive_multicast.
 # TYPE node_network_receive_multicast_total counter
 node_network_receive_multicast_total{device="docker0"} 0
@@ -2137,7 +2152,7 @@ node_network_receive_multicast_total{device="lxcbr0"} 0
 node_network_receive_multicast_total{device="tun0"} 0
 node_network_receive_multicast_total{device="veth4B09XN"} 0
 node_network_receive_multicast_total{device="wlan0"} 0
-node_network_receive_multicast_total{device="💩0"} 72
+node_network_receive_multicast_total{device="í ½í²©0"} 72
 # HELP node_network_receive_packets_total Network device statistic receive_packets.
 # TYPE node_network_receive_packets_total counter
 node_network_receive_packets_total{device="docker0"} 1.065585e+06
@@ -2149,7 +2164,7 @@ node_network_receive_packets_total{device="lxcbr0"} 0
 node_network_receive_packets_total{device="tun0"} 24
 node_network_receive_packets_total{device="veth4B09XN"} 8
 node_network_receive_packets_total{device="wlan0"} 1.3899359e+07
-node_network_receive_packets_total{device="💩0"} 105557
+node_network_receive_packets_total{device="í ½í²©0"} 105557
 # HELP node_network_speed_bytes speed_bytes value of /sys/class/net/<iface>.
 # TYPE node_network_speed_bytes gauge
 node_network_speed_bytes{device="eth0"} 1.25e+08
@@ -2164,7 +2179,7 @@ node_network_transmit_bytes_total{device="lxcbr0"} 2.630299e+06
 node_network_transmit_bytes_total{device="tun0"} 67120
 node_network_transmit_bytes_total{device="veth4B09XN"} 1.943284e+06
 node_network_transmit_bytes_total{device="wlan0"} 2.85164936e+09
-node_network_transmit_bytes_total{device="💩0"} 4.04570255e+08
+node_network_transmit_bytes_total{device="í ½í²©0"} 4.04570255e+08
 # HELP node_network_transmit_carrier_total Network device statistic transmit_carrier.
 # TYPE node_network_transmit_carrier_total counter
 node_network_transmit_carrier_total{device="docker0"} 0
@@ -2176,7 +2191,7 @@ node_network_transmit_carrier_total{device="lxcbr0"} 0
 node_network_transmit_carrier_total{device="tun0"} 0
 node_network_transmit_carrier_total{device="veth4B09XN"} 0
 node_network_transmit_carrier_total{device="wlan0"} 0
-node_network_transmit_carrier_total{device="💩0"} 0
+node_network_transmit_carrier_total{device="í ½í²©0"} 0
 # HELP node_network_transmit_colls_total Network device statistic transmit_colls.
 # TYPE node_network_transmit_colls_total counter
 node_network_transmit_colls_total{device="docker0"} 0
@@ -2188,7 +2203,7 @@ node_network_transmit_colls_total{device="lxcbr0"} 0
 node_network_transmit_colls_total{device="tun0"} 0
 node_network_transmit_colls_total{device="veth4B09XN"} 0
 node_network_transmit_colls_total{device="wlan0"} 0
-node_network_transmit_colls_total{device="💩0"} 0
+node_network_transmit_colls_total{device="í ½í²©0"} 0
 # HELP node_network_transmit_compressed_total Network device statistic transmit_compressed.
 # TYPE node_network_transmit_compressed_total counter
 node_network_transmit_compressed_total{device="docker0"} 0
@@ -2200,7 +2215,7 @@ node_network_transmit_compressed_total{device="lxcbr0"} 0
 node_network_transmit_compressed_total{device="tun0"} 0
 node_network_transmit_compressed_total{device="veth4B09XN"} 0
 node_network_transmit_compressed_total{device="wlan0"} 0
-node_network_transmit_compressed_total{device="💩0"} 0
+node_network_transmit_compressed_total{device="í ½í²©0"} 0
 # HELP node_network_transmit_drop_total Network device statistic transmit_drop.
 # TYPE node_network_transmit_drop_total counter
 node_network_transmit_drop_total{device="docker0"} 0
@@ -2212,7 +2227,7 @@ node_network_transmit_drop_total{device="lxcbr0"} 0
 node_network_transmit_drop_total{device="tun0"} 0
 node_network_transmit_drop_total{device="veth4B09XN"} 0
 node_network_transmit_drop_total{device="wlan0"} 0
-node_network_transmit_drop_total{device="💩0"} 0
+node_network_transmit_drop_total{device="í ½í²©0"} 0
 # HELP node_network_transmit_errs_total Network device statistic transmit_errs.
 # TYPE node_network_transmit_errs_total counter
 node_network_transmit_errs_total{device="docker0"} 0
@@ -2224,7 +2239,7 @@ node_network_transmit_errs_total{device="lxcbr0"} 0
 node_network_transmit_errs_total{device="tun0"} 0
 node_network_transmit_errs_total{device="veth4B09XN"} 0
 node_network_transmit_errs_total{device="wlan0"} 0
-node_network_transmit_errs_total{device="💩0"} 0
+node_network_transmit_errs_total{device="í ½í²©0"} 0
 # HELP node_network_transmit_fifo_total Network device statistic transmit_fifo.
 # TYPE node_network_transmit_fifo_total counter
 node_network_transmit_fifo_total{device="docker0"} 0
@@ -2236,7 +2251,7 @@ node_network_transmit_fifo_total{device="lxcbr0"} 0
 node_network_transmit_fifo_total{device="tun0"} 0
 node_network_transmit_fifo_total{device="veth4B09XN"} 0
 node_network_transmit_fifo_total{device="wlan0"} 0
-node_network_transmit_fifo_total{device="💩0"} 0
+node_network_transmit_fifo_total{device="í ½í²©0"} 0
 # HELP node_network_transmit_packets_total Network device statistic transmit_packets.
 # TYPE node_network_transmit_packets_total counter
 node_network_transmit_packets_total{device="docker0"} 1.929779e+06
@@ -2248,7 +2263,7 @@ node_network_transmit_packets_total{device="lxcbr0"} 28339
 node_network_transmit_packets_total{device="tun0"} 934
 node_network_transmit_packets_total{device="veth4B09XN"} 10640
 node_network_transmit_packets_total{device="wlan0"} 1.17262e+07
-node_network_transmit_packets_total{device="💩0"} 304261
+node_network_transmit_packets_total{device="í ½í²©0"} 304261
 # HELP node_network_transmit_queue_length transmit_queue_length value of /sys/class/net/<iface>.
 # TYPE node_network_transmit_queue_length gauge
 node_network_transmit_queue_length{device="eth0"} 1000
@@ -2406,7 +2421,7 @@ node_nfsd_reply_cache_hits_total 0
 # HELP node_nfsd_reply_cache_misses_total Total number of NFSd Reply Cache an operation that requires caching (idempotent).
 # TYPE node_nfsd_reply_cache_misses_total counter
 node_nfsd_reply_cache_misses_total 6
-# HELP node_nfsd_reply_cache_nocache_total Total number of NFSd Reply Cache non-idempotent operations (rename/delete/…).
+# HELP node_nfsd_reply_cache_nocache_total Total number of NFSd Reply Cache non-idempotent operations (rename/delete/â€¦).
 # TYPE node_nfsd_reply_cache_nocache_total counter
 node_nfsd_reply_cache_nocache_total 18622
 # HELP node_nfsd_requests_total Total number NFSd Requests by method and protocol.
@@ -2563,10 +2578,18 @@ node_procs_blocked 0
 # HELP node_procs_running Number of processes in runnable state.
 # TYPE node_procs_running gauge
 node_procs_running 2
+# HELP node_qdisc_backlog Number of bytes currently in queue to be sent.
+# TYPE node_qdisc_backlog gauge
+node_qdisc_backlog{device="eth0",kind="pfifo_fast"} 0
+node_qdisc_backlog{device="wlan0",kind="fq"} 0
 # HELP node_qdisc_bytes_total Number of bytes sent.
 # TYPE node_qdisc_bytes_total counter
 node_qdisc_bytes_total{device="eth0",kind="pfifo_fast"} 83
 node_qdisc_bytes_total{device="wlan0",kind="fq"} 42
+# HELP node_qdisc_current_queue_length Number of packets currently in queue to be sent.
+# TYPE node_qdisc_current_queue_length gauge
+node_qdisc_current_queue_length{device="eth0",kind="pfifo_fast"} 0
+node_qdisc_current_queue_length{device="wlan0",kind="fq"} 0
 # HELP node_qdisc_drops_total Number of packets dropped.
 # TYPE node_qdisc_drops_total counter
 node_qdisc_drops_total{device="eth0",kind="pfifo_fast"} 0

--- a/collector/rapl_linux.go
+++ b/collector/rapl_linux.go
@@ -16,12 +16,11 @@
 package collector
 
 import (
-	"strconv"
-	"strings"
-
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs/sysfs"
+	"github.com/prometheus/prometheus/util/strutil"
+	"strconv"
 )
 
 type raplCollector struct {
@@ -62,7 +61,7 @@ func (c *raplCollector) Update(ch chan<- prometheus.Metric) error {
 		index := strconv.Itoa(rz.Index)
 
 		descriptor := prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "rapl", strings.ReplaceAll(rz.Name, "-", "_")+"_joules_total"),
+			prometheus.BuildFQName(namespace, "rapl", strutil.SanitizeLabelName(rz.Name)+"_joules_total"),
 			"Current RAPL "+rz.Name+" value in joules",
 			[]string{"index"}, nil,
 		)

--- a/collector/rapl_linux.go
+++ b/collector/rapl_linux.go
@@ -17,6 +17,7 @@ package collector
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/client_golang/prometheus"

--- a/collector/rapl_linux.go
+++ b/collector/rapl_linux.go
@@ -61,7 +61,7 @@ func (c *raplCollector) Update(ch chan<- prometheus.Metric) error {
 		index := strconv.Itoa(rz.Index)
 
 		descriptor := prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "rapl", rz.Name+"_joules_total"),
+			prometheus.BuildFQName(namespace, "rapl", strings.ReplaceAll(rz.Name, "-", "_")+"_joules_total"),
 			"Current RAPL "+rz.Name+" value in joules",
 			[]string{"index"}, nil,
 		)

--- a/collector/rapl_linux.go
+++ b/collector/rapl_linux.go
@@ -19,7 +19,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs/sysfs"
-	"github.com/prometheus/prometheus/util/strutil"
 	"strconv"
 )
 
@@ -61,15 +60,16 @@ func (c *raplCollector) Update(ch chan<- prometheus.Metric) error {
 		index := strconv.Itoa(rz.Index)
 
 		descriptor := prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "rapl", strutil.SanitizeLabelName(rz.Name)+"_joules_total"),
+			prometheus.BuildFQName(namespace, "rapl", "joules_total"),
 			"Current RAPL "+rz.Name+" value in joules",
-			[]string{"index"}, nil,
+			[]string{"name","index"}, nil,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			descriptor,
 			prometheus.CounterValue,
 			float64(newMicrojoules)/1000000.0,
+			rz.Name,
 			index,
 		)
 	}

--- a/collector/rapl_linux.go
+++ b/collector/rapl_linux.go
@@ -62,7 +62,7 @@ func (c *raplCollector) Update(ch chan<- prometheus.Metric) error {
 		descriptor := prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "rapl", "joules_total"),
 			"Current RAPL "+rz.Name+" value in joules",
-			[]string{"name","index"}, nil,
+			[]string{"name", "index"}, nil,
 		)
 
 		ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
Issue:
When the rz.Name contains invalid metric character ("-") like this:
\# cat /sys/class/powercap/intel-rapl:0/name
package-15

Node exporter will panic

```
panic: "node_rapl_package-15_joules_total" is not a valid metric name
```

Signed-off-by: chinhnc <chicknsoupuds@gmail.com>