### PR TITLE
Add flag to ignore network speed if it is unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * [ENHANCEMENT]
 * [BUGFIX]
 
+Note: Ignoring invalid network speed will be the default in 2.x
+
+* [FEATURE] Add flag to ignore network speed if it is unknown #1989
+  
 ## 1.1.2 / 2021-03-05
 
 * [BUGFIX] Handle errors from disabled PSI subsystem #1983

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2110,51 +2110,67 @@ node_netstat_Udp_RcvbufErrors 9
 node_netstat_Udp_SndbufErrors 8
 # HELP node_network_address_assign_type address_assign_type value of /sys/class/net/<iface>.
 # TYPE node_network_address_assign_type gauge
+node_network_address_assign_type{device="bond0"} 3
 node_network_address_assign_type{device="eth0"} 3
 # HELP node_network_carrier carrier value of /sys/class/net/<iface>.
 # TYPE node_network_carrier gauge
+node_network_carrier{device="bond0"} 1
 node_network_carrier{device="eth0"} 1
 # HELP node_network_carrier_changes_total carrier_changes_total value of /sys/class/net/<iface>.
 # TYPE node_network_carrier_changes_total counter
+node_network_carrier_changes_total{device="bond0"} 2
 node_network_carrier_changes_total{device="eth0"} 2
 # HELP node_network_carrier_down_changes_total carrier_down_changes_total value of /sys/class/net/<iface>.
 # TYPE node_network_carrier_down_changes_total counter
+node_network_carrier_down_changes_total{device="bond0"} 1
 node_network_carrier_down_changes_total{device="eth0"} 1
 # HELP node_network_carrier_up_changes_total carrier_up_changes_total value of /sys/class/net/<iface>.
 # TYPE node_network_carrier_up_changes_total counter
+node_network_carrier_up_changes_total{device="bond0"} 1
 node_network_carrier_up_changes_total{device="eth0"} 1
 # HELP node_network_device_id device_id value of /sys/class/net/<iface>.
 # TYPE node_network_device_id gauge
+node_network_device_id{device="bond0"} 32
 node_network_device_id{device="eth0"} 32
 # HELP node_network_dormant dormant value of /sys/class/net/<iface>.
 # TYPE node_network_dormant gauge
+node_network_dormant{device="bond0"} 1
 node_network_dormant{device="eth0"} 1
 # HELP node_network_flags flags value of /sys/class/net/<iface>.
 # TYPE node_network_flags gauge
+node_network_flags{device="bond0"} 4867
 node_network_flags{device="eth0"} 4867
 # HELP node_network_iface_id iface_id value of /sys/class/net/<iface>.
 # TYPE node_network_iface_id gauge
+node_network_iface_id{device="bond0"} 2
 node_network_iface_id{device="eth0"} 2
 # HELP node_network_iface_link iface_link value of /sys/class/net/<iface>.
 # TYPE node_network_iface_link gauge
+node_network_iface_link{device="bond0"} 2
 node_network_iface_link{device="eth0"} 2
 # HELP node_network_iface_link_mode iface_link_mode value of /sys/class/net/<iface>.
 # TYPE node_network_iface_link_mode gauge
+node_network_iface_link_mode{device="bond0"} 1
 node_network_iface_link_mode{device="eth0"} 1
 # HELP node_network_info Non-numeric data from /sys/class/net/<iface>, value is always 1.
 # TYPE node_network_info gauge
+node_network_info{address="01:01:01:01:01:01",broadcast="ff:ff:ff:ff:ff:ff",device="bond0",duplex="full",ifalias="",operstate="up"} 1
 node_network_info{address="01:01:01:01:01:01",broadcast="ff:ff:ff:ff:ff:ff",device="eth0",duplex="full",ifalias="",operstate="up"} 1
 # HELP node_network_mtu_bytes mtu_bytes value of /sys/class/net/<iface>.
 # TYPE node_network_mtu_bytes gauge
+node_network_mtu_bytes{device="bond0"} 1500
 node_network_mtu_bytes{device="eth0"} 1500
 # HELP node_network_name_assign_type name_assign_type value of /sys/class/net/<iface>.
 # TYPE node_network_name_assign_type gauge
+node_network_name_assign_type{device="bond0"} 2
 node_network_name_assign_type{device="eth0"} 2
 # HELP node_network_net_dev_group net_dev_group value of /sys/class/net/<iface>.
 # TYPE node_network_net_dev_group gauge
+node_network_net_dev_group{device="bond0"} 0
 node_network_net_dev_group{device="eth0"} 0
 # HELP node_network_protocol_type protocol_type value of /sys/class/net/<iface>.
 # TYPE node_network_protocol_type gauge
+node_network_protocol_type{device="bond0"} 1
 node_network_protocol_type{device="eth0"} 1
 # HELP node_network_receive_bytes_total Network device statistic receive_bytes.
 # TYPE node_network_receive_bytes_total counter
@@ -2353,9 +2369,11 @@ node_network_transmit_packets_total{device="wlan0"} 1.17262e+07
 node_network_transmit_packets_total{device="💩0"} 304261
 # HELP node_network_transmit_queue_length transmit_queue_length value of /sys/class/net/<iface>.
 # TYPE node_network_transmit_queue_length gauge
+node_network_transmit_queue_length{device="bond0"} 1000
 node_network_transmit_queue_length{device="eth0"} 1000
 # HELP node_network_up Value is 1 if operstate is 'up', 0 otherwise.
 # TYPE node_network_up gauge
+node_network_up{device="bond0"} 1
 node_network_up{device="eth0"} 1
 # HELP node_nf_conntrack_entries Number of currently allocated flow entries for connection tracking.
 # TYPE node_nf_conntrack_entries gauge

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -765,7 +765,7 @@ Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/class/net/bond0/speed
 Lines: 1
-1000
+-1
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/class/net/bond0/tx_queue_len

--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -107,7 +107,8 @@ fi
   --collector.textfile.directory="collector/fixtures/textfile/two_metric_files/" \
   --collector.wifi.fixtures="collector/fixtures/wifi" \
   --collector.qdisc.fixtures="collector/fixtures/qdisc/" \
-  --collector.netclass.ignored-devices="(bond0|dmz|int)" \
+  --collector.netclass.ignored-devices="(dmz|int)" \
+  --collector.netclass.ignore-invalid-speed \
   --collector.bcache.priorityStats \
   --collector.cpu.info \
   --collector.cpu.info.flags-include="^(aes|avx.?|constant_tsc)$" \


### PR DESCRIPTION
Some devices (ex virtual) don't have a speed and report `-1` as the
speed value. Add a flag to allow ignoring speed on these devices.

Fixes: https://github.com/prometheus/node_exporter/issues/1967

Signed-off-by: Ben Kochie <superq@gmail.com>