### PR TITLE
Improved explanation of the CPU saturation rule

### DIFF
--- a/docs/node-mixin/rules/rules.libsonnet
+++ b/docs/node-mixin/rules/rules.libsonnet
@@ -25,10 +25,12 @@
             ||| % $._config,
           },
           {
-            // This is CPU saturation: 1min avg run queue length / number of CPUs.
-            // Can go over 1.
-            // TODO: There are situation where a run queue >1/core is just normal and fine.
-            //       We need to clarify how to read this metric and if its usage is helpful at all.
+            // One minute load average per CPU.
+            // This metrics is taken from /proc/loadavg file.
+            // It represents the number of jobs in the run queue (processes that are running; state R),
+            // or waiting for disk I/O (state D) averaged over 1 minute.
+            // Values over 1 don't have to be outright considered problematic,
+            // for example there can be multiple processes trying to access the disk.
             record: 'instance:node_load1_per_cpu:ratio',
             expr: |||
               (


### PR DESCRIPTION
Related #1929 
Well, that didn't take more than a month, yikes.

I am not sure if this is finished.
1. I wanted to include some reference as to where the information was taken from, but as @nemobis mentioned in the issue, the `loadavg` could be different in other kernels.
2. If `loadavg` is possibly different in other the kernels (is this true?), then should it be described as the `loadavg` taken from Linux kernel? 
3. Also what about this CPU saturation comment in the USE dashboard? Should I improve that as well? 
https://github.com/prometheus/node_exporter/blob/master/docs/node-mixin/dashboards/use.libsonnet#L24-L27

What do you think?

