### PR TITLE
Silence missing netclass errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * [BUGFIX] Handle errors from disabled PSI subsystem #1983
 * [BUGFIX] Sanitize strings from /sys/class/power_supply #1984
+* [BUGFIX] Silence missing netclass errors #1986
 
 ## 1.1.1 / 2021-02-12
 


### PR DESCRIPTION
* Handle no such file and permission denied errors.
* Reduce excessive error wrapping.

Fixes: https://github.com/prometheus/node_exporter/issues/1840

Signed-off-by: Ben Kochie <superq@gmail.com>