### PR TITLE
Change timex sync_status to follow maximum error

### DIFF
--- a/collector/timex.go
+++ b/collector/timex.go
@@ -35,6 +35,10 @@ const (
 	// 1 second in
 	nanoSeconds  = 1000000000
 	microSeconds = 1000000
+
+	// Maximum value of timex.Maxerror, which triggers
+	// the TIME_ERROR status
+	maxMaxerror = 16000000
 )
 
 type timexCollector struct {
@@ -161,12 +165,12 @@ func (c *timexCollector) Update(ch chan<- prometheus.Metric) error {
 	var divisor float64
 	var timex = new(unix.Timex)
 
-	status, err := unix.Adjtimex(timex)
+	_, err := unix.Adjtimex(timex)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve adjtimex stats: %w", err)
 	}
 
-	if status == timeError {
+	if timex.Maxerror >= maxMaxerror {
 		syncStatus = 0
 	} else {
 		syncStatus = 1


### PR DESCRIPTION
Some NTP implementations (e.g. chrony) can be configured to not clear
the "unsynchronized" bit from the system clock status in order to
prevent kernel updating the real-time clock, which causes the timex
sync_status to be always 0, even if the system clock is synchronized.

The kernel tracks a maximum error of the clock, which is incremented at
a rate of 500 ppm. When it gets to 16 seconds, the "unsynchronized" bit
is set automatically.

Ignore the timex status and set sync_status to 1 if the maximum error
is smaller than 16 seconds.