### PR TITLE
Use absolute jsonnet import paths

### DIFF
--- a/docs/node-mixin/dashboards/node.libsonnet
+++ b/docs/node-mixin/dashboards/node.libsonnet
@@ -1,10 +1,10 @@
-local grafana = import 'grafonnet/grafana.libsonnet';
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
 local dashboard = grafana.dashboard;
 local row = grafana.row;
 local prometheus = grafana.prometheus;
 local template = grafana.template;
 local graphPanel = grafana.graphPanel;
-local promgrafonnet = import 'promgrafonnet/promgrafonnet.libsonnet';
+local promgrafonnet = import 'github.com/kubernetes-monitoring/kubernetes-mixin/lib/promgrafonnet/promgrafonnet.libsonnet';
 local gauge = promgrafonnet.gauge;
 
 {

--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -1,4 +1,4 @@
-local g = import 'grafana-builder/grafana.libsonnet';
+local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libsonnet';
 
 {
   grafanaDashboards+:: {

--- a/docs/node-mixin/jsonnetfile.json
+++ b/docs/node-mixin/jsonnetfile.json
@@ -29,5 +29,5 @@
       "version": "master"
     }
   ],
-  "legacyImports": true
+  "legacyImports": false
 }


### PR DESCRIPTION
This should be the way forward when importing libraries in jsonnet. It's closer to how Go imports look and makes it more obvious where packages live.

This is not breaking anything, as the old imports were already symlinks to the now directly used directories.
