### PR TITLE
docs/node-mixin: add max error condition to alert about desynchronized clock

### DIFF
--- a/docs/node-mixin/alerts/alerts.libsonnet
+++ b/docs/node-mixin/alerts/alerts.libsonnet
@@ -238,6 +238,8 @@
             alert: 'NodeClockNotSynchronising',
             expr: |||
               min_over_time(node_timex_sync_status[5m]) == 0
+              and
+              node_timex_maxerror_seconds >= 16
             ||| % $._config,
             'for': '10m',
             labels: {


### PR DESCRIPTION
Different approach to the same problem as in https://github.com/prometheus/node_exporter/pull/1850

/cc @SuperQ 