### PR TITLE
ProcessStatCollector: continue if PID disappears between opening and reading file

### DIFF
--- a/collector/processes_linux_test.go
+++ b/collector/processes_linux_test.go
@@ -16,8 +16,6 @@
 package collector
 
 import (
-	"errors"
-	"syscall"
 	"testing"
 
 	"github.com/go-kit/kit/log"
@@ -52,30 +50,5 @@ func TestReadProcessStatus(t *testing.T) {
 	}
 	if uint64(pids) > maxPid || pids == 0 {
 		t.Fatalf("Total running pids cannot be greater than %d or equals to 0", maxPid)
-	}
-}
-
-func Test_errorContains(t *testing.T) {
-	testCases := []struct {
-		err      error
-		target   error
-		expected bool
-	}{
-		{err: nil, target: nil, expected: false},
-		{err: errors.New("e"), target: nil, expected: false},
-		{err: nil, target: errors.New("e"), expected: false},
-		{err: errors.New("abc"), target: errors.New("def"), expected: false},
-		{err: errors.New("abc"), target: errors.New("bc"), expected: true},
-		{err: errors.New("read /proc/2054/stat: no such process"), target: syscall.ESRCH, expected: true},
-	}
-	for _, tc := range testCases {
-		actual := errorContains(tc.err, tc.target)
-		if actual != tc.expected {
-			negation := " not"
-			if tc.expected {
-				negation = ""
-			}
-			t.Fatalf("Expected \"%v\"%s to contain \"%v\", got %v", tc.err, negation, tc.target, actual)
-		}
 	}
 }


### PR DESCRIPTION
As @acastong writes in #1901, 
> This is very closely related to #1043 : that change fixed processes disappearing between list the /proc directory and reading the actual process stats. But another race condition is possible: between opening the `/proc/<process id>/stat` file and actually reading it, another race condition can occur and the error code returned is different. Bellow is a small code snippet to reproduce that race condition.
>
> The recommended fix is to modify `getAllocatedThreads()` in `collector/processes_linux.go` to continue after `stat, err := pid.Stat()` if the error meets this condition: `strings.Contains(err.Error(),syscall.ESRCH.Error())`.

This PR just does what @acastong suggests.

Closes #1901