### PR TITLE
Adding netclass labels to netdev stats

### DIFF
--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2086,199 +2086,199 @@ node_network_net_dev_group{device="eth0"} 0
 node_network_protocol_type{device="eth0"} 1
 # HELP node_network_receive_bytes_total Network device statistic receive_bytes.
 # TYPE node_network_receive_bytes_total counter
-node_network_receive_bytes_total{device="docker0"} 6.4910168e+07
-node_network_receive_bytes_total{device="eth0"} 6.8210035552e+10
-node_network_receive_bytes_total{device="flannel.1"} 1.8144009813e+10
-node_network_receive_bytes_total{device="ibr10:30"} 0
-node_network_receive_bytes_total{device="lo"} 4.35303245e+08
-node_network_receive_bytes_total{device="lxcbr0"} 0
-node_network_receive_bytes_total{device="tun0"} 1888
-node_network_receive_bytes_total{device="veth4B09XN"} 648
-node_network_receive_bytes_total{device="wlan0"} 1.0437182923e+10
-node_network_receive_bytes_total{device="💩0"} 5.7750104e+07
+node_network_receive_bytes_total{device="docker0",ifalias="",operstate=""} 6.4910168e+07
+node_network_receive_bytes_total{device="eth0",ifalias="",operstate="up"} 6.8210035552e+10
+node_network_receive_bytes_total{device="flannel.1",ifalias="",operstate=""} 1.8144009813e+10
+node_network_receive_bytes_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_receive_bytes_total{device="lo",ifalias="",operstate=""} 4.35303245e+08
+node_network_receive_bytes_total{device="lxcbr0",ifalias="",operstate=""} 0
+node_network_receive_bytes_total{device="tun0",ifalias="",operstate=""} 1888
+node_network_receive_bytes_total{device="veth4B09XN",ifalias="",operstate=""} 648
+node_network_receive_bytes_total{device="wlan0",ifalias="",operstate=""} 1.0437182923e+10
+node_network_receive_bytes_total{device="💩0",ifalias="",operstate=""} 5.7750104e+07
 # HELP node_network_receive_compressed_total Network device statistic receive_compressed.
 # TYPE node_network_receive_compressed_total counter
-node_network_receive_compressed_total{device="docker0"} 0
-node_network_receive_compressed_total{device="eth0"} 0
-node_network_receive_compressed_total{device="flannel.1"} 0
-node_network_receive_compressed_total{device="ibr10:30"} 0
-node_network_receive_compressed_total{device="lo"} 0
-node_network_receive_compressed_total{device="lxcbr0"} 0
-node_network_receive_compressed_total{device="tun0"} 0
-node_network_receive_compressed_total{device="veth4B09XN"} 0
-node_network_receive_compressed_total{device="wlan0"} 0
-node_network_receive_compressed_total{device="💩0"} 0
+node_network_receive_compressed_total{device="docker0",ifalias="",operstate=""} 0
+node_network_receive_compressed_total{device="eth0",ifalias="",operstate="up"} 0
+node_network_receive_compressed_total{device="flannel.1",ifalias="",operstate=""} 0
+node_network_receive_compressed_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_receive_compressed_total{device="lo",ifalias="",operstate=""} 0
+node_network_receive_compressed_total{device="lxcbr0",ifalias="",operstate=""} 0
+node_network_receive_compressed_total{device="tun0",ifalias="",operstate=""} 0
+node_network_receive_compressed_total{device="veth4B09XN",ifalias="",operstate=""} 0
+node_network_receive_compressed_total{device="wlan0",ifalias="",operstate=""} 0
+node_network_receive_compressed_total{device="💩0",ifalias="",operstate=""} 0
 # HELP node_network_receive_drop_total Network device statistic receive_drop.
 # TYPE node_network_receive_drop_total counter
-node_network_receive_drop_total{device="docker0"} 0
-node_network_receive_drop_total{device="eth0"} 0
-node_network_receive_drop_total{device="flannel.1"} 0
-node_network_receive_drop_total{device="ibr10:30"} 0
-node_network_receive_drop_total{device="lo"} 0
-node_network_receive_drop_total{device="lxcbr0"} 0
-node_network_receive_drop_total{device="tun0"} 0
-node_network_receive_drop_total{device="veth4B09XN"} 0
-node_network_receive_drop_total{device="wlan0"} 0
-node_network_receive_drop_total{device="💩0"} 0
+node_network_receive_drop_total{device="docker0",ifalias="",operstate=""} 0
+node_network_receive_drop_total{device="eth0",ifalias="",operstate="up"} 0
+node_network_receive_drop_total{device="flannel.1",ifalias="",operstate=""} 0
+node_network_receive_drop_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_receive_drop_total{device="lo",ifalias="",operstate=""} 0
+node_network_receive_drop_total{device="lxcbr0",ifalias="",operstate=""} 0
+node_network_receive_drop_total{device="tun0",ifalias="",operstate=""} 0
+node_network_receive_drop_total{device="veth4B09XN",ifalias="",operstate=""} 0
+node_network_receive_drop_total{device="wlan0",ifalias="",operstate=""} 0
+node_network_receive_drop_total{device="💩0",ifalias="",operstate=""} 0
 # HELP node_network_receive_errs_total Network device statistic receive_errs.
 # TYPE node_network_receive_errs_total counter
-node_network_receive_errs_total{device="docker0"} 0
-node_network_receive_errs_total{device="eth0"} 0
-node_network_receive_errs_total{device="flannel.1"} 0
-node_network_receive_errs_total{device="ibr10:30"} 0
-node_network_receive_errs_total{device="lo"} 0
-node_network_receive_errs_total{device="lxcbr0"} 0
-node_network_receive_errs_total{device="tun0"} 0
-node_network_receive_errs_total{device="veth4B09XN"} 0
-node_network_receive_errs_total{device="wlan0"} 0
-node_network_receive_errs_total{device="💩0"} 0
+node_network_receive_errs_total{device="docker0",ifalias="",operstate=""} 0
+node_network_receive_errs_total{device="eth0",ifalias="",operstate="up"} 0
+node_network_receive_errs_total{device="flannel.1",ifalias="",operstate=""} 0
+node_network_receive_errs_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_receive_errs_total{device="lo",ifalias="",operstate=""} 0
+node_network_receive_errs_total{device="lxcbr0",ifalias="",operstate=""} 0
+node_network_receive_errs_total{device="tun0",ifalias="",operstate=""} 0
+node_network_receive_errs_total{device="veth4B09XN",ifalias="",operstate=""} 0
+node_network_receive_errs_total{device="wlan0",ifalias="",operstate=""} 0
+node_network_receive_errs_total{device="💩0",ifalias="",operstate=""} 0
 # HELP node_network_receive_fifo_total Network device statistic receive_fifo.
 # TYPE node_network_receive_fifo_total counter
-node_network_receive_fifo_total{device="docker0"} 0
-node_network_receive_fifo_total{device="eth0"} 0
-node_network_receive_fifo_total{device="flannel.1"} 0
-node_network_receive_fifo_total{device="ibr10:30"} 0
-node_network_receive_fifo_total{device="lo"} 0
-node_network_receive_fifo_total{device="lxcbr0"} 0
-node_network_receive_fifo_total{device="tun0"} 0
-node_network_receive_fifo_total{device="veth4B09XN"} 0
-node_network_receive_fifo_total{device="wlan0"} 0
-node_network_receive_fifo_total{device="💩0"} 0
+node_network_receive_fifo_total{device="docker0",ifalias="",operstate=""} 0
+node_network_receive_fifo_total{device="eth0",ifalias="",operstate="up"} 0
+node_network_receive_fifo_total{device="flannel.1",ifalias="",operstate=""} 0
+node_network_receive_fifo_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_receive_fifo_total{device="lo",ifalias="",operstate=""} 0
+node_network_receive_fifo_total{device="lxcbr0",ifalias="",operstate=""} 0
+node_network_receive_fifo_total{device="tun0",ifalias="",operstate=""} 0
+node_network_receive_fifo_total{device="veth4B09XN",ifalias="",operstate=""} 0
+node_network_receive_fifo_total{device="wlan0",ifalias="",operstate=""} 0
+node_network_receive_fifo_total{device="💩0",ifalias="",operstate=""} 0
 # HELP node_network_receive_frame_total Network device statistic receive_frame.
 # TYPE node_network_receive_frame_total counter
-node_network_receive_frame_total{device="docker0"} 0
-node_network_receive_frame_total{device="eth0"} 0
-node_network_receive_frame_total{device="flannel.1"} 0
-node_network_receive_frame_total{device="ibr10:30"} 0
-node_network_receive_frame_total{device="lo"} 0
-node_network_receive_frame_total{device="lxcbr0"} 0
-node_network_receive_frame_total{device="tun0"} 0
-node_network_receive_frame_total{device="veth4B09XN"} 0
-node_network_receive_frame_total{device="wlan0"} 0
-node_network_receive_frame_total{device="💩0"} 0
+node_network_receive_frame_total{device="docker0",ifalias="",operstate=""} 0
+node_network_receive_frame_total{device="eth0",ifalias="",operstate="up"} 0
+node_network_receive_frame_total{device="flannel.1",ifalias="",operstate=""} 0
+node_network_receive_frame_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_receive_frame_total{device="lo",ifalias="",operstate=""} 0
+node_network_receive_frame_total{device="lxcbr0",ifalias="",operstate=""} 0
+node_network_receive_frame_total{device="tun0",ifalias="",operstate=""} 0
+node_network_receive_frame_total{device="veth4B09XN",ifalias="",operstate=""} 0
+node_network_receive_frame_total{device="wlan0",ifalias="",operstate=""} 0
+node_network_receive_frame_total{device="💩0",ifalias="",operstate=""} 0
 # HELP node_network_receive_multicast_total Network device statistic receive_multicast.
 # TYPE node_network_receive_multicast_total counter
-node_network_receive_multicast_total{device="docker0"} 0
-node_network_receive_multicast_total{device="eth0"} 0
-node_network_receive_multicast_total{device="flannel.1"} 0
-node_network_receive_multicast_total{device="ibr10:30"} 0
-node_network_receive_multicast_total{device="lo"} 0
-node_network_receive_multicast_total{device="lxcbr0"} 0
-node_network_receive_multicast_total{device="tun0"} 0
-node_network_receive_multicast_total{device="veth4B09XN"} 0
-node_network_receive_multicast_total{device="wlan0"} 0
-node_network_receive_multicast_total{device="💩0"} 72
+node_network_receive_multicast_total{device="docker0",ifalias="",operstate=""} 0
+node_network_receive_multicast_total{device="eth0",ifalias="",operstate="up"} 0
+node_network_receive_multicast_total{device="flannel.1",ifalias="",operstate=""} 0
+node_network_receive_multicast_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_receive_multicast_total{device="lo",ifalias="",operstate=""} 0
+node_network_receive_multicast_total{device="lxcbr0",ifalias="",operstate=""} 0
+node_network_receive_multicast_total{device="tun0",ifalias="",operstate=""} 0
+node_network_receive_multicast_total{device="veth4B09XN",ifalias="",operstate=""} 0
+node_network_receive_multicast_total{device="wlan0",ifalias="",operstate=""} 0
+node_network_receive_multicast_total{device="💩0",ifalias="",operstate=""} 72
 # HELP node_network_receive_packets_total Network device statistic receive_packets.
 # TYPE node_network_receive_packets_total counter
-node_network_receive_packets_total{device="docker0"} 1.065585e+06
-node_network_receive_packets_total{device="eth0"} 5.20993275e+08
-node_network_receive_packets_total{device="flannel.1"} 2.28499337e+08
-node_network_receive_packets_total{device="ibr10:30"} 0
-node_network_receive_packets_total{device="lo"} 1.832522e+06
-node_network_receive_packets_total{device="lxcbr0"} 0
-node_network_receive_packets_total{device="tun0"} 24
-node_network_receive_packets_total{device="veth4B09XN"} 8
-node_network_receive_packets_total{device="wlan0"} 1.3899359e+07
-node_network_receive_packets_total{device="💩0"} 105557
+node_network_receive_packets_total{device="docker0",ifalias="",operstate=""} 1.065585e+06
+node_network_receive_packets_total{device="eth0",ifalias="",operstate="up"} 5.20993275e+08
+node_network_receive_packets_total{device="flannel.1",ifalias="",operstate=""} 2.28499337e+08
+node_network_receive_packets_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_receive_packets_total{device="lo",ifalias="",operstate=""} 1.832522e+06
+node_network_receive_packets_total{device="lxcbr0",ifalias="",operstate=""} 0
+node_network_receive_packets_total{device="tun0",ifalias="",operstate=""} 24
+node_network_receive_packets_total{device="veth4B09XN",ifalias="",operstate=""} 8
+node_network_receive_packets_total{device="wlan0",ifalias="",operstate=""} 1.3899359e+07
+node_network_receive_packets_total{device="💩0",ifalias="",operstate=""} 105557
 # HELP node_network_speed_bytes speed_bytes value of /sys/class/net/<iface>.
 # TYPE node_network_speed_bytes gauge
 node_network_speed_bytes{device="eth0"} 1.25e+08
 # HELP node_network_transmit_bytes_total Network device statistic transmit_bytes.
 # TYPE node_network_transmit_bytes_total counter
-node_network_transmit_bytes_total{device="docker0"} 2.681662018e+09
-node_network_transmit_bytes_total{device="eth0"} 9.315587528e+09
-node_network_transmit_bytes_total{device="flannel.1"} 2.0758990068e+10
-node_network_transmit_bytes_total{device="ibr10:30"} 0
-node_network_transmit_bytes_total{device="lo"} 4.35303245e+08
-node_network_transmit_bytes_total{device="lxcbr0"} 2.630299e+06
-node_network_transmit_bytes_total{device="tun0"} 67120
-node_network_transmit_bytes_total{device="veth4B09XN"} 1.943284e+06
-node_network_transmit_bytes_total{device="wlan0"} 2.85164936e+09
-node_network_transmit_bytes_total{device="💩0"} 4.04570255e+08
+node_network_transmit_bytes_total{device="docker0",ifalias="",operstate=""} 2.681662018e+09
+node_network_transmit_bytes_total{device="eth0",ifalias="",operstate="up"} 9.315587528e+09
+node_network_transmit_bytes_total{device="flannel.1",ifalias="",operstate=""} 2.0758990068e+10
+node_network_transmit_bytes_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_transmit_bytes_total{device="lo",ifalias="",operstate=""} 4.35303245e+08
+node_network_transmit_bytes_total{device="lxcbr0",ifalias="",operstate=""} 2.630299e+06
+node_network_transmit_bytes_total{device="tun0",ifalias="",operstate=""} 67120
+node_network_transmit_bytes_total{device="veth4B09XN",ifalias="",operstate=""} 1.943284e+06
+node_network_transmit_bytes_total{device="wlan0",ifalias="",operstate=""} 2.85164936e+09
+node_network_transmit_bytes_total{device="💩0",ifalias="",operstate=""} 4.04570255e+08
 # HELP node_network_transmit_carrier_total Network device statistic transmit_carrier.
 # TYPE node_network_transmit_carrier_total counter
-node_network_transmit_carrier_total{device="docker0"} 0
-node_network_transmit_carrier_total{device="eth0"} 0
-node_network_transmit_carrier_total{device="flannel.1"} 0
-node_network_transmit_carrier_total{device="ibr10:30"} 0
-node_network_transmit_carrier_total{device="lo"} 0
-node_network_transmit_carrier_total{device="lxcbr0"} 0
-node_network_transmit_carrier_total{device="tun0"} 0
-node_network_transmit_carrier_total{device="veth4B09XN"} 0
-node_network_transmit_carrier_total{device="wlan0"} 0
-node_network_transmit_carrier_total{device="💩0"} 0
+node_network_transmit_carrier_total{device="docker0",ifalias="",operstate=""} 0
+node_network_transmit_carrier_total{device="eth0",ifalias="",operstate="up"} 0
+node_network_transmit_carrier_total{device="flannel.1",ifalias="",operstate=""} 0
+node_network_transmit_carrier_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_transmit_carrier_total{device="lo",ifalias="",operstate=""} 0
+node_network_transmit_carrier_total{device="lxcbr0",ifalias="",operstate=""} 0
+node_network_transmit_carrier_total{device="tun0",ifalias="",operstate=""} 0
+node_network_transmit_carrier_total{device="veth4B09XN",ifalias="",operstate=""} 0
+node_network_transmit_carrier_total{device="wlan0",ifalias="",operstate=""} 0
+node_network_transmit_carrier_total{device="💩0",ifalias="",operstate=""} 0
 # HELP node_network_transmit_colls_total Network device statistic transmit_colls.
 # TYPE node_network_transmit_colls_total counter
-node_network_transmit_colls_total{device="docker0"} 0
-node_network_transmit_colls_total{device="eth0"} 0
-node_network_transmit_colls_total{device="flannel.1"} 0
-node_network_transmit_colls_total{device="ibr10:30"} 0
-node_network_transmit_colls_total{device="lo"} 0
-node_network_transmit_colls_total{device="lxcbr0"} 0
-node_network_transmit_colls_total{device="tun0"} 0
-node_network_transmit_colls_total{device="veth4B09XN"} 0
-node_network_transmit_colls_total{device="wlan0"} 0
-node_network_transmit_colls_total{device="💩0"} 0
+node_network_transmit_colls_total{device="docker0",ifalias="",operstate=""} 0
+node_network_transmit_colls_total{device="eth0",ifalias="",operstate="up"} 0
+node_network_transmit_colls_total{device="flannel.1",ifalias="",operstate=""} 0
+node_network_transmit_colls_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_transmit_colls_total{device="lo",ifalias="",operstate=""} 0
+node_network_transmit_colls_total{device="lxcbr0",ifalias="",operstate=""} 0
+node_network_transmit_colls_total{device="tun0",ifalias="",operstate=""} 0
+node_network_transmit_colls_total{device="veth4B09XN",ifalias="",operstate=""} 0
+node_network_transmit_colls_total{device="wlan0",ifalias="",operstate=""} 0
+node_network_transmit_colls_total{device="💩0",ifalias="",operstate=""} 0
 # HELP node_network_transmit_compressed_total Network device statistic transmit_compressed.
 # TYPE node_network_transmit_compressed_total counter
-node_network_transmit_compressed_total{device="docker0"} 0
-node_network_transmit_compressed_total{device="eth0"} 0
-node_network_transmit_compressed_total{device="flannel.1"} 0
-node_network_transmit_compressed_total{device="ibr10:30"} 0
-node_network_transmit_compressed_total{device="lo"} 0
-node_network_transmit_compressed_total{device="lxcbr0"} 0
-node_network_transmit_compressed_total{device="tun0"} 0
-node_network_transmit_compressed_total{device="veth4B09XN"} 0
-node_network_transmit_compressed_total{device="wlan0"} 0
-node_network_transmit_compressed_total{device="💩0"} 0
+node_network_transmit_compressed_total{device="docker0",ifalias="",operstate=""} 0
+node_network_transmit_compressed_total{device="eth0",ifalias="",operstate="up"} 0
+node_network_transmit_compressed_total{device="flannel.1",ifalias="",operstate=""} 0
+node_network_transmit_compressed_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_transmit_compressed_total{device="lo",ifalias="",operstate=""} 0
+node_network_transmit_compressed_total{device="lxcbr0",ifalias="",operstate=""} 0
+node_network_transmit_compressed_total{device="tun0",ifalias="",operstate=""} 0
+node_network_transmit_compressed_total{device="veth4B09XN",ifalias="",operstate=""} 0
+node_network_transmit_compressed_total{device="wlan0",ifalias="",operstate=""} 0
+node_network_transmit_compressed_total{device="💩0",ifalias="",operstate=""} 0
 # HELP node_network_transmit_drop_total Network device statistic transmit_drop.
 # TYPE node_network_transmit_drop_total counter
-node_network_transmit_drop_total{device="docker0"} 0
-node_network_transmit_drop_total{device="eth0"} 0
-node_network_transmit_drop_total{device="flannel.1"} 64
-node_network_transmit_drop_total{device="ibr10:30"} 0
-node_network_transmit_drop_total{device="lo"} 0
-node_network_transmit_drop_total{device="lxcbr0"} 0
-node_network_transmit_drop_total{device="tun0"} 0
-node_network_transmit_drop_total{device="veth4B09XN"} 0
-node_network_transmit_drop_total{device="wlan0"} 0
-node_network_transmit_drop_total{device="💩0"} 0
+node_network_transmit_drop_total{device="docker0",ifalias="",operstate=""} 0
+node_network_transmit_drop_total{device="eth0",ifalias="",operstate="up"} 0
+node_network_transmit_drop_total{device="flannel.1",ifalias="",operstate=""} 64
+node_network_transmit_drop_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_transmit_drop_total{device="lo",ifalias="",operstate=""} 0
+node_network_transmit_drop_total{device="lxcbr0",ifalias="",operstate=""} 0
+node_network_transmit_drop_total{device="tun0",ifalias="",operstate=""} 0
+node_network_transmit_drop_total{device="veth4B09XN",ifalias="",operstate=""} 0
+node_network_transmit_drop_total{device="wlan0",ifalias="",operstate=""} 0
+node_network_transmit_drop_total{device="💩0",ifalias="",operstate=""} 0
 # HELP node_network_transmit_errs_total Network device statistic transmit_errs.
 # TYPE node_network_transmit_errs_total counter
-node_network_transmit_errs_total{device="docker0"} 0
-node_network_transmit_errs_total{device="eth0"} 0
-node_network_transmit_errs_total{device="flannel.1"} 0
-node_network_transmit_errs_total{device="ibr10:30"} 0
-node_network_transmit_errs_total{device="lo"} 0
-node_network_transmit_errs_total{device="lxcbr0"} 0
-node_network_transmit_errs_total{device="tun0"} 0
-node_network_transmit_errs_total{device="veth4B09XN"} 0
-node_network_transmit_errs_total{device="wlan0"} 0
-node_network_transmit_errs_total{device="💩0"} 0
+node_network_transmit_errs_total{device="docker0",ifalias="",operstate=""} 0
+node_network_transmit_errs_total{device="eth0",ifalias="",operstate="up"} 0
+node_network_transmit_errs_total{device="flannel.1",ifalias="",operstate=""} 0
+node_network_transmit_errs_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_transmit_errs_total{device="lo",ifalias="",operstate=""} 0
+node_network_transmit_errs_total{device="lxcbr0",ifalias="",operstate=""} 0
+node_network_transmit_errs_total{device="tun0",ifalias="",operstate=""} 0
+node_network_transmit_errs_total{device="veth4B09XN",ifalias="",operstate=""} 0
+node_network_transmit_errs_total{device="wlan0",ifalias="",operstate=""} 0
+node_network_transmit_errs_total{device="💩0",ifalias="",operstate=""} 0
 # HELP node_network_transmit_fifo_total Network device statistic transmit_fifo.
 # TYPE node_network_transmit_fifo_total counter
-node_network_transmit_fifo_total{device="docker0"} 0
-node_network_transmit_fifo_total{device="eth0"} 0
-node_network_transmit_fifo_total{device="flannel.1"} 0
-node_network_transmit_fifo_total{device="ibr10:30"} 0
-node_network_transmit_fifo_total{device="lo"} 0
-node_network_transmit_fifo_total{device="lxcbr0"} 0
-node_network_transmit_fifo_total{device="tun0"} 0
-node_network_transmit_fifo_total{device="veth4B09XN"} 0
-node_network_transmit_fifo_total{device="wlan0"} 0
-node_network_transmit_fifo_total{device="💩0"} 0
+node_network_transmit_fifo_total{device="docker0",ifalias="",operstate=""} 0
+node_network_transmit_fifo_total{device="eth0",ifalias="",operstate="up"} 0
+node_network_transmit_fifo_total{device="flannel.1",ifalias="",operstate=""} 0
+node_network_transmit_fifo_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_transmit_fifo_total{device="lo",ifalias="",operstate=""} 0
+node_network_transmit_fifo_total{device="lxcbr0",ifalias="",operstate=""} 0
+node_network_transmit_fifo_total{device="tun0",ifalias="",operstate=""} 0
+node_network_transmit_fifo_total{device="veth4B09XN",ifalias="",operstate=""} 0
+node_network_transmit_fifo_total{device="wlan0",ifalias="",operstate=""} 0
+node_network_transmit_fifo_total{device="💩0",ifalias="",operstate=""} 0
 # HELP node_network_transmit_packets_total Network device statistic transmit_packets.
 # TYPE node_network_transmit_packets_total counter
-node_network_transmit_packets_total{device="docker0"} 1.929779e+06
-node_network_transmit_packets_total{device="eth0"} 4.3451486e+07
-node_network_transmit_packets_total{device="flannel.1"} 2.58369223e+08
-node_network_transmit_packets_total{device="ibr10:30"} 0
-node_network_transmit_packets_total{device="lo"} 1.832522e+06
-node_network_transmit_packets_total{device="lxcbr0"} 28339
-node_network_transmit_packets_total{device="tun0"} 934
-node_network_transmit_packets_total{device="veth4B09XN"} 10640
-node_network_transmit_packets_total{device="wlan0"} 1.17262e+07
-node_network_transmit_packets_total{device="💩0"} 304261
+node_network_transmit_packets_total{device="docker0",ifalias="",operstate=""} 1.929779e+06
+node_network_transmit_packets_total{device="eth0",ifalias="",operstate="up"} 4.3451486e+07
+node_network_transmit_packets_total{device="flannel.1",ifalias="",operstate=""} 2.58369223e+08
+node_network_transmit_packets_total{device="ibr10:30",ifalias="",operstate=""} 0
+node_network_transmit_packets_total{device="lo",ifalias="",operstate=""} 1.832522e+06
+node_network_transmit_packets_total{device="lxcbr0",ifalias="",operstate=""} 28339
+node_network_transmit_packets_total{device="tun0",ifalias="",operstate=""} 934
+node_network_transmit_packets_total{device="veth4B09XN",ifalias="",operstate=""} 10640
+node_network_transmit_packets_total{device="wlan0",ifalias="",operstate=""} 1.17262e+07
+node_network_transmit_packets_total{device="💩0",ifalias="",operstate=""} 304261
 # HELP node_network_transmit_queue_length transmit_queue_length value of /sys/class/net/<iface>.
 # TYPE node_network_transmit_queue_length gauge
 node_network_transmit_queue_length{device="eth0"} 1000

--- a/collector/netdev_bsd.go
+++ b/collector/netdev_bsd.go
@@ -60,17 +60,21 @@ func getNetDevStats(ignore *regexp.Regexp, accept *regexp.Regexp, logger log.Log
 
 		data := (*C.struct_if_data)(ifa.ifa_data)
 
-		netDev[dev] = map[string]uint64{
-			"receive_packets":    uint64(data.ifi_ipackets),
-			"transmit_packets":   uint64(data.ifi_opackets),
-			"receive_errs":       uint64(data.ifi_ierrors),
-			"transmit_errs":      uint64(data.ifi_oerrors),
-			"receive_bytes":      uint64(data.ifi_ibytes),
-			"transmit_bytes":     uint64(data.ifi_obytes),
-			"receive_multicast":  uint64(data.ifi_imcasts),
-			"transmit_multicast": uint64(data.ifi_omcasts),
-			"receive_drop":       uint64(data.ifi_iqdrops),
-			"transmit_drop":      uint64(data.ifi_oqdrops),
+		netDev[dev] = netDevMetrics{
+			metrics: map[string]uint64{
+				"receive_packets":    uint64(data.ifi_ipackets),
+				"transmit_packets":   uint64(data.ifi_opackets),
+				"receive_errs":       uint64(data.ifi_ierrors),
+				"transmit_errs":      uint64(data.ifi_oerrors),
+				"receive_bytes":      uint64(data.ifi_ibytes),
+				"transmit_bytes":     uint64(data.ifi_obytes),
+				"receive_multicast":  uint64(data.ifi_imcasts),
+				"transmit_multicast": uint64(data.ifi_omcasts),
+				"receive_drop":       uint64(data.ifi_iqdrops),
+				"transmit_drop":      uint64(data.ifi_oqdrops),
+			},
+			labels:      []string{"device"},
+			labelValues: []string{dev},
 		}
 	}
 

--- a/collector/netdev_darwin.go
+++ b/collector/netdev_darwin.go
@@ -32,7 +32,7 @@ func getNetDevStats(ignore *regexp.Regexp, accept *regexp.Regexp, logger log.Log
 
 	ifs, err := net.Interfaces()
 	if err != nil {
-		return nil, fmt.Errorf("net.Interfaces() failed: %w", err)
+		return netDev, fmt.Errorf("net.Interfaces() failed: %w", err)
 	}
 
 	for _, iface := range ifs {
@@ -51,15 +51,19 @@ func getNetDevStats(ignore *regexp.Regexp, accept *regexp.Regexp, logger log.Log
 			continue
 		}
 
-		netDev[iface.Name] = map[string]uint64{
-			"receive_packets":    ifaceData.Data.Ipackets,
-			"transmit_packets":   ifaceData.Data.Opackets,
-			"receive_errs":       ifaceData.Data.Ierrors,
-			"transmit_errs":      ifaceData.Data.Oerrors,
-			"receive_bytes":      ifaceData.Data.Ibytes,
-			"transmit_bytes":     ifaceData.Data.Obytes,
-			"receive_multicast":  ifaceData.Data.Imcasts,
-			"transmit_multicast": ifaceData.Data.Omcasts,
+		netDev[iface.Name] = netDevMetrics{
+			metrics: map[string]uint64{
+				"receive_packets":    ifaceData.Data.Ipackets,
+				"transmit_packets":   ifaceData.Data.Opackets,
+				"receive_errs":       ifaceData.Data.Ierrors,
+				"transmit_errs":      ifaceData.Data.Oerrors,
+				"receive_bytes":      ifaceData.Data.Ibytes,
+				"transmit_bytes":     ifaceData.Data.Obytes,
+				"receive_multicast":  ifaceData.Data.Imcasts,
+				"transmit_multicast": ifaceData.Data.Omcasts,
+			},
+			labels:      []string{"device"},
+			labelValues: []string{iface.Name},
 		}
 	}
 

--- a/collector/netdev_linux.go
+++ b/collector/netdev_linux.go
@@ -127,7 +127,6 @@ func getNetClassLabels(dev string, fs sysfs.FS) ([]string, []string, error) {
 		labels := []string{"device", "ifalias", "operstate"}
 		labelValues := []string{info.Name, info.IfAlias, info.OperState}
 		return labels, labelValues, nil
-	} else {
-		return []string{"device"}, []string{dev}, nil
 	}
+	return []string{"device"}, []string{dev}, nil
 }

--- a/collector/netdev_linux.go
+++ b/collector/netdev_linux.go
@@ -123,10 +123,10 @@ func getNetClassLabels(dev string, fs sysfs.FS) ([]string, []string, error) {
 		return nil, nil, fmt.Errorf("error obtaining net class info: %w", err)
 	}
 
+	labels := []string{"device", "ifalias", "operstate"}
 	if info, ok := netClass[dev]; ok {
-		labels := []string{"device", "ifalias", "operstate"}
 		labelValues := []string{info.Name, info.IfAlias, info.OperState}
 		return labels, labelValues, nil
 	}
-	return []string{"device"}, []string{dev}, nil
+	return labels, []string{dev, "", ""}, nil
 }

--- a/collector/netdev_linux_test.go
+++ b/collector/netdev_linux_test.go
@@ -32,15 +32,15 @@ func TestNetDevStatsIgnore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if want, got := uint64(10437182923), netStats["wlan0"]["receive_bytes"]; want != got {
+	if want, got := uint64(10437182923), netStats["wlan0"].metrics["receive_bytes"]; want != got {
 		t.Errorf("want netstat wlan0 bytes %v, got %v", want, got)
 	}
 
-	if want, got := uint64(68210035552), netStats["eth0"]["receive_bytes"]; want != got {
+	if want, got := uint64(68210035552), netStats["eth0"].metrics["receive_bytes"]; want != got {
 		t.Errorf("want netstat eth0 bytes %v, got %v", want, got)
 	}
 
-	if want, got := uint64(934), netStats["tun0"]["transmit_packets"]; want != got {
+	if want, got := uint64(934), netStats["tun0"].metrics["transmit_packets"]; want != got {
 		t.Errorf("want netstat tun0 packets %v, got %v", want, got)
 	}
 
@@ -48,15 +48,15 @@ func TestNetDevStatsIgnore(t *testing.T) {
 		t.Errorf("want count of devices to be %d, got %d", want, got)
 	}
 
-	if _, ok := netStats["veth4B09XN"]["transmit_bytes"]; ok {
+	if _, ok := netStats["veth4B09XN"].metrics["transmit_bytes"]; ok {
 		t.Error("want fixture interface veth4B09XN to not exist, but it does")
 	}
 
-	if want, got := uint64(0), netStats["ibr10:30"]["receive_fifo"]; want != got {
+	if want, got := uint64(0), netStats["ibr10:30"].metrics["receive_fifo"]; want != got {
 		t.Error("want fixture interface ibr10:30 to exist, but it does not")
 	}
 
-	if want, got := uint64(72), netStats["💩0"]["receive_multicast"]; want != got {
+	if want, got := uint64(72), netStats["💩0"].metrics["receive_multicast"]; want != got {
 		t.Error("want fixture interface 💩0 to exist, but it does not")
 	}
 }
@@ -76,7 +76,7 @@ func TestNetDevStatsAccept(t *testing.T) {
 	if want, got := 1, len(netStats); want != got {
 		t.Errorf("want count of devices to be %d, got %d", want, got)
 	}
-	if want, got := uint64(72), netStats["💩0"]["receive_multicast"]; want != got {
+	if want, got := uint64(72), netStats["💩0"].metrics["receive_multicast"]; want != got {
 		t.Error("want fixture interface 💩0 to exist, but it does not")
 	}
 }

--- a/collector/netdev_openbsd.go
+++ b/collector/netdev_openbsd.go
@@ -57,16 +57,20 @@ func getNetDevStats(ignore *regexp.Regexp, accept *regexp.Regexp, logger log.Log
 
 		data := (*C.struct_if_data)(ifa.ifa_data)
 
-		netDev[dev] = map[string]uint64{
-			"receive_packets":    uint64(data.ifi_ipackets),
-			"transmit_packets":   uint64(data.ifi_opackets),
-			"receive_errs":       uint64(data.ifi_ierrors),
-			"transmit_errs":      uint64(data.ifi_oerrors),
-			"receive_bytes":      uint64(data.ifi_ibytes),
-			"transmit_bytes":     uint64(data.ifi_obytes),
-			"receive_multicast":  uint64(data.ifi_imcasts),
-			"transmit_multicast": uint64(data.ifi_omcasts),
-			"receive_drop":       uint64(data.ifi_iqdrops),
+		netDev[dev] = netDevMetrics{
+			metrics: map[string]uint64{
+				"receive_packets":    uint64(data.ifi_ipackets),
+				"transmit_packets":   uint64(data.ifi_opackets),
+				"receive_errs":       uint64(data.ifi_ierrors),
+				"transmit_errs":      uint64(data.ifi_oerrors),
+				"receive_bytes":      uint64(data.ifi_ibytes),
+				"transmit_bytes":     uint64(data.ifi_obytes),
+				"receive_multicast":  uint64(data.ifi_imcasts),
+				"transmit_multicast": uint64(data.ifi_omcasts),
+				"receive_drop":       uint64(data.ifi_iqdrops),
+			},
+			labels:      []string{"device"},
+			labelValues: []string{dev},
 		}
 	}
 


### PR DESCRIPTION
This PR adds support for labeling linux netdev stats with netclass information, starting with `ifalias` and `operstatus` labels. The functionality was requested in https://github.com/prometheus/node_exporter/issues/794.

Example metrics output:
```
node_network_receive_packets_total{device="eth0",ifalias="this is a mgmt interface",operstate="up"} 118162
node_network_receive_packets_total{device="lo",ifalias="this is a loopback",operstate="unknown"} 17376
node_network_receive_packets_total{device="mgmt",ifalias="this is a mgmt vrf",operstate="up"} 33809
```
Signed-off-by: Steve Shaw <shaw38@gmail.com>