### PR TITLE
Fix node_scrape_collector_success behaviour

### DIFF
--- a/collector/conntrack_linux.go
+++ b/collector/conntrack_linux.go
@@ -51,14 +51,14 @@ func (c *conntrackCollector) Update(ch chan<- prometheus.Metric) error {
 	value, err := readUintFromFile(procFilePath("sys/net/netfilter/nf_conntrack_count"))
 	if err != nil {
 		// Conntrack probably not loaded into the kernel.
-		return nil
+		return err
 	}
 	ch <- prometheus.MustNewConstMetric(
 		c.current, prometheus.GaugeValue, float64(value))
 
 	value, err = readUintFromFile(procFilePath("sys/net/netfilter/nf_conntrack_max"))
 	if err != nil {
-		return nil
+		return err
 	}
 	ch <- prometheus.MustNewConstMetric(
 		c.limit, prometheus.GaugeValue, float64(value))

--- a/collector/conntrack_linux.go
+++ b/collector/conntrack_linux.go
@@ -16,7 +16,12 @@
 package collector
 
 import (
+	"errors"
+	"fmt"
+	"os"
+
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -50,18 +55,25 @@ func NewConntrackCollector(logger log.Logger) (Collector, error) {
 func (c *conntrackCollector) Update(ch chan<- prometheus.Metric) error {
 	value, err := readUintFromFile(procFilePath("sys/net/netfilter/nf_conntrack_count"))
 	if err != nil {
-		// Conntrack probably not loaded into the kernel.
-		return err
+		return c.handleErr(err)
 	}
 	ch <- prometheus.MustNewConstMetric(
 		c.current, prometheus.GaugeValue, float64(value))
 
 	value, err = readUintFromFile(procFilePath("sys/net/netfilter/nf_conntrack_max"))
 	if err != nil {
-		return err
+		return c.handleErr(err)
 	}
 	ch <- prometheus.MustNewConstMetric(
 		c.limit, prometheus.GaugeValue, float64(value))
 
 	return nil
+}
+
+func (c *conntrackCollector) handleErr(err error) error {
+	if errors.Is(err, os.ErrNotExist) {
+		level.Debug(c.logger).Log("msg", "conntrack probably not loaded")
+		return ErrNoData
+	}
+	return fmt.Errorf("failed to retrieve conntrack stats: %w", err)
 }

--- a/collector/pressure_linux.go
+++ b/collector/pressure_linux.go
@@ -89,7 +89,7 @@ func (c *pressureStatsCollector) Update(ch chan<- prometheus.Metric) error {
 		vals, err := c.fs.PSIStatsForResource(res)
 		if err != nil {
 			level.Debug(c.logger).Log("msg", "pressure information is unavailable, you need a Linux kernel >= 4.20 and/or CONFIG_PSI enabled for your kernel")
-			return nil
+			return ErrNoData
 		}
 		switch res {
 		case "cpu":

--- a/collector/pressure_linux.go
+++ b/collector/pressure_linux.go
@@ -16,7 +16,9 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -88,8 +90,11 @@ func (c *pressureStatsCollector) Update(ch chan<- prometheus.Metric) error {
 		level.Debug(c.logger).Log("msg", "collecting statistics for resource", "resource", res)
 		vals, err := c.fs.PSIStatsForResource(res)
 		if err != nil {
-			level.Debug(c.logger).Log("msg", "pressure information is unavailable, you need a Linux kernel >= 4.20 and/or CONFIG_PSI enabled for your kernel")
-			return ErrNoData
+			if errors.Is(err, os.ErrNotExist) {
+				level.Debug(c.logger).Log("msg", "pressure information is unavailable, you need a Linux kernel >= 4.20 and/or CONFIG_PSI enabled for your kernel")
+				return ErrNoData
+			}
+			return fmt.Errorf("failed to retrieve pressure stats: %w", err)
 		}
 		switch res {
 		case "cpu":

--- a/collector/rapl_linux.go
+++ b/collector/rapl_linux.go
@@ -16,15 +16,20 @@
 package collector
 
 import (
+	"errors"
+	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs/sysfs"
 )
 
 type raplCollector struct {
-	fs sysfs.FS
+	fs     sysfs.FS
+	logger log.Logger
 }
 
 func init() {
@@ -40,7 +45,8 @@ func NewRaplCollector(logger log.Logger) (Collector, error) {
 	}
 
 	collector := raplCollector{
-		fs: fs,
+		fs:     fs,
+		logger: logger,
 	}
 	return &collector, nil
 }
@@ -50,7 +56,11 @@ func (c *raplCollector) Update(ch chan<- prometheus.Metric) error {
 	// nil zones are fine when platform doesn't have powercap files present.
 	zones, err := sysfs.GetRaplZones(c.fs)
 	if err != nil {
-		return ErrNoData
+		if errors.Is(err, os.ErrNotExist) {
+			level.Debug(c.logger).Log("msg", "Platform doesn't have powercap files present", "err", err)
+			return ErrNoData
+		}
+		return fmt.Errorf("failed to retrieve rapl stats: %w", err)
 	}
 
 	for _, rz := range zones {

--- a/collector/rapl_linux.go
+++ b/collector/rapl_linux.go
@@ -50,7 +50,7 @@ func (c *raplCollector) Update(ch chan<- prometheus.Metric) error {
 	// nil zones are fine when platform doesn't have powercap files present.
 	zones, err := sysfs.GetRaplZones(c.fs)
 	if err != nil {
-		return nil
+		return ErrNoData
 	}
 
 	for _, rz := range zones {

--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -65,6 +65,14 @@ func NewZFSCollector(logger log.Logger) (Collector, error) {
 }
 
 func (c *zfsCollector) Update(ch chan<- prometheus.Metric) error {
+
+	if _, err := c.openProcFile(c.linuxProcpathBase); err != nil {
+		if err == errZFSNotAvailable {
+			level.Debug(c.logger).Log("err", err)
+			return ErrNoData
+		}
+	}
+
 	for subsystem := range c.linuxPathMap {
 		if err := c.updateZfsStats(subsystem, ch); err != nil {
 			if err == errZFSNotAvailable {


### PR DESCRIPTION
Fixes #1723 
Related to #1323 

- Make empty collection of ZFS return success=0
- Modify behaviour of other collectors that return nil as error when experiencing error in the Update method