### PR TITLE
Support for CPU, network and filesystem stat collection on NetBSD

### DIFF
--- a/collector/cpu_netbsd.go
+++ b/collector/cpu_netbsd.go
@@ -1,0 +1,81 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !nocpu
+
+package collector
+
+import (
+	"strconv"
+	"unsafe"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sys/unix"
+)
+
+/*
+#include <sys/param.h>
+#include <sys/sched.h>
+#include <sys/sysctl.h>
+*/
+import "C"
+
+type cpuCollector struct {
+	cpu typedDesc
+}
+
+func init() {
+	registerCollector("cpu", defaultEnabled, NewCPUCollector)
+}
+
+func NewCPUCollector() (Collector, error) {
+	return &cpuCollector{
+		cpu: typedDesc{nodeCPUSecondsDesc, prometheus.CounterValue},
+	}, nil
+}
+
+func (c *cpuCollector) Update(ch chan<- prometheus.Metric) (err error) {
+	clockb, err := unix.SysctlRaw("kern.clockrate")
+	if err != nil {
+		return err
+	}
+	clock := *(*C.struct_clockinfo)(unsafe.Pointer(&clockb[0]))
+	hz := float64(clock.stathz)
+
+	ncpus, err := unix.SysctlUint32("hw.ncpu")
+	if err != nil {
+		return err
+	}
+
+	var cpTime [][C.CPUSTATES]C.int64_t
+	for i := 0; i < int(ncpus); i++ {
+		cpb, err := unix.SysctlRaw("kern.cp_time", i)
+		if err != nil && err != unix.ENODEV {
+			return err
+		}
+		if err != unix.ENODEV {
+			cpTime = append(cpTime, *(*[C.CPUSTATES]C.int64_t)(unsafe.Pointer(&cpb[0])))
+		}
+	}
+
+	for cpu, time := range cpTime {
+		lcpu := strconv.Itoa(cpu)
+		ch <- c.cpu.mustNewConstMetric(float64(time[C.CP_USER])/hz, lcpu, "user")
+		ch <- c.cpu.mustNewConstMetric(float64(time[C.CP_NICE])/hz, lcpu, "nice")
+		ch <- c.cpu.mustNewConstMetric(float64(time[C.CP_SYS])/hz, lcpu, "system")
+		ch <- c.cpu.mustNewConstMetric(float64(time[C.CP_INTR])/hz, lcpu, "interrupt")
+		ch <- c.cpu.mustNewConstMetric(float64(time[C.CP_IDLE])/hz, lcpu, "idle")
+	}
+
+	return err
+}

--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // +build !nofilesystem
-// +build linux freebsd openbsd darwin,amd64 dragonfly
+// +build linux freebsd openbsd darwin,amd64 dragonfly netbsd
 
 package collector
 

--- a/collector/filesystem_netbsd.go
+++ b/collector/filesystem_netbsd.go
@@ -1,0 +1,85 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !nofilesystem
+
+package collector
+
+import (
+	"errors"
+	"unsafe"
+
+	"github.com/prometheus/common/log"
+)
+
+/*
+#include <sys/param.h>
+#include <sys/ucred.h>
+#include <sys/mount.h>
+#include <sys/types.h>
+#include <sys/statvfs.h>
+#include <stdio.h>
+*/
+import "C"
+
+const (
+	defIgnoredMountPoints = "^/(dev)($|/)"
+	defIgnoredFSTypes     = "^devfs$"
+	readOnly              = 0x1 // MNT_RDONLY
+)
+
+// Expose filesystem fullness.
+func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
+	var mntbuf *C.struct_statvfs
+	count := C.getmntinfo(&mntbuf, C.MNT_NOWAIT)
+	if count == 0 {
+		return nil, errors.New("getmntinfo() failed")
+	}
+
+	mnt := (*[1 << 20]C.struct_statvfs)(unsafe.Pointer(mntbuf))
+	stats = []filesystemStats{}
+	for i := 0; i < int(count); i++ {
+		mountpoint := C.GoString(&mnt[i].f_mntonname[0])
+		if c.ignoredMountPointsPattern.MatchString(mountpoint) {
+			log.Debugf("Ignoring mount point: %s", mountpoint)
+			continue
+		}
+
+		device := C.GoString(&mnt[i].f_mntfromname[0])
+		fstype := C.GoString(&mnt[i].f_fstypename[0])
+		if c.ignoredFSTypesPattern.MatchString(fstype) {
+			log.Debugf("Ignoring fs type: %s", fstype)
+			continue
+		}
+
+		var ro float64
+		if (mnt[i].f_flag & readOnly) != 0 {
+			ro = 1
+		}
+
+		stats = append(stats, filesystemStats{
+			labels: filesystemLabels{
+				device:     device,
+				mountPoint: mountpoint,
+				fsType:     fstype,
+			},
+			size:      float64(mnt[i].f_blocks) * float64(mnt[i].f_bsize),
+			free:      float64(mnt[i].f_bfree) * float64(mnt[i].f_bsize),
+			avail:     float64(mnt[i].f_bavail) * float64(mnt[i].f_bsize),
+			files:     float64(mnt[i].f_files),
+			filesFree: float64(mnt[i].f_ffree),
+			ro:        ro,
+		})
+	}
+	return stats, nil
+}

--- a/collector/netdev_common.go
+++ b/collector/netdev_common.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // +build !nonetdev
-// +build linux freebsd openbsd dragonfly darwin
+// +build linux freebsd openbsd dragonfly darwin netbsd
 
 package collector
 

--- a/collector/netdev_netbsd.go
+++ b/collector/netdev_netbsd.go
@@ -1,0 +1,75 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !nonetdev
+// +build netbsd
+
+package collector
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+
+	"github.com/prometheus/common/log"
+)
+
+/*
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+*/
+import "C"
+
+func getNetDevStats(ignore *regexp.Regexp) (map[string]map[string]string, error) {
+	netDev := map[string]map[string]string{}
+
+	var ifap, ifa *C.struct_ifaddrs
+	if C.getifaddrs(&ifap) == -1 {
+		return nil, errors.New("getifaddrs() failed")
+	}
+	defer C.freeifaddrs(ifap)
+
+	for ifa = ifap; ifa != nil; ifa = ifa.ifa_next {
+		if ifa.ifa_addr.sa_family == C.AF_LINK {
+			dev := C.GoString(ifa.ifa_name)
+			if ignore.MatchString(dev) {
+				log.Debugf("Ignoring device: %s", dev)
+				continue
+			}
+
+			devStats := map[string]string{}
+			data := (*C.struct_if_data)(ifa.ifa_data)
+
+			devStats["receive_packets"] = convertNetBSDCPUTime(uint64(data.ifi_ipackets))
+			devStats["transmit_packets"] = convertNetBSDCPUTime(uint64(data.ifi_opackets))
+			devStats["receive_errs"] = convertNetBSDCPUTime(uint64(data.ifi_ierrors))
+			devStats["transmit_errs"] = convertNetBSDCPUTime(uint64(data.ifi_oerrors))
+			devStats["receive_bytes"] = convertNetBSDCPUTime(uint64(data.ifi_ibytes))
+			devStats["transmit_bytes"] = convertNetBSDCPUTime(uint64(data.ifi_obytes))
+			devStats["receive_multicast"] = convertNetBSDCPUTime(uint64(data.ifi_imcasts))
+			devStats["transmit_multicast"] = convertNetBSDCPUTime(uint64(data.ifi_omcasts))
+			devStats["receive_drop"] = convertNetBSDCPUTime(uint64(data.ifi_iqdrops))
+
+			netDev[dev] = devStats
+		}
+	}
+
+	return netDev, nil
+}
+
+func convertNetBSDCPUTime(counter uint64) string {
+	return strconv.FormatUint(counter, 10)
+}

--- a/examples/netbsd-rc.d/node_exporter
+++ b/examples/netbsd-rc.d/node_exporter
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# PROVIDE: node_exporter
+# REQUIRE: NETWORK
+
+$_rc_subr_loaded . /etc/rc.subr
+
+name="node_exporter"
+rcvar="${name}"
+procname="/usr/pkg/bin/${name}"
+pidfile="/var/run/${name}.pid"
+
+start_cmd="node_exporter_start"
+
+node_exporter_start()
+{
+	$procname ${node_exporter_flags} >/dev/null 2>&1 &
+	echo $! > $pidfile
+}
+
+load_rc_config $name
+run_rc_command "$1"


### PR DESCRIPTION
This PR adds code to make node_exporter more useful on NetBSD hosts. I mainly cobbled this together from the freebsd and openbsd specific code that was already in here, since I don't speak golang at all.

There probably are opportunities for deduplication--especially netdev_netbsd.go which is a single line difference from the netdev_bsd.go which assumes that a FreeBSD-specific struct member exists--that I just don't know about, and I would ask you to please check my work.

@SuperQ @discordianfish 