### PR TITLE
add total CPU usage metrics

### DIFF
--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -297,6 +297,19 @@ func (c *cpuCollector) updateStat(ch chan<- prometheus.Metric) error {
 		ch <- prometheus.MustNewConstMetric(c.cpuGuest, prometheus.CounterValue, cpuStat.GuestNice, cpuNum, "nice")
 	}
 
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, stats.CPUTotal.User, "total", "user")
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, stats.CPUTotal.Nice, "total", "nice")
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, stats.CPUTotal.System, "total", "system")
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, stats.CPUTotal.Idle, "total", "idle")
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, stats.CPUTotal.Iowait, "total", "iowait")
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, stats.CPUTotal.IRQ, "total", "irq")
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, stats.CPUTotal.SoftIRQ, "total", "softirq")
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, stats.CPUTotal.Steal, "total", "steal")
+
+	// Guest CPU is also accounted for in cpuStat.User and cpuStat.Nice, expose these as separate metrics.
+	ch <- prometheus.MustNewConstMetric(c.cpuGuest, prometheus.CounterValue, stats.CPUTotal.Guest, "total", "user")
+	ch <- prometheus.MustNewConstMetric(c.cpuGuest, prometheus.CounterValue, stats.CPUTotal.GuestNice, "total", "nice")
+
 	return nil
 }
 

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -283,6 +283,8 @@ node_cpu_guest_seconds_total{cpu="6",mode="nice"} 0.07
 node_cpu_guest_seconds_total{cpu="6",mode="user"} 0.08
 node_cpu_guest_seconds_total{cpu="7",mode="nice"} 0.08
 node_cpu_guest_seconds_total{cpu="7",mode="user"} 0.09
+node_cpu_guest_seconds_total{cpu="total",mode="nice"} 0.36
+node_cpu_guest_seconds_total{cpu="total",mode="user"} 0.44
 # HELP node_cpu_info CPU information from /proc/cpuinfo.
 # TYPE node_cpu_info gauge
 node_cpu_info{cachesize="8192 KB",core="0",cpu="0",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
@@ -381,6 +383,14 @@ node_cpu_seconds_total{cpu="7",mode="softirq"} 0.31
 node_cpu_seconds_total{cpu="7",mode="steal"} 0
 node_cpu_seconds_total{cpu="7",mode="system"} 101.64
 node_cpu_seconds_total{cpu="7",mode="user"} 290.98
+node_cpu_seconds_total{cpu="total",mode="idle"} 89790.04
+node_cpu_seconds_total{cpu="total",mode="iowait"} 35.52
+node_cpu_seconds_total{cpu="total",mode="irq"} 0.02
+node_cpu_seconds_total{cpu="total",mode="nice"} 6.12
+node_cpu_seconds_total{cpu="total",mode="softirq"} 39.44
+node_cpu_seconds_total{cpu="total",mode="steal"} 0
+node_cpu_seconds_total{cpu="total",mode="system"} 1119.22
+node_cpu_seconds_total{cpu="total",mode="user"} 3018.54
 # HELP node_disk_discard_time_seconds_total This is the total number of seconds spent by all discards.
 # TYPE node_disk_discard_time_seconds_total counter
 node_disk_discard_time_seconds_total{device="sdb"} 11.13


### PR DESCRIPTION
These changes allow you to get statistics on nodes without the need to summarize.
Reason: In our monitoring system these metrics are summed up by Grafana itself, and on large clusters with 64 CPU core nodes, the calculation was interrupted due to a timeout.