### PR TITLE
Fix panic when using systemd compatibility flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 Note: Ignoring invalid network speed will be the default in 2.x
 
 * [FEATURE] Add flag to ignore network speed if it is unknown #1989
+* [BUGFIX] Fix panic when using systemd unit compatibility flags
   
 ## 1.1.2 / 2021-03-05
 

--- a/collector/systemd_linux.go
+++ b/collector/systemd_linux.go
@@ -37,12 +37,15 @@ const (
 	// the 'SystemState' manager property and the timer property 'LastTriggerUSec'
 	// https://github.com/prometheus/node_exporter/issues/291
 	minSystemdVersionSystemState = 212
+
+	unitIncludeDefault = ".+"
+	unitExcludeDefault = ".+\\.(automount|device|mount|scope|slice)"
 )
 
 var (
-	unitInclude            = kingpin.Flag("collector.systemd.unit-include", "Regexp of systemd units to include. Units must both match include and not match exclude to be included.").Default(".+").String()
+	unitInclude            = kingpin.Flag("collector.systemd.unit-include", "Regexp of systemd units to include. Units must both match include and not match exclude to be included.").Default(unitIncludeDefault).String()
 	oldUnitInclude         = kingpin.Flag("collector.systemd.unit-whitelist", "DEPRECATED: Use --collector.systemd.unit-include").Hidden().String()
-	unitExclude            = kingpin.Flag("collector.systemd.unit-exclude", "Regexp of systemd units to exclude. Units must both match include and not match exclude to be included.").Default(".+\\.(automount|device|mount|scope|slice)").String()
+	unitExclude            = kingpin.Flag("collector.systemd.unit-exclude", "Regexp of systemd units to exclude. Units must both match include and not match exclude to be included.").Default(unitExcludeDefault).String()
 	oldUnitExclude         = kingpin.Flag("collector.systemd.unit-blacklist", "DEPRECATED: Use collector.systemd.unit-exclude").Hidden().String()
 	systemdPrivate         = kingpin.Flag("collector.systemd.private", "Establish a private, direct connection to systemd without dbus (Strongly discouraged since it requires root. For testing purposes only).").Hidden().Bool()
 	enableTaskMetrics      = kingpin.Flag("collector.systemd.enable-task-metrics", "Enables service unit tasks metrics unit_tasks_current and unit_tasks_max").Bool()
@@ -123,7 +126,7 @@ func NewSystemdCollector(logger log.Logger) (Collector, error) {
 		"Detected systemd version", []string{}, nil)
 
 	if *oldUnitExclude != "" {
-		if *unitExclude == "" {
+		if *unitExclude == unitExcludeDefault {
 			level.Warn(logger).Log("msg", "--collector.systemd.unit-blacklist is DEPRECATED and will be removed in 2.0.0, use --collector.systemd.unit-exclude")
 			*unitExclude = *oldUnitExclude
 		} else {
@@ -131,7 +134,7 @@ func NewSystemdCollector(logger log.Logger) (Collector, error) {
 		}
 	}
 	if *oldUnitInclude != "" {
-		if *unitInclude == "" {
+		if *unitInclude == unitIncludeDefault {
 			level.Warn(logger).Log("msg", "--collector.systemd.unit-whitelist is DEPRECATED and will be removed in 2.0.0, use --collector.systemd.unit-include")
 			*unitInclude = *oldUnitInclude
 		} else {


### PR DESCRIPTION
Define the flag defaults as a const to avoid panic when
backwards comatibility flags are used.

Fixes: https://github.com/prometheus/node_exporter/issues/1999

Signed-off-by: Ben Kochie <superq@gmail.com>