### PR TITLE
docs: Replace `go get` with `go install` for command installation

### DIFF
--- a/docs/node-mixin/README.md
+++ b/docs/node-mixin/README.md
@@ -11,9 +11,9 @@ for Grafana.
 To use them, you need to have `jsonnet` (v0.16+) and `jb` installed. If you
 have a working Go development environment, it's easiest to run the following:
 ```bash
-$ go get github.com/google/go-jsonnet/cmd/jsonnet
-$ go get github.com/google/go-jsonnet/cmd/jsonnetfmt
-$ go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+$ go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+$ go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+$ go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
 ```
 
 Next, install the dependencies by running the following command in this


### PR DESCRIPTION
`go get` is deprecated for installation of commands as of go v1.17
Ref: https://go.googlesource.com/go/+/ced0fdbad0655d63d535390b1a7126fd1fef8348

Signed-off-by: Frederic Hemberger <mail@frederic-hemberger.de>