### PR TITLE
Handle errors from disabled PSI subsystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * [ENHANCEMENT]
 * [BUGFIX]
 
+* [BUGFIX] Handle errors from disabled PSI subsystem #1983
+
 ## 1.1.1 / 2021-02-12
 
 * [BUGFIX] Fix ineffassign issue #1957

--- a/collector/pressure_linux.go
+++ b/collector/pressure_linux.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"syscall"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -92,6 +93,10 @@ func (c *pressureStatsCollector) Update(ch chan<- prometheus.Metric) error {
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				level.Debug(c.logger).Log("msg", "pressure information is unavailable, you need a Linux kernel >= 4.20 and/or CONFIG_PSI enabled for your kernel")
+				return ErrNoData
+			}
+			if errors.Is(err, syscall.ENOTSUP) {
+				level.Debug(c.logger).Log("msg", "pressure information is disabled, add psi=1 kernel command line to enable it")
 				return ErrNoData
 			}
 			return fmt.Errorf("failed to retrieve pressure stats: %w", err)


### PR DESCRIPTION
When CONFIG_PSI_DEFAULT_DISABLED=y, the pressure system returns
"operation not supported", rather than permission denied or not
exposing the /proc/pressure files.

Fixes: https://github.com/prometheus/node_exporter/issues/1961

Signed-off-by: Ben Kochie <superq@gmail.com>