### PR TITLE
Add support for custom labels on network interface metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,3 +288,25 @@ See the [exporter-toolkit https package](https://github.com/prometheus/exporter-
 [circleci]: https://circleci.com/gh/prometheus/node_exporter
 [quay]: https://quay.io/repository/prometheus/node-exporter
 [goreportcard]: https://goreportcard.com/report/github.com/prometheus/node_exporter
+
+## Annotations (Custom Labels)
+
+** EXPERIMENTAL **
+
+The exporter supports adding custom labels to network interface metrics.
+
+```console
+./node_exporter --annotations.config=annotations.yml
+```
+
+```yaml
+netdev:
+  - name: "eth0"
+    labels:
+      remote_dev: "router-1.pop01"
+      remote_if: "xe-0/0/0"
+      customer: "ACME"
+      drained: "false"
+      circuit_id: "xx12345"
+      status: "planned"
+```

--- a/annotator.go
+++ b/annotator.go
@@ -1,3 +1,16 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/annotator.go
+++ b/annotator.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/node_exporter/collector"
+	"gopkg.in/yaml.v2"
+)
+
+type Annotator struct {
+	cfg *AnnotatorCfg
+}
+
+type AnnotatorCfg struct {
+	Netdev []AnnotatorCfgNetdev `yaml:"netdev"`
+}
+
+type AnnotatorCfgNetdev struct {
+	Name   string            `yaml:"name"`
+	Labels map[string]string `yaml:"labels"`
+}
+
+func NewAnnotator(fp string) (*Annotator, error) {
+	cfg, err := getAnnotatorConfig(fp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Annotator{
+		cfg: cfg,
+	}, nil
+}
+
+func getAnnotatorConfig(fp string) (*AnnotatorCfg, error) {
+	cfg := &AnnotatorCfg{}
+
+	fc, err := ioutil.ReadFile(fp)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to read annotations config")
+	}
+
+	err = yaml.Unmarshal(fc, cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unmarshal failed")
+	}
+
+	return cfg, nil
+}
+
+func (a *Annotator) Netdev(name string) collector.Labels {
+	if a.cfg.Netdev == nil {
+		return nil
+	}
+
+	for _, x := range a.cfg.Netdev {
+		if name != x.Name {
+			continue
+		}
+
+		return labelMapToLabelSlice(x.Labels)
+	}
+
+	return nil
+}
+
+func labelMapToLabelSlice(m map[string]string) collector.Labels {
+	ret := make(collector.Labels, 0, len(m))
+
+	for k, v := range m {
+		ret = append(ret, collector.Label{
+			Key:   k,
+			Value: v,
+		})
+	}
+
+	return ret
+}

--- a/collector/annotation.go
+++ b/collector/annotation.go
@@ -1,3 +1,16 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package collector
 
 type Annotator interface {

--- a/collector/annotation.go
+++ b/collector/annotation.go
@@ -1,0 +1,42 @@
+package collector
+
+type Annotator interface {
+	Netdev(name string) Labels
+}
+
+type Label struct {
+	Key   string
+	Value string
+}
+
+func SetAnnotator(a Annotator) {
+	annotator = a
+}
+
+type Labels []Label
+
+func (l Labels) keys() []string {
+	ret := make([]string, 0, len(l))
+
+	for _, la := range l {
+		ret = append(ret, la.Key)
+	}
+
+	return ret
+}
+
+func (l Labels) values() []string {
+	ret := make([]string, 0, len(l))
+
+	for _, la := range l {
+		ret = append(ret, la.Value)
+	}
+
+	return ret
+}
+
+type dummyAnnotator struct{}
+
+func (d *dummyAnnotator) Netdev(name string) Labels {
+	return nil
+}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -50,11 +50,12 @@ const (
 )
 
 var (
-	factories              = make(map[string]func(logger log.Logger) (Collector, error))
-	initiatedCollectorsMtx = sync.Mutex{}
-	initiatedCollectors    = make(map[string]Collector)
-	collectorState         = make(map[string]*bool)
-	forcedCollectors       = map[string]bool{} // collectors which have been explicitly enabled or disabled
+	factories                        = make(map[string]func(logger log.Logger) (Collector, error))
+	initiatedCollectorsMtx           = sync.Mutex{}
+	initiatedCollectors              = make(map[string]Collector)
+	collectorState                   = make(map[string]*bool)
+	forcedCollectors                 = map[string]bool{} // collectors which have been explicitly enabled or disabled
+	annotator              Annotator = &dummyAnnotator{}
 )
 
 func registerCollector(collector string, isDefaultEnabled bool, factory func(logger log.Logger) (Collector, error)) {

--- a/collector/ethtool_linux.go
+++ b/collector/ethtool_linux.go
@@ -140,7 +140,7 @@ func (c *ethtoolCollector) Update(ch chan<- prometheus.Metric) error {
 			metricFQName = transmittedRegex.ReplaceAllString(metricFQName, "_transmitted_")
 
 			entry := prometheus.NewDesc(
-				metricFQName,
+				metricFQName+"_total",
 				fmt.Sprintf("Network interface %s", metric),
 				labelKeys, nil,
 			)

--- a/collector/ethtool_linux.go
+++ b/collector/ethtool_linux.go
@@ -52,10 +52,9 @@ func (e *ethtoolStats) Stats(intf string) (map[string]uint64, error) {
 }
 
 type ethtoolCollector struct {
-	fs      sysfs.FS
-	entries map[string]*prometheus.Desc
-	logger  log.Logger
-	stats   EthtoolStats
+	fs     sysfs.FS
+	logger log.Logger
+	stats  EthtoolStats
 }
 
 // makeEthtoolCollector is the internal constructor for EthtoolCollector.
@@ -69,45 +68,8 @@ func makeEthtoolCollector(logger log.Logger) (*ethtoolCollector, error) {
 
 	// Pre-populate some common ethtool metrics.
 	return &ethtoolCollector{
-		fs:    fs,
-		stats: &ethtoolStats{},
-		entries: map[string]*prometheus.Desc{
-			"rx_bytes": prometheus.NewDesc(
-				"node_ethtool_received_bytes_total",
-				"Network interface bytes received",
-				[]string{"device"}, nil,
-			),
-			"rx_dropped": prometheus.NewDesc(
-				"node_ethtool_received_dropped_total",
-				"Number of received frames dropped",
-				[]string{"device"}, nil,
-			),
-			"rx_errors": prometheus.NewDesc(
-				"node_ethtool_received_errors_total",
-				"Number of received frames with errors",
-				[]string{"device"}, nil,
-			),
-			"rx_packets": prometheus.NewDesc(
-				"node_ethtool_received_packets_total",
-				"Network interface packets received",
-				[]string{"device"}, nil,
-			),
-			"tx_bytes": prometheus.NewDesc(
-				"node_ethtool_transmitted_bytes_total",
-				"Network interface bytes sent",
-				[]string{"device"}, nil,
-			),
-			"tx_errors": prometheus.NewDesc(
-				"node_ethtool_transmitted_errors_total",
-				"Number of sent frames with errors",
-				[]string{"device"}, nil,
-			),
-			"tx_packets": prometheus.NewDesc(
-				"node_ethtool_transmitted_packets_total",
-				"Network interface packets sent",
-				[]string{"device"}, nil,
-			),
-		},
+		fs:     fs,
+		stats:  &ethtoolStats{},
 		logger: logger,
 	}, nil
 }
@@ -141,6 +103,10 @@ func (c *ethtoolCollector) Update(ch chan<- prometheus.Metric) error {
 
 		stats, err = c.stats.Stats(device)
 
+		labels := annotator.Netdev(device)
+		labelKeys := append([]string{"device"}, labels.keys()...)
+		labelValues := append([]string{device}, labels.values()...)
+
 		// If Stats() returns EOPNOTSUPP it doesn't support ethtool stats. Log that only at Debug level.
 		// Otherwise log it at Error level.
 		if err != nil {
@@ -173,18 +139,13 @@ func (c *ethtoolCollector) Update(ch chan<- prometheus.Metric) error {
 			metricFQName = receivedRegex.ReplaceAllString(metricFQName, "_received_")
 			metricFQName = transmittedRegex.ReplaceAllString(metricFQName, "_transmitted_")
 
-			// Check to see if this metric exists; if not then create it and store it in c.entries.
-			entry, exists := c.entries[metric]
-			if !exists {
-				entry = prometheus.NewDesc(
-					metricFQName,
-					fmt.Sprintf("Network interface %s", metric),
-					[]string{"device"}, nil,
-				)
-				c.entries[metric] = entry
-			}
+			entry := prometheus.NewDesc(
+				metricFQName,
+				fmt.Sprintf("Network interface %s", metric),
+				labelKeys, nil,
+			)
 			ch <- prometheus.MustNewConstMetric(
-				entry, prometheus.UntypedValue, float64(val), device)
+				entry, prometheus.UntypedValue, float64(val), labelValues...)
 		}
 	}
 

--- a/collector/ethtool_linux_test.go
+++ b/collector/ethtool_linux_test.go
@@ -83,17 +83,17 @@ func NewEthtoolTestCollector(logger log.Logger) (Collector, error) {
 
 func TestEthtoolCollector(t *testing.T) {
 	testcases := []string{
-		prometheus.NewDesc("node_ethtool_align_errors", "Network interface align_errors", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_received_broadcast", "Network interface rx_broadcast", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_received_errors_total", "Number of received frames with errors", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_received_missed", "Network interface rx_missed", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_received_multicast", "Network interface rx_multicast", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_received_packets_total", "Network interface packets received", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_received_unicast", "Network interface rx_unicast", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_transmitted_aborted", "Network interface tx_aborted", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_transmitted_errors_total", "Number of sent frames with errors", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_transmitted_multi_collisions", "Network interface tx_multi_collisions", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_transmitted_packets_total", "Network interface packets sent", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_align_errors_total", "Network interface align_errors", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_received_broadcast_total", "Network interface rx_broadcast", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_received_errors_total", "Network interface rx_errors", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_received_missed_total", "Network interface rx_missed", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_received_multicast_total", "Network interface rx_multicast", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_received_packets_total", "Network interface rx_packets", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_received_unicast_total", "Network interface rx_unicast", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_transmitted_aborted_total", "Network interface tx_aborted", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_transmitted_errors_total", "Network interface tx_errors", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_transmitted_multi_collisions_total", "Network interface tx_multi_collisions", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_transmitted_packets_total", "Network interface tx_packets", []string{"device"}, nil).String(),
 	}
 
 	*sysPath = "fixtures/sys"

--- a/collector/netclass_linux.go
+++ b/collector/netclass_linux.go
@@ -72,10 +72,14 @@ func (c *netClassCollector) Update(ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("could not get net class info: %w", err)
 	}
 	for _, ifaceInfo := range netClass {
+		labels := annotator.Netdev(ifaceInfo.Name)
+		labelKeys := append([]string{"device"}, labels.keys()...)
+		labelValues := append([]string{ifaceInfo.Name}, labels.values()...)
+
 		upDesc := prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, c.subsystem, "up"),
 			"Value is 1 if operstate is 'up', 0 otherwise.",
-			[]string{"device"},
+			labelKeys,
 			nil,
 		)
 		upValue := 0.0
@@ -83,103 +87,103 @@ func (c *netClassCollector) Update(ch chan<- prometheus.Metric) error {
 			upValue = 1.0
 		}
 
-		ch <- prometheus.MustNewConstMetric(upDesc, prometheus.GaugeValue, upValue, ifaceInfo.Name)
+		ch <- prometheus.MustNewConstMetric(upDesc, prometheus.GaugeValue, upValue, labelValues...)
 
 		infoDesc := prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, c.subsystem, "info"),
 			"Non-numeric data from /sys/class/net/<iface>, value is always 1.",
-			[]string{"device", "address", "broadcast", "duplex", "operstate", "ifalias"},
+			append([]string{"device", "address", "broadcast", "duplex", "operstate", "ifalias"}, labels.keys()...),
 			nil,
 		)
 		infoValue := 1.0
 
-		ch <- prometheus.MustNewConstMetric(infoDesc, prometheus.GaugeValue, infoValue, ifaceInfo.Name, ifaceInfo.Address, ifaceInfo.Broadcast, ifaceInfo.Duplex, ifaceInfo.OperState, ifaceInfo.IfAlias)
+		ch <- prometheus.MustNewConstMetric(infoDesc, prometheus.GaugeValue, infoValue, append([]string{ifaceInfo.Name, ifaceInfo.Address, ifaceInfo.Broadcast, ifaceInfo.Duplex, ifaceInfo.OperState, ifaceInfo.IfAlias}, labels.values()...)...)
 
 		if ifaceInfo.AddrAssignType != nil {
-			pushMetric(ch, c.subsystem, "address_assign_type", *ifaceInfo.AddrAssignType, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "address_assign_type", *ifaceInfo.AddrAssignType, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.Carrier != nil {
-			pushMetric(ch, c.subsystem, "carrier", *ifaceInfo.Carrier, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "carrier", *ifaceInfo.Carrier, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.CarrierChanges != nil {
-			pushMetric(ch, c.subsystem, "carrier_changes_total", *ifaceInfo.CarrierChanges, ifaceInfo.Name, prometheus.CounterValue)
+			pushMetric(ch, c.subsystem, "carrier_changes_total", *ifaceInfo.CarrierChanges, labelKeys, labelValues, prometheus.CounterValue)
 		}
 
 		if ifaceInfo.CarrierUpCount != nil {
-			pushMetric(ch, c.subsystem, "carrier_up_changes_total", *ifaceInfo.CarrierUpCount, ifaceInfo.Name, prometheus.CounterValue)
+			pushMetric(ch, c.subsystem, "carrier_up_changes_total", *ifaceInfo.CarrierUpCount, labelKeys, labelValues, prometheus.CounterValue)
 		}
 
 		if ifaceInfo.CarrierDownCount != nil {
-			pushMetric(ch, c.subsystem, "carrier_down_changes_total", *ifaceInfo.CarrierDownCount, ifaceInfo.Name, prometheus.CounterValue)
+			pushMetric(ch, c.subsystem, "carrier_down_changes_total", *ifaceInfo.CarrierDownCount, labelKeys, labelValues, prometheus.CounterValue)
 		}
 
 		if ifaceInfo.DevID != nil {
-			pushMetric(ch, c.subsystem, "device_id", *ifaceInfo.DevID, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "device_id", *ifaceInfo.DevID, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.Dormant != nil {
-			pushMetric(ch, c.subsystem, "dormant", *ifaceInfo.Dormant, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "dormant", *ifaceInfo.Dormant, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.Flags != nil {
-			pushMetric(ch, c.subsystem, "flags", *ifaceInfo.Flags, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "flags", *ifaceInfo.Flags, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.IfIndex != nil {
-			pushMetric(ch, c.subsystem, "iface_id", *ifaceInfo.IfIndex, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "iface_id", *ifaceInfo.IfIndex, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.IfLink != nil {
-			pushMetric(ch, c.subsystem, "iface_link", *ifaceInfo.IfLink, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "iface_link", *ifaceInfo.IfLink, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.LinkMode != nil {
-			pushMetric(ch, c.subsystem, "iface_link_mode", *ifaceInfo.LinkMode, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "iface_link_mode", *ifaceInfo.LinkMode, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.MTU != nil {
-			pushMetric(ch, c.subsystem, "mtu_bytes", *ifaceInfo.MTU, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "mtu_bytes", *ifaceInfo.MTU, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.NameAssignType != nil {
-			pushMetric(ch, c.subsystem, "name_assign_type", *ifaceInfo.NameAssignType, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "name_assign_type", *ifaceInfo.NameAssignType, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.NetDevGroup != nil {
-			pushMetric(ch, c.subsystem, "net_dev_group", *ifaceInfo.NetDevGroup, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "net_dev_group", *ifaceInfo.NetDevGroup, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.Speed != nil {
 			// Some devices return -1 if the speed is unknown.
 			if *ifaceInfo.Speed >= 0 || !*netclassInvalidSpeed {
 				speedBytes := int64(*ifaceInfo.Speed * 1000 * 1000 / 8)
-				pushMetric(ch, c.subsystem, "speed_bytes", speedBytes, ifaceInfo.Name, prometheus.GaugeValue)
+				pushMetric(ch, c.subsystem, "speed_bytes", speedBytes, labelKeys, labelValues, prometheus.GaugeValue)
 			}
 		}
 
 		if ifaceInfo.TxQueueLen != nil {
-			pushMetric(ch, c.subsystem, "transmit_queue_length", *ifaceInfo.TxQueueLen, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "transmit_queue_length", *ifaceInfo.TxQueueLen, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.Type != nil {
-			pushMetric(ch, c.subsystem, "protocol_type", *ifaceInfo.Type, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "protocol_type", *ifaceInfo.Type, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 	}
 
 	return nil
 }
 
-func pushMetric(ch chan<- prometheus.Metric, subsystem string, name string, value int64, ifaceName string, valueType prometheus.ValueType) {
+func pushMetric(ch chan<- prometheus.Metric, subsystem string, name string, value int64, labelKeys []string, labelValues []string, valueType prometheus.ValueType) {
 	fieldDesc := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, subsystem, name),
 		fmt.Sprintf("%s value of /sys/class/net/<iface>.", name),
-		[]string{"device"},
+		labelKeys,
 		nil,
 	)
 
-	ch <- prometheus.MustNewConstMetric(fieldDesc, valueType, float64(value), ifaceName)
+	ch <- prometheus.MustNewConstMetric(fieldDesc, valueType, float64(value), labelValues...)
 }
 
 func (c *netClassCollector) getNetClassInfo() (sysfs.NetClass, error) {

--- a/collector/netdev_common.go
+++ b/collector/netdev_common.go
@@ -93,17 +93,15 @@ func (c *netDevCollector) Update(ch chan<- prometheus.Metric) error {
 	}
 	for dev, devStats := range netDev {
 		for key, value := range devStats {
-			desc, ok := c.metricDescs[key]
-			if !ok {
-				desc = prometheus.NewDesc(
-					prometheus.BuildFQName(namespace, c.subsystem, key+"_total"),
-					fmt.Sprintf("Network device statistic %s.", key),
-					[]string{"device"},
-					nil,
-				)
-				c.metricDescs[key] = desc
-			}
-			ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, float64(value), dev)
+			labels := annotator.Netdev(dev)
+			desc := prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, c.subsystem, key+"_total"),
+				fmt.Sprintf("Network device statistic %s.", key),
+				append([]string{"device"}, labels.keys()...),
+				nil,
+			)
+
+			ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, float64(value), append([]string{dev}, labels.values()...)...)
 		}
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/mattn/go-xmlrpc v0.0.3
 	github.com/mdlayher/genetlink v1.0.0 // indirect
 	github.com/mdlayher/wifi v0.0.0-20200527114002-84f0b9457fdd
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.26.0
@@ -23,7 +23,7 @@ require (
 	github.com/soundcloud/go-runit v0.0.0-20150630195641-06ad41a06c4a
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/beevik/ntp v0.3.0
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/ema/qdisc v0.0.0-20200603082823-62d0308e3e00
+	github.com/go-kit/kit v0.10.0 // indirect
 	github.com/go-kit/log v0.1.0
 	github.com/godbus/dbus v0.0.0-20190402143921-271e53dc4968
 	github.com/hodgesds/perf-utils v0.2.5
@@ -12,6 +13,7 @@ require (
 	github.com/mattn/go-xmlrpc v0.0.3
 	github.com/mdlayher/genetlink v1.0.0 // indirect
 	github.com/mdlayher/wifi v0.0.0-20200527114002-84f0b9457fdd
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.26.0
@@ -22,6 +24,7 @@ require (
 	github.com/soundcloud/go-runit v0.0.0-20150630195641-06ad41a06c4a
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	github.com/beevik/ntp v0.3.0
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/ema/qdisc v0.0.0-20200603082823-62d0308e3e00
-	github.com/go-kit/kit v0.10.0 // indirect
 	github.com/go-kit/log v0.1.0
 	github.com/godbus/dbus v0.0.0-20190402143921-271e53dc4968
 	github.com/hodgesds/perf-utils v0.2.5

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -165,6 +165,10 @@ func main() {
 			"web.config",
 			"[EXPERIMENTAL] Path to config yaml file that can enable TLS or authentication.",
 		).Default("").String()
+		annotationsConfigFile = kingpin.Flag(
+			"annotations.config",
+			"Annotations configuration file.",
+		).Default("").String()
 	)
 
 	promlogConfig := &promlog.Config{}
@@ -182,6 +186,15 @@ func main() {
 	level.Info(logger).Log("msg", "Build context", "build_context", version.BuildContext())
 	if user, err := user.Current(); err == nil && user.Uid == "0" {
 		level.Warn(logger).Log("msg", "Node Exporter is running as root user. This exporter is designed to run as unpriviledged user, root is not required.")
+	}
+
+	if annotationsConfigFile != nil {
+		annotator, err := NewAnnotator(*annotationsConfigFile)
+		if err != nil {
+			logger.Log("msg", "Unablt to get annotator")
+		} else {
+			collector.SetAnnotator(annotator)
+		}
 	}
 
 	http.Handle(*metricsPath, newHandler(!*disableExporterMetrics, *maxRequests, logger))


### PR DESCRIPTION
As proposed in my email on the ML (https://groups.google.com/g/prometheus-developers/c/fWjiEw-GL1g) I've implemented support for adding custom labels to network interface metrics. Having additional labels on interface metrics makes both silencing and querying a lot simpler when operating networks.