### PR TITLE
collector/filesystem: fixing logging message

### DIFF
--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -73,7 +73,7 @@ func NewFilesystemCollector(logger log.Logger) (Collector, error) {
 	subsystem := "filesystem"
 	level.Info(logger).Log("msg", "Parsed flag --collector.filesystem.ignored-mount-points", "flag", *ignoredMountPoints)
 	mountPointPattern := regexp.MustCompile(*ignoredMountPoints)
-	level.Info(logger).Log("msg", "Parsed flag --collector.filesystem.ignored-fs-types", "flag", *ignoredMountPoints)
+	level.Info(logger).Log("msg", "Parsed flag --collector.filesystem.ignored-fs-types", "flag", *ignoredFSTypes)
 	filesystemsTypesPattern := regexp.MustCompile(*ignoredFSTypes)
 
 	sizeDesc := prometheus.NewDesc(


### PR DESCRIPTION
this change fixes the logging message for the filesystem ignored-fs-types flag to output the flag instead of the mountpoints flag.