### PR TITLE
Sanitize strings from /sys/class/power_supply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [BUGFIX]
 
 * [BUGFIX] Handle errors from disabled PSI subsystem #1983
+* [BUGFIX] Sanitize strings from /sys/class/power_supply #1984
 
 ## 1.1.1 / 2021-02-12
 

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2613,7 +2613,7 @@ node_power_supply_energy_watthour{power_supply="BAT0"} 36.58
 # HELP node_power_supply_info info of /sys/class/power_supply/<power_supply>.
 # TYPE node_power_supply_info gauge
 node_power_supply_info{power_supply="AC",type="Mains"} 1
-node_power_supply_info{capacity_level="Normal",manufacturer="LGC",model_name="LNV-45N1",power_supply="BAT0",serial_number="38109",status="Discharging",technology="Li-ion",type="Battery"} 1
+node_power_supply_info{capacity_level="Normal",manufacturer="LGC",model_name="LNV-45N1�",power_supply="BAT0",serial_number="38109",status="Discharging",technology="Li-ion",type="Battery"} 1
 # HELP node_power_supply_online online value of /sys/class/power_supply/<power_supply>.
 # TYPE node_power_supply_online gauge
 node_power_supply_online{power_supply="AC"} 0

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -1298,7 +1298,7 @@ Mode: 444
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/class/power_supply/BAT0/model_name
 Lines: 1
-LNV-45N1
+LNV-45N1¿¿
 Mode: 444
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/class/power_supply/BAT0/power

--- a/collector/powersupplyclass.go
+++ b/collector/powersupplyclass.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -153,7 +154,7 @@ func (c *powerSupplyClassCollector) Update(ch chan<- prometheus.Metric) error {
 		} {
 			if value != "" {
 				keys = append(keys, name)
-				values = append(values, value)
+				values = append(values, strings.ToValidUTF8(value, "�"))
 			}
 		}
 


### PR DESCRIPTION
Avoid panic on invalid UTF-8 from /sys/class/power_supply by
sanitizing strings parsed from the kernel.

Fixes: https://github.com/prometheus/node_exporter/issues/1979

Signed-off-by: Ben Kochie <superq@gmail.com>