### PR TITLE
Use rm -rf to remove fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ skip-test-32bit:
 
 %/.unpacked: %.ttar
 	@echo ">> extracting fixtures"
-	if [ -d $(dir $@) ] ; then rm -r $(dir $@) ; fi
+	if [ -d $(dir $@) ] ; then rm -rf $(dir $@) ; fi
 	./ttar -C $(dir $*) -x -f $*.ttar
 	touch $@
 


### PR DESCRIPTION
rm interactively asks for confirmation while removing read-only
files and fixtures sys has dozens of them.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>