### PR TITLE
Added an ability to pass collector.supervisord.url via ENV vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [ENHANCEMENT] Include TCP OutRsts in netstat metrics
 * [ENHANCEMENT] Added XFS inode operations to XFS metrics
 * [ENHANCEMENT] Remove CGO dependencies for OpenBSD amd64
+* [ENHANCEMENT] Added an ability to pass collector.supervisord.url via SUPERVISORD_URL environment variable
 * [BUGFIX] Handle EPERM for syscall in timex collector
 * [BUGFIX]
 

--- a/collector/supervisord.go
+++ b/collector/supervisord.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	supervisordURL = kingpin.Flag("collector.supervisord.url", "XML RPC endpoint.").Default("http://localhost:9001/RPC2").String()
+	supervisordURL = kingpin.Flag("collector.supervisord.url", "XML RPC endpoint.").Default("http://localhost:9001/RPC2").Envar("SUPERVISORD_URL").String()
 	xrpc           *xmlrpc.Client
 )
 


### PR DESCRIPTION
Supervisord supports auth via adding `username` and `password` in the[ configuration file.](http://supervisord.org/configuration.html)

Passing that info via CLI args is insecure. 
Passing them via Env vars is a bit more secure without any downsides to the default configuration.