### PR TITLE
Make node_exporter print usage to STDOUT

### DIFF
--- a/node_exporter.go
+++ b/node_exporter.go
@@ -168,6 +168,7 @@ func main() {
 	promlogConfig := &promlog.Config{}
 	flag.AddFlags(kingpin.CommandLine, promlogConfig)
 	kingpin.Version(version.Print("node_exporter"))
+	kingpin.CommandLine.UsageWriter(os.Stdout)
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 	logger := promlog.New(promlogConfig)


### PR DESCRIPTION
Matches updated behaviour in Prometheus and other tools.

Signed-off-by: David Leadbeater <dgl@dgl.cx>