### PR TITLE
Default GOMAXPROCS to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * [ENHANCEMENT]
 * [BUGFIX]
 
+* [CHANGE] Default GOMAXPROCS to 1
+
 ## 1.1.0 / 2021-02-05
 
 NOTE: We have improved some of the flag naming conventions (PR #1743). The old names are


### PR DESCRIPTION
Avoid running on all CPUs by limiting the Go runtime to one CPU by
default. Avoids having Go routines schedule on every CPU, driving up the
visible run queue length on high CPU count systems.

https://github.com/prometheus/node_exporter/issues/1880

Signed-off-by: Ben Kochie <superq@gmail.com>