### PR TITLE
Add Darwin arm64 build

### DIFF
--- a/.promu-cgo.yml
+++ b/.promu-cgo.yml
@@ -22,5 +22,6 @@ tarball:
 crossbuild:
     platforms:
         - darwin/amd64
+        - darwin/arm64
         - netbsd/amd64
         - netbsd/386

--- a/Makefile.common
+++ b/Makefile.common
@@ -78,12 +78,12 @@ ifneq ($(shell which gotestsum),)
 endif
 endif
 
-PROMU_VERSION ?= 0.11.1
+PROMU_VERSION ?= 0.12.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v1.36.0
+GOLANGCI_LINT_VERSION ?= v1.39.0
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))

--- a/collector/filesystem_bsd.go
+++ b/collector/filesystem_bsd.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build openbsd,!amd64 darwin,amd64 dragonfly
+// +build openbsd,!amd64 darwin dragonfly
 // +build !nofilesystem
 
 package collector

--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // +build !nofilesystem
-// +build linux freebsd openbsd darwin,amd64 dragonfly
+// +build linux freebsd openbsd darwin dragonfly
 
 package collector
 

--- a/collector/filesystem_openbsd_amd64.go
+++ b/collector/filesystem_openbsd_amd64.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build openbsd darwin,amd64 dragonfly
+// +build openbsd
 // +build !nofilesystem
 
 package collector

--- a/collector/zfs_linux.go
+++ b/collector/zfs_linux.go
@@ -102,7 +102,7 @@ func (c *zfsCollector) updatePoolStats(ch chan<- prometheus.Metric) error {
 	for _, zpoolPath := range zpoolObjsetPaths {
 		file, err := os.Open(zpoolPath)
 		if err != nil {
-			// this file should exist, but there is a race where an exporting pool can remove the files -- ok to ignore
+			// This file should exist, but there is a race where an exporting pool can remove the files. Ok to ignore.
 			level.Debug(c.logger).Log("msg", "Cannot open file for reading", "path", zpoolPath)
 			return errZFSNotAvailable
 		}
@@ -122,13 +122,14 @@ func (c *zfsCollector) updatePoolStats(ch chan<- prometheus.Metric) error {
 	}
 
 	if zpoolStatePaths == nil {
-		level.Debug(c.logger).Log("msg", "Not found pool state files")
+		level.Debug(c.logger).Log("msg", "No pool state files found")
+		return nil
 	}
 
 	for _, zpoolPath := range zpoolStatePaths {
 		file, err := os.Open(zpoolPath)
 		if err != nil {
-			// this file should exist, but there is a race where an exporting pool can remove the files -- ok to ignore
+			// This file should exist, but there is a race where an exporting pool can remove the files. Ok to ignore.
 			level.Debug(c.logger).Log("msg", "Cannot open file for reading", "path", zpoolPath)
 			return errZFSNotAvailable
 		}


### PR DESCRIPTION
Add darwin/arm64 to the CGO crossbuilder list.
* Update Makefile.common to pick up new promu.
* Fix possible nil pointer caught by staticcheck.
* Update collector build tags.

Fixes: https://github.com/prometheus/node_exporter/issues/1997

Signed-off-by: Ben Kochie <superq@gmail.com>