### PR TITLE
Rename filesystem collector flags to match netdev and systemd collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master / unreleased
 
-* [CHANGE]
+* [CHANGE] Rename flags `collector.filesystem.ignored-mount-points` and `collector.filesystem.ignored-fs-types` to match other collectors
 * [FEATURE]
 * [ENHANCEMENT]
 * [BUGFIX]

--- a/collector/filesystem_bsd.go
+++ b/collector/filesystem_bsd.go
@@ -32,9 +32,9 @@ import (
 import "C"
 
 const (
-	defIgnoredMountPoints = "^/(dev)($|/)"
-	defIgnoredFSTypes     = "^devfs$"
-	readOnly              = 0x1 // MNT_RDONLY
+	defMountPointsExcluded = "^/(dev)($|/)"
+	defFSTypesExcluded     = "^devfs$"
+	readOnly               = 0x1 // MNT_RDONLY
 )
 
 // Expose filesystem fullness.
@@ -49,14 +49,14 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 	stats = []filesystemStats{}
 	for i := 0; i < int(count); i++ {
 		mountpoint := C.GoString(&mnt[i].f_mntonname[0])
-		if c.ignoredMountPointsPattern.MatchString(mountpoint) {
+		if c.excludedMountPointsPattern.MatchString(mountpoint) {
 			level.Debug(c.logger).Log("msg", "Ignoring mount point", "mountpoint", mountpoint)
 			continue
 		}
 
 		device := C.GoString(&mnt[i].f_mntfromname[0])
 		fstype := C.GoString(&mnt[i].f_fstypename[0])
-		if c.ignoredFSTypesPattern.MatchString(fstype) {
+		if c.excludedFSTypesPattern.MatchString(fstype) {
 			level.Debug(c.logger).Log("msg", "Ignoring fs type", "type", fstype)
 			continue
 		}

--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -17,6 +17,7 @@
 package collector
 
 import (
+	"errors"
 	"regexp"
 
 	"github.com/go-kit/kit/log"
@@ -26,27 +27,44 @@ import (
 )
 
 // Arch-dependent implementation must define:
-// * defIgnoredMountPoints
-// * defIgnoredFSTypes
+// * defMountPointsExcluded
+// * defFSTypesExcluded
 // * filesystemLabelNames
 // * filesystemCollector.GetStats
 
 var (
-	ignoredMountPoints = kingpin.Flag(
+	mountPointsExcludeSet bool
+	mountPointsExclude    = kingpin.Flag(
+		"collector.filesystem.mount-points-exclude",
+		"Regexp of mount points to exclude for filesystem collector.",
+	).Default(defMountPointsExcluded).PreAction(func(c *kingpin.ParseContext) error {
+		mountPointsExcludeSet = true
+		return nil
+	}).String()
+	oldMountPointsExcluded = kingpin.Flag(
 		"collector.filesystem.ignored-mount-points",
 		"Regexp of mount points to ignore for filesystem collector.",
-	).Default(defIgnoredMountPoints).String()
-	ignoredFSTypes = kingpin.Flag(
+	).Hidden().String()
+
+	fsTypesExcludeSet bool
+	fsTypesExclude    = kingpin.Flag(
+		"collector.filesystem.fs-types-exclude",
+		"Regexp of filesystem types to exclude for filesystem collector.",
+	).Default(defFSTypesExcluded).PreAction(func(c *kingpin.ParseContext) error {
+		fsTypesExcludeSet = true
+		return nil
+	}).String()
+	oldFSTypesExcluded = kingpin.Flag(
 		"collector.filesystem.ignored-fs-types",
 		"Regexp of filesystem types to ignore for filesystem collector.",
-	).Default(defIgnoredFSTypes).String()
+	).Hidden().String()
 
 	filesystemLabelNames = []string{"device", "mountpoint", "fstype"}
 )
 
 type filesystemCollector struct {
-	ignoredMountPointsPattern     *regexp.Regexp
-	ignoredFSTypesPattern         *regexp.Regexp
+	excludedMountPointsPattern    *regexp.Regexp
+	excludedFSTypesPattern        *regexp.Regexp
 	sizeDesc, freeDesc, availDesc *prometheus.Desc
 	filesDesc, filesFreeDesc      *prometheus.Desc
 	roDesc, deviceErrorDesc       *prometheus.Desc
@@ -70,11 +88,29 @@ func init() {
 
 // NewFilesystemCollector returns a new Collector exposing filesystems stats.
 func NewFilesystemCollector(logger log.Logger) (Collector, error) {
+	if *oldMountPointsExcluded != "" {
+		if !mountPointsExcludeSet {
+			level.Warn(logger).Log("msg", "--collector.filesystem.ignored-mount-points is DEPRECATED and will be removed in 2.0.0, use --collector.filesystem.mount-points-exclude")
+			*mountPointsExclude = *oldMountPointsExcluded
+		} else {
+			return nil, errors.New("--collector.filesystem.ignored-mount-points and --collector.filesystem.mount-points-exclude are mutually exclusive")
+		}
+	}
+
+	if *oldFSTypesExcluded != "" {
+		if !fsTypesExcludeSet {
+			level.Warn(logger).Log("msg", "--collector.filesystem.ignored-fs-types is DEPRECATED and will be removed in 2.0.0, use --collector.filesystem.fs-types-exclude")
+			*fsTypesExclude = *oldFSTypesExcluded
+		} else {
+			return nil, errors.New("--collector.filesystem.ignored-fs-types and --collector.filesystem.fs-types-exclude are mutually exclusive")
+		}
+	}
+
 	subsystem := "filesystem"
-	level.Info(logger).Log("msg", "Parsed flag --collector.filesystem.ignored-mount-points", "flag", *ignoredMountPoints)
-	mountPointPattern := regexp.MustCompile(*ignoredMountPoints)
-	level.Info(logger).Log("msg", "Parsed flag --collector.filesystem.ignored-fs-types", "flag", *ignoredFSTypes)
-	filesystemsTypesPattern := regexp.MustCompile(*ignoredFSTypes)
+	level.Info(logger).Log("msg", "Parsed flag --collector.filesystem.mount-points-exclude", "flag", *mountPointsExclude)
+	mountPointPattern := regexp.MustCompile(*mountPointsExclude)
+	level.Info(logger).Log("msg", "Parsed flag --collector.filesystem.fs-types-exclude", "flag", *fsTypesExclude)
+	filesystemsTypesPattern := regexp.MustCompile(*fsTypesExclude)
 
 	sizeDesc := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, subsystem, "size_bytes"),
@@ -119,16 +155,16 @@ func NewFilesystemCollector(logger log.Logger) (Collector, error) {
 	)
 
 	return &filesystemCollector{
-		ignoredMountPointsPattern: mountPointPattern,
-		ignoredFSTypesPattern:     filesystemsTypesPattern,
-		sizeDesc:                  sizeDesc,
-		freeDesc:                  freeDesc,
-		availDesc:                 availDesc,
-		filesDesc:                 filesDesc,
-		filesFreeDesc:             filesFreeDesc,
-		roDesc:                    roDesc,
-		deviceErrorDesc:           deviceErrorDesc,
-		logger:                    logger,
+		excludedMountPointsPattern: mountPointPattern,
+		excludedFSTypesPattern:     filesystemsTypesPattern,
+		sizeDesc:                   sizeDesc,
+		freeDesc:                   freeDesc,
+		availDesc:                  availDesc,
+		filesDesc:                  filesDesc,
+		filesFreeDesc:              filesFreeDesc,
+		roDesc:                     roDesc,
+		deviceErrorDesc:            deviceErrorDesc,
+		logger:                     logger,
 	}, nil
 }
 

--- a/collector/filesystem_freebsd.go
+++ b/collector/filesystem_freebsd.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	defIgnoredMountPoints = "^/(dev)($|/)"
-	defIgnoredFSTypes     = "^devfs$"
-	readOnly              = 0x1 // MNT_RDONLY
-	noWait                = 0x2 // MNT_NOWAIT
+	defMountPointsExcluded = "^/(dev)($|/)"
+	defFSTypesExcluded     = "^devfs$"
+	readOnly               = 0x1 // MNT_RDONLY
+	noWait                 = 0x2 // MNT_NOWAIT
 )
 
 // Expose filesystem fullness.
@@ -41,14 +41,14 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 	stats := []filesystemStats{}
 	for _, fs := range buf {
 		mountpoint := bytesToString(fs.Mntonname[:])
-		if c.ignoredMountPointsPattern.MatchString(mountpoint) {
+		if c.excludedMountPointsPattern.MatchString(mountpoint) {
 			level.Debug(c.logger).Log("msg", "Ignoring mount point", "mountpoint", mountpoint)
 			continue
 		}
 
 		device := bytesToString(fs.Mntfromname[:])
 		fstype := bytesToString(fs.Fstypename[:])
-		if c.ignoredFSTypesPattern.MatchString(fstype) {
+		if c.excludedFSTypesPattern.MatchString(fstype) {
 			level.Debug(c.logger).Log("msg", "Ignoring fs type", "type", fstype)
 			continue
 		}

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -32,8 +32,8 @@ import (
 )
 
 const (
-	defIgnoredMountPoints = "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
-	defIgnoredFSTypes     = "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"
+	defMountPointsExcluded = "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
+	defFSTypesExcluded     = "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"
 )
 
 var mountTimeout = kingpin.Flag("collector.filesystem.mount-timeout",
@@ -50,11 +50,11 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 	}
 	stats := []filesystemStats{}
 	for _, labels := range mps {
-		if c.ignoredMountPointsPattern.MatchString(labels.mountPoint) {
+		if c.excludedMountPointsPattern.MatchString(labels.mountPoint) {
 			level.Debug(c.logger).Log("msg", "Ignoring mount point", "mountpoint", labels.mountPoint)
 			continue
 		}
-		if c.ignoredFSTypesPattern.MatchString(labels.fsType) {
+		if c.excludedFSTypesPattern.MatchString(labels.fsType) {
 			level.Debug(c.logger).Log("msg", "Ignoring fs", "type", labels.fsType)
 			continue
 		}

--- a/collector/filesystem_openbsd_amd64.go
+++ b/collector/filesystem_openbsd_amd64.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	defIgnoredMountPoints = "^/(dev)($|/)"
-	defIgnoredFSTypes     = "^devfs$"
+	defMountPointsExcluded = "^/(dev)($|/)"
+	defFSTypesExcluded     = "^devfs$"
 )
 
 // Expose filesystem fullness.
@@ -42,14 +42,14 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 	stats = []filesystemStats{}
 	for _, v := range mnt {
 		mountpoint := int8ToString(v.F_mntonname[:])
-		if c.ignoredMountPointsPattern.MatchString(mountpoint) {
+		if c.excludedMountPointsPattern.MatchString(mountpoint) {
 			level.Debug(c.logger).Log("msg", "Ignoring mount point", "mountpoint", mountpoint)
 			continue
 		}
 
 		device := int8ToString(v.F_mntfromname[:])
 		fstype := int8ToString(v.F_fstypename[:])
-		if c.ignoredFSTypesPattern.MatchString(fstype) {
+		if c.excludedFSTypesPattern.MatchString(fstype) {
 			level.Debug(c.logger).Log("msg", "Ignoring fs type", "type", fstype)
 			continue
 		}


### PR DESCRIPTION
PR #1743 changed filter flag names to `collector.netdev.device-exclude` and `collector.systemd.unit-exclude`. To follow this naming scheme, `collector.filesystem.ignored-mount-points` and `collector.filesystem.ignored-fs-types`should be renamed as well and the old flags deprecated for 2.0.

Fixes: #1994

FYI: I couldn't run `make` and `make test` because of some linting issues in other modules I didn't want to touch:

```
GO111MODULE=on /Users/frederic/go/bin/golangci-lint run  ./...
collector/diskstats_common.go:54:2: `ioTimeSecondsDesc` is unused (deadcode)
        ioTimeSecondsDesc = prometheus.NewDesc(
        ^
collector/helper.go:23:6: `readUintFromFile` is unused (deadcode)
func readUintFromFile(path string) (uint64, error) {
     ^
collector/paths.go:39:6: `rootfsFilePath` is unused (deadcode)
func rootfsFilePath(name string) string {
     ^
collector/sysctl_bsd.go:52:2: `valueType` is unused (structcheck)
        valueType prometheus.ValueType
        ^
collector/filesystem_common.go:66:30: field `options` is unused (unused)
make: *** [common-lint] Error 1
```

Took the required code changes right from PR #1743.