### PR TITLE
fix: node_md_disks state label from fail to failed

### DIFF
--- a/docs/node-mixin/alerts/alerts.libsonnet
+++ b/docs/node-mixin/alerts/alerts.libsonnet
@@ -265,7 +265,7 @@
           {
             alert: 'NodeRAIDDiskFailure',
             expr: |||
-              node_md_disks{state="fail"} > 0
+              node_md_disks{state="failed"} > 0
             ||| % $._config,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
Within `node_exporter` the metric `node_md_disks` exports the following states:
- Active
- Failed
- Spare

In the meantime, on the jsonnet alerts it was using the label `state="fail"` instead of `state="failed"`. 

This pull request fixes that issue.

---
### Additional information

This information can be also confirmed on:
- [Node Exporter collector source code](https://github.com/prometheus/node_exporter/blob/master/collector/mdadm_linux.go#L146)
```go
ch <- prometheus.MustNewConstMetric(
  disksDesc,
  prometheus.GaugeValue,
  float64(mdStat.DisksFailed),
  mdStat.Name,
  "failed",
)
```
- [Node Exporter fixture for node_md_disks](https://github.com/prometheus/node_exporter/blob/master/collector/fixtures/e2e-output.txt#L1243)
```go
# HELP node_md_disks Number of active/failed/spare disks of device.
# TYPE node_md_disks gauge
node_md_disks{device="md0",state="active"} 2
node_md_disks{device="md0",state="failed"} 0
node_md_disks{device="md0",state="spare"} 0
```

/cc @SuperQ @simonpasquier 