### PR TITLE
bcache: fix typo

### DIFF
--- a/collector/bcache_linux.go
+++ b/collector/bcache_linux.go
@@ -251,7 +251,7 @@ func (c *bcacheCollector) updateBcacheStats(ch chan<- prometheus.Metric, s *bcac
 				extraLabelValue: bdev.Name,
 			},
 			{
-				name:            "writeback_rate_proportinal_term",
+				name:            "writeback_rate_proportional_term",
 				desc:            "Current result of proportional controller, part of writeback rate",
 				value:           float64(bdev.WritebackRateDebug.Proportional),
 				metricType:      prometheus.GaugeValue,

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -136,9 +136,9 @@ node_bcache_writeback_rate{backing_device="bdev0",uuid="deaddd54-c735-46d5-868e-
 # HELP node_bcache_writeback_rate_integral_term Current result of integral controller, part of writeback rate
 # TYPE node_bcache_writeback_rate_integral_term gauge
 node_bcache_writeback_rate_integral_term{backing_device="bdev0",uuid="deaddd54-c735-46d5-868e-f331c5fd7c74"} 808960
-# HELP node_bcache_writeback_rate_proportinal_term Current result of proportional controller, part of writeback rate
-# TYPE node_bcache_writeback_rate_proportinal_term gauge
-node_bcache_writeback_rate_proportinal_term{backing_device="bdev0",uuid="deaddd54-c735-46d5-868e-f331c5fd7c74"} 437748
+# HELP node_bcache_writeback_rate_proportional_term Current result of proportional controller, part of writeback rate
+# TYPE node_bcache_writeback_rate_proportional_term gauge
+node_bcache_writeback_rate_proportional_term{backing_device="bdev0",uuid="deaddd54-c735-46d5-868e-f331c5fd7c74"} 437748
 # HELP node_bcache_written_bytes_total Sum of all data that has been written to the cache.
 # TYPE node_bcache_written_bytes_total counter
 node_bcache_written_bytes_total{cache_device="cache0",uuid="deaddd54-c735-46d5-868e-f331c5fd7c74"} 0


### PR DESCRIPTION
Fix typos in collector/bcache_linux.go and collector/fixtures/e2e-output.txt

Signed-off-by: Hu Shuai <hus.fnst@cn.fujitsu.com>