### PR TITLE
Fix memory gauge in mixin with multiple pods

### DIFF
--- a/docs/node-mixin/dashboards/node.libsonnet
+++ b/docs/node-mixin/dashboards/node.libsonnet
@@ -75,14 +75,15 @@ local gauge = promgrafonnet.gauge;
 
       // TODO: It would be nicer to have a gauge that gets a 0-1 range and displays it as a percentage 0%-100%.
       // This needs to be added upstream in the promgrafonnet library and then changed here.
+      // NOTE: avg() is used to circumvent a label change caused by a node_exporter rollout.
       local memoryGauge = gauge.new(
         'Memory Usage',
         |||
           100 -
           (
-            node_memory_MemAvailable_bytes{%(nodeExporterSelector)s, instance="$instance"}
+            avg(node_memory_MemAvailable_bytes{%(nodeExporterSelector)s, instance="$instance"})
           /
-            node_memory_MemTotal_bytes{%(nodeExporterSelector)s, instance="$instance"}
+            avg(node_memory_MemTotal_bytes{%(nodeExporterSelector)s, instance="$instance"})
           * 100
           )
         ||| % $._config,


### PR DESCRIPTION
Signed-off-by: Arthur Outhenin-Chalandre <arthur@cri.epita.fr>

When there is multiple pods over the selected time range grafana display the following errors "Only queries that return single series/table is supported".

This PR add a simple avg() to fix this issue.