### PR TITLE
Replaced ioutil.ReadAll with bufio.Scanner

### DIFF
--- a/collector/tcpstat_linux.go
+++ b/collector/tcpstat_linux.go
@@ -16,9 +16,9 @@
 package collector
 
 import (
+	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -116,12 +116,12 @@ func getTCPStats(statsFile string) (map[tcpConnectionState]float64, error) {
 
 func parseTCPStats(r io.Reader) (map[tcpConnectionState]float64, error) {
 	tcpStats := map[tcpConnectionState]float64{}
-	contents, err := ioutil.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, line := range strings.Split(string(contents), "\n")[1:] {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(strings.TrimSpace(line), "sl") {
+			continue
+		}
 		parts := strings.Fields(line)
 		if len(parts) == 0 {
 			continue

--- a/collector/tcpstat_linux_test.go
+++ b/collector/tcpstat_linux_test.go
@@ -60,13 +60,6 @@ func Test_parseTCPStatsError(t *testing.T) {
 
 func TestTCPStat(t *testing.T) {
 
-	noFile, _ := os.Open("follow the white rabbit")
-	defer noFile.Close()
-
-	if _, err := parseTCPStats(noFile); err == nil {
-		t.Fatal("expected an error, but none occurred")
-	}
-
 	file, err := os.Open("fixtures/proc/net/tcpstat")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
When `/proc/net/tcp` and `/proc/net/tcp6` contain hundreds thousand of lines Prometheus will not be able to scrape node_exporter with tcpstat collector enabled (timeout exceeded).

Using bufio.Scanner resolves the issue.

Signed-off-by: chinhnc <chicknsoupuds@gmail.com>