### PR TITLE
add yamllint config, fix yamllint errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,47 +9,47 @@ executors:
   # should also be updated.
   golang:
     docker:
-    - image: circleci/golang:1.16
+      - image: circleci/golang:1.16
 
 jobs:
   test:
     executor: golang
 
     steps:
-    - prometheus/setup_environment
-    - run: go mod download
-    - run: make
-    - prometheus/store_artifact:
-        file: node_exporter
+      - prometheus/setup_environment
+      - run: go mod download
+      - run: make
+      - prometheus/store_artifact:
+          file: node_exporter
 
   codespell:
     docker:
-    - image: circleci/python
+      - image: circleci/python
 
     steps:
-    - checkout
-    - run: sudo pip install codespell
-    - run: codespell --skip=".git,./vendor,ttar,go.mod,go.sum,*pem,./collector/fixtures" -L uint,packages\',uptodate
+      - checkout
+      - run: sudo pip install codespell
+      - run: codespell --skip=".git,./vendor,ttar,go.mod,go.sum,*pem,./collector/fixtures" -L uint,packages\',uptodate
 
   test_mixins:
     executor: golang
     steps:
-    - checkout
-    - run:
-        command: go install -mod=readonly github.com/google/go-jsonnet/cmd/jsonnet github.com/google/go-jsonnet/cmd/jsonnetfmt github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb github.com/prometheus/prometheus/cmd/promtool
-        working_directory: ~/project/docs/node-mixin
-    - run:
-        command: make clean
-        working_directory: ~/project/docs/node-mixin
-    - run:
-        command: jb install
-        working_directory: ~/project/docs/node-mixin
-    - run:
-        command: make
-        working_directory: ~/project/docs/node-mixin
-    - run:
-        command: git diff --exit-code
-        working_directory: ~/project/docs/node-mixin
+      - checkout
+      - run:
+          command: go install -mod=readonly github.com/google/go-jsonnet/cmd/jsonnet github.com/google/go-jsonnet/cmd/jsonnetfmt github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb github.com/prometheus/prometheus/cmd/promtool
+          working_directory: ~/project/docs/node-mixin
+      - run:
+          command: make clean
+          working_directory: ~/project/docs/node-mixin
+      - run:
+          command: jb install
+          working_directory: ~/project/docs/node-mixin
+      - run:
+          command: make
+          working_directory: ~/project/docs/node-mixin
+      - run:
+          command: git diff --exit-code
+          working_directory: ~/project/docs/node-mixin
 
   build:
     machine:
@@ -58,17 +58,17 @@ jobs:
     parallelism: 3
 
     steps:
-    - prometheus/setup_environment
-    - run: docker run --privileged linuxkit/binfmt:v0.8
-    - run: promu crossbuild -v --parallelism $CIRCLE_NODE_TOTAL --parallelism-thread $CIRCLE_NODE_INDEX
-    - run: promu --config .promu-cgo.yml crossbuild -v --parallelism $CIRCLE_NODE_TOTAL --parallelism-thread $CIRCLE_NODE_INDEX
-    - persist_to_workspace:
-        root: .
-        paths:
-        - .build
-    - store_artifacts:
-        path: .build
-        destination: /build
+      - prometheus/setup_environment
+      - run: docker run --privileged linuxkit/binfmt:v0.8
+      - run: promu crossbuild -v --parallelism $CIRCLE_NODE_TOTAL --parallelism-thread $CIRCLE_NODE_INDEX
+      - run: promu --config .promu-cgo.yml crossbuild -v --parallelism $CIRCLE_NODE_TOTAL --parallelism-thread $CIRCLE_NODE_INDEX
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .build
+      - store_artifacts:
+          path: .build
+          destination: /build
 
   test_docker:
     machine:
@@ -79,68 +79,68 @@ jobs:
       REPO_PATH: github.com/prometheus/node_exporter
 
     steps:
-    - prometheus/setup_environment
-    - attach_workspace:
-        at: .
-    - run:
-        command: |
-          if [ -n "$CIRCLE_TAG" ]; then
-            make docker DOCKER_IMAGE_TAG=$CIRCLE_TAG
-          else
-            make docker
-          fi
-    - run: docker images
-    - run: docker run --rm -t -v "$(pwd):/app" "${DOCKER_TEST_IMAGE_NAME}" -i "${REPO_PATH}" -T
-    - run:
-        command: |
-          if [ -n "$CIRCLE_TAG" ]; then
-            make test-docker DOCKER_IMAGE_TAG=$CIRCLE_TAG
-          else
-            make test-docker
-          fi
+      - prometheus/setup_environment
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            if [ -n "$CIRCLE_TAG" ]; then
+              make docker DOCKER_IMAGE_TAG=$CIRCLE_TAG
+            else
+              make docker
+            fi
+      - run: docker images
+      - run: docker run --rm -t -v "$(pwd):/app" "${DOCKER_TEST_IMAGE_NAME}" -i "${REPO_PATH}" -T
+      - run:
+          command: |
+            if [ -n "$CIRCLE_TAG" ]; then
+              make test-docker DOCKER_IMAGE_TAG=$CIRCLE_TAG
+            else
+              make test-docker
+            fi
 
 workflows:
   version: 2
   node_exporter:
     jobs:
-    - test:
-        filters:
-          tags:
-            only: /.*/
-    - build:
-        filters:
-          tags:
-            only: /.*/
-    - codespell:
-        filters:
-          tags:
-            only: /.*/
-    - test_docker:
-        requires:
-        - test
-        - build
-        filters:
-          tags:
-            only: /.*/
-    - test_mixins:
-        filters:
-          tags:
-            only: /.*/
-    - prometheus/publish_master:
-        context: org-context
-        requires:
-        - test
-        - build
-        filters:
-          branches:
-            only: master
-    - prometheus/publish_release:
-        context: org-context
-        requires:
-        - test
-        - build
-        filters:
-          tags:
-            only: /^v.*/
-          branches:
-            ignore: /.*/
+      - test:
+          filters:
+            tags:
+              only: /.*/
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - codespell:
+          filters:
+            tags:
+              only: /.*/
+      - test_docker:
+          requires:
+            - test
+            - build
+          filters:
+            tags:
+              only: /.*/
+      - test_mixins:
+          filters:
+            tags:
+              only: /.*/
+      - prometheus/publish_master:
+          context: org-context
+          requires:
+            - test
+            - build
+          filters:
+            branches:
+              only: master
+      - prometheus/publish_release:
+          context: org-context
+          requires:
+            - test
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,21 @@
 linters:
   enable:
-  - golint
+    - golint
   disable:
     # Disable soon to deprecated[1] linters that lead to false
     # positives when build tags disable certain files[2]
     # 1: https://github.com/golangci/golangci-lint/issues/1841
     # 2: https://github.com/prometheus/node_exporter/issues/1545
-  - deadcode
-  - unused
-  - structcheck
-  - varcheck
+    - deadcode
+    - unused
+    - structcheck
+    - varcheck
 
 issues:
   exclude-rules:
-  - path: _test.go
-    linters:
-    - errcheck
+    - path: _test.go
+      linters:
+        - errcheck
 
 linters-settings:
   errcheck:

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,17 @@
+---
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  commas: disable
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  indentation:
+    spaces: consistent
+  line-length: disable

--- a/docs/example-16-compatibility-rules-new-to-old.yml
+++ b/docs/example-16-compatibility-rules-new-to-old.yml
@@ -1,201 +1,201 @@
 groups:
-- name: node_exporter-16-bcache
-  rules:
-  - expr: node_bcache_cache_read_races
-    record: node_bcache_cache_read_races_total
-- name: node_exporter-16-buddyinfo
-  rules:
-  - expr: node_buddyinfo_blocks
-    record: node_buddyinfo_count
-- name: node_exporter-16-stat
-  rules:
-  - expr: node_boot_time_seconds
-    record: node_boot_time
-  - expr: node_time_seconds
-    record: node_time
-  - expr: node_context_switches_total
-    record: node_context_switches
-  - expr: node_forks_total
-    record: node_forks
-  - expr: node_intr_total
-    record: node_intr
-- name: node_exporter-16-cpu
-  rules:
-  - expr: label_replace(node_cpu_seconds_total, "cpu", "$1", "cpu", "cpu(.+)")
-    record: node_cpu
-- name: node_exporter-16-diskstats
-  rules:
-  - expr: node_disk_read_bytes_total
-    record: node_disk_bytes_read
-  - expr: node_disk_written_bytes_total
-    record: node_disk_bytes_written
-  - expr: node_disk_io_time_seconds_total * 1000
-    record: node_disk_io_time_ms
-  - expr: node_disk_io_time_weighted_seconds_total
-    record: node_disk_io_time_weighted
-  - expr: node_disk_reads_completed_total
-    record: node_disk_reads_completed
-  - expr: node_disk_reads_merged_total
-    record: node_disk_reads_merged
-  - expr: node_disk_read_time_seconds_total * 1000
-    record: node_disk_read_time_ms
-  - expr: node_disk_writes_completed_total
-    record: node_disk_writes_completed
-  - expr: node_disk_writes_merged_total
-    record: node_disk_writes_merged
-  - expr: node_disk_write_time_seconds_total * 1000
-    record: node_disk_write_time_ms
-- name: node_exporter-16-filesystem
-  rules:
-  - expr: node_filesystem_free_bytes
-    record: node_filesystem_free
-  - expr: node_filesystem_avail_bytes
-    record: node_filesystem_avail
-  - expr: node_filesystem_size_bytes
-    record: node_filesystem_size
-- name: node_exporter-16-infiniband
-  rules:
-  - expr: node_infiniband_port_data_received_bytes_total
-    record: node_infiniband_port_data_received_bytes
-  - expr: node_infiniband_port_data_transmitted_bytes_total
-    record: node_infiniband_port_data_transmitted_bytes
-- name: node_exporter-16-interrupts
-  rules:
-  - expr: node_interrupts_total
-    record: node_interrupts
-- name: node_exporter-16-memory
-  rules:
-  - expr: node_memory_Active_bytes
-    record: node_memory_Active
-  - expr: node_memory_Active_anon_bytes
-    record: node_memory_Active_anon
-  - expr: node_memory_Active_file_bytes
-    record: node_memory_Active_file
-  - expr: node_memory_AnonHugePages_bytes
-    record: node_memory_AnonHugePages
-  - expr: node_memory_AnonPages_bytes
-    record: node_memory_AnonPages
-  - expr: node_memory_Bounce_bytes
-    record: node_memory_Bounce
-  - expr: node_memory_Buffers_bytes
-    record: node_memory_Buffers
-  - expr: node_memory_Cached_bytes
-    record: node_memory_Cached
-  - expr: node_memory_CommitLimit_bytes
-    record: node_memory_CommitLimit
-  - expr: node_memory_Committed_AS_bytes
-    record: node_memory_Committed_AS
-  - expr: node_memory_DirectMap2M_bytes
-    record: node_memory_DirectMap2M
-  - expr: node_memory_DirectMap4k_bytes
-    record: node_memory_DirectMap4k
-  - expr: node_memory_Dirty_bytes
-    record: node_memory_Dirty
-  - expr: node_memory_HardwareCorrupted_bytes
-    record: node_memory_HardwareCorrupted
-  - expr: node_memory_Hugepagesize_bytes
-    record: node_memory_Hugepagesize
-  - expr: node_memory_Inactive_bytes
-    record: node_memory_Inactive
-  - expr: node_memory_Inactive_anon_bytes
-    record: node_memory_Inactive_anon
-  - expr: node_memory_Inactive_file_bytes
-    record: node_memory_Inactive_file
-  - expr: node_memory_KernelStack_bytes
-    record: node_memory_KernelStack
-  - expr: node_memory_Mapped_bytes
-    record: node_memory_Mapped
-  - expr: node_memory_MemAvailable_bytes
-    record: node_memory_MemAvailable
-  - expr: node_memory_MemFree_bytes
-    record: node_memory_MemFree
-  - expr: node_memory_MemTotal_bytes
-    record: node_memory_MemTotal
-  - expr: node_memory_Mlocked_bytes
-    record: node_memory_Mlocked
-  - expr: node_memory_NFS_Unstable_bytes
-    record: node_memory_NFS_Unstable
-  - expr: node_memory_PageTables_bytes
-    record: node_memory_PageTables
-  - expr: node_memory_Shmem_bytes
-    record: node_memory_Shmem
-  - expr: node_memory_ShmemHugePages_bytes
-    record: node_memory_ShmemHugePages
-  - expr: node_memory_ShmemPmdMapped_bytes
-    record: node_memory_ShmemPmdMapped
-  - expr: node_memory_Slab_bytes
-    record: node_memory_Slab
-  - expr: node_memory_SReclaimable_bytes
-    record: node_memory_SReclaimable
-  - expr: node_memory_SUnreclaim_bytes
-    record: node_memory_SUnreclaim
-  - expr: node_memory_SwapCached_bytes
-    record: node_memory_SwapCached
-  - expr: node_memory_SwapFree_bytes
-    record: node_memory_SwapFree
-  - expr: node_memory_SwapTotal_bytes
-    record: node_memory_SwapTotal
-  - expr: node_memory_Unevictable_bytes
-    record: node_memory_Unevictable
-  - expr: node_memory_VmallocChunk_bytes
-    record: node_memory_VmallocChunk
-  - expr: node_memory_VmallocTotal_bytes
-    record: node_memory_VmallocTotal
-  - expr: node_memory_VmallocUsed_bytes
-    record: node_memory_VmallocUsed
-  - expr: node_memory_Writeback_bytes
-    record: node_memory_Writeback
-  - expr: node_memory_WritebackTmp_bytes
-    record: node_memory_WritebackTmp
-- name: node_exporter-16-network
-  rules:
-  - expr: node_network_receive_bytes_total
-    record: node_network_receive_bytes
-  - expr: node_network_receive_compressed_total
-    record: node_network_receive_compressed
-  - expr: node_network_receive_drop_total
-    record: node_network_receive_drop
-  - expr: node_network_receive_errs_total
-    record: node_network_receive_errs
-  - expr: node_network_receive_fifo_total
-    record: node_network_receive_fifo
-  - expr: node_network_receive_frame_total
-    record: node_network_receive_frame
-  - expr: node_network_receive_multicast_total
-    record: node_network_receive_multicast
-  - expr: node_network_receive_packets_total
-    record: node_network_receive_packets
-  - expr: node_network_transmit_bytes_total
-    record: node_network_transmit_bytes
-  - expr: node_network_transmit_compressed_total
-    record: node_network_transmit_compressed
-  - expr: node_network_transmit_drop_total
-    record: node_network_transmit_drop
-  - expr: node_network_transmit_errs_total
-    record: node_network_transmit_errs
-  - expr: node_network_transmit_fifo_total
-    record: node_network_transmit_fifo
-  - expr: node_network_transmit_frame_total
-    record: node_network_transmit_frame
-  - expr: node_network_transmit_multicast_total
-    record: node_network_transmit_multicast
-  - expr: node_network_transmit_packets_total
-    record: node_network_transmit_packets
-- name: node_exporter-16-nfs
-  rules:
-  - expr: node_nfs_connections_total
-    record: node_nfs_net_connections
-  - expr: node_nfs_packets_total
-    record: node_nfs_net_reads
-  - expr: label_replace(label_replace(node_nfs_requests_total, "proto", "$1", "version", "(.+)"), "method", "$1", "procedure", "(.+)")
-    record: node_nfs_procedures
-  - expr: node_nfs_rpc_authentication_refreshes_total
-    record: node_nfs_rpc_authentication_refreshes
-  - expr: node_nfs_rpcs_total
-    record: node_nfs_rpc_operations
-  - expr: node_nfs_rpc_retransmissions_total
-    record: node_nfs_rpc_retransmissions
-- name: node_exporter-16-textfile
-  rules:
-  - expr: node_textfile_mtime_seconds
-    record: node_textfile_mtime
+  - name: node_exporter-16-bcache
+    rules:
+      - expr: node_bcache_cache_read_races
+        record: node_bcache_cache_read_races_total
+  - name: node_exporter-16-buddyinfo
+    rules:
+      - expr: node_buddyinfo_blocks
+        record: node_buddyinfo_count
+  - name: node_exporter-16-stat
+    rules:
+      - expr: node_boot_time_seconds
+        record: node_boot_time
+      - expr: node_time_seconds
+        record: node_time
+      - expr: node_context_switches_total
+        record: node_context_switches
+      - expr: node_forks_total
+        record: node_forks
+      - expr: node_intr_total
+        record: node_intr
+  - name: node_exporter-16-cpu
+    rules:
+      - expr: label_replace(node_cpu_seconds_total, "cpu", "$1", "cpu", "cpu(.+)")
+        record: node_cpu
+  - name: node_exporter-16-diskstats
+    rules:
+      - expr: node_disk_read_bytes_total
+        record: node_disk_bytes_read
+      - expr: node_disk_written_bytes_total
+        record: node_disk_bytes_written
+      - expr: node_disk_io_time_seconds_total * 1000
+        record: node_disk_io_time_ms
+      - expr: node_disk_io_time_weighted_seconds_total
+        record: node_disk_io_time_weighted
+      - expr: node_disk_reads_completed_total
+        record: node_disk_reads_completed
+      - expr: node_disk_reads_merged_total
+        record: node_disk_reads_merged
+      - expr: node_disk_read_time_seconds_total * 1000
+        record: node_disk_read_time_ms
+      - expr: node_disk_writes_completed_total
+        record: node_disk_writes_completed
+      - expr: node_disk_writes_merged_total
+        record: node_disk_writes_merged
+      - expr: node_disk_write_time_seconds_total * 1000
+        record: node_disk_write_time_ms
+  - name: node_exporter-16-filesystem
+    rules:
+      - expr: node_filesystem_free_bytes
+        record: node_filesystem_free
+      - expr: node_filesystem_avail_bytes
+        record: node_filesystem_avail
+      - expr: node_filesystem_size_bytes
+        record: node_filesystem_size
+  - name: node_exporter-16-infiniband
+    rules:
+      - expr: node_infiniband_port_data_received_bytes_total
+        record: node_infiniband_port_data_received_bytes
+      - expr: node_infiniband_port_data_transmitted_bytes_total
+        record: node_infiniband_port_data_transmitted_bytes
+  - name: node_exporter-16-interrupts
+    rules:
+      - expr: node_interrupts_total
+        record: node_interrupts
+  - name: node_exporter-16-memory
+    rules:
+      - expr: node_memory_Active_bytes
+        record: node_memory_Active
+      - expr: node_memory_Active_anon_bytes
+        record: node_memory_Active_anon
+      - expr: node_memory_Active_file_bytes
+        record: node_memory_Active_file
+      - expr: node_memory_AnonHugePages_bytes
+        record: node_memory_AnonHugePages
+      - expr: node_memory_AnonPages_bytes
+        record: node_memory_AnonPages
+      - expr: node_memory_Bounce_bytes
+        record: node_memory_Bounce
+      - expr: node_memory_Buffers_bytes
+        record: node_memory_Buffers
+      - expr: node_memory_Cached_bytes
+        record: node_memory_Cached
+      - expr: node_memory_CommitLimit_bytes
+        record: node_memory_CommitLimit
+      - expr: node_memory_Committed_AS_bytes
+        record: node_memory_Committed_AS
+      - expr: node_memory_DirectMap2M_bytes
+        record: node_memory_DirectMap2M
+      - expr: node_memory_DirectMap4k_bytes
+        record: node_memory_DirectMap4k
+      - expr: node_memory_Dirty_bytes
+        record: node_memory_Dirty
+      - expr: node_memory_HardwareCorrupted_bytes
+        record: node_memory_HardwareCorrupted
+      - expr: node_memory_Hugepagesize_bytes
+        record: node_memory_Hugepagesize
+      - expr: node_memory_Inactive_bytes
+        record: node_memory_Inactive
+      - expr: node_memory_Inactive_anon_bytes
+        record: node_memory_Inactive_anon
+      - expr: node_memory_Inactive_file_bytes
+        record: node_memory_Inactive_file
+      - expr: node_memory_KernelStack_bytes
+        record: node_memory_KernelStack
+      - expr: node_memory_Mapped_bytes
+        record: node_memory_Mapped
+      - expr: node_memory_MemAvailable_bytes
+        record: node_memory_MemAvailable
+      - expr: node_memory_MemFree_bytes
+        record: node_memory_MemFree
+      - expr: node_memory_MemTotal_bytes
+        record: node_memory_MemTotal
+      - expr: node_memory_Mlocked_bytes
+        record: node_memory_Mlocked
+      - expr: node_memory_NFS_Unstable_bytes
+        record: node_memory_NFS_Unstable
+      - expr: node_memory_PageTables_bytes
+        record: node_memory_PageTables
+      - expr: node_memory_Shmem_bytes
+        record: node_memory_Shmem
+      - expr: node_memory_ShmemHugePages_bytes
+        record: node_memory_ShmemHugePages
+      - expr: node_memory_ShmemPmdMapped_bytes
+        record: node_memory_ShmemPmdMapped
+      - expr: node_memory_Slab_bytes
+        record: node_memory_Slab
+      - expr: node_memory_SReclaimable_bytes
+        record: node_memory_SReclaimable
+      - expr: node_memory_SUnreclaim_bytes
+        record: node_memory_SUnreclaim
+      - expr: node_memory_SwapCached_bytes
+        record: node_memory_SwapCached
+      - expr: node_memory_SwapFree_bytes
+        record: node_memory_SwapFree
+      - expr: node_memory_SwapTotal_bytes
+        record: node_memory_SwapTotal
+      - expr: node_memory_Unevictable_bytes
+        record: node_memory_Unevictable
+      - expr: node_memory_VmallocChunk_bytes
+        record: node_memory_VmallocChunk
+      - expr: node_memory_VmallocTotal_bytes
+        record: node_memory_VmallocTotal
+      - expr: node_memory_VmallocUsed_bytes
+        record: node_memory_VmallocUsed
+      - expr: node_memory_Writeback_bytes
+        record: node_memory_Writeback
+      - expr: node_memory_WritebackTmp_bytes
+        record: node_memory_WritebackTmp
+  - name: node_exporter-16-network
+    rules:
+      - expr: node_network_receive_bytes_total
+        record: node_network_receive_bytes
+      - expr: node_network_receive_compressed_total
+        record: node_network_receive_compressed
+      - expr: node_network_receive_drop_total
+        record: node_network_receive_drop
+      - expr: node_network_receive_errs_total
+        record: node_network_receive_errs
+      - expr: node_network_receive_fifo_total
+        record: node_network_receive_fifo
+      - expr: node_network_receive_frame_total
+        record: node_network_receive_frame
+      - expr: node_network_receive_multicast_total
+        record: node_network_receive_multicast
+      - expr: node_network_receive_packets_total
+        record: node_network_receive_packets
+      - expr: node_network_transmit_bytes_total
+        record: node_network_transmit_bytes
+      - expr: node_network_transmit_compressed_total
+        record: node_network_transmit_compressed
+      - expr: node_network_transmit_drop_total
+        record: node_network_transmit_drop
+      - expr: node_network_transmit_errs_total
+        record: node_network_transmit_errs
+      - expr: node_network_transmit_fifo_total
+        record: node_network_transmit_fifo
+      - expr: node_network_transmit_frame_total
+        record: node_network_transmit_frame
+      - expr: node_network_transmit_multicast_total
+        record: node_network_transmit_multicast
+      - expr: node_network_transmit_packets_total
+        record: node_network_transmit_packets
+  - name: node_exporter-16-nfs
+    rules:
+      - expr: node_nfs_connections_total
+        record: node_nfs_net_connections
+      - expr: node_nfs_packets_total
+        record: node_nfs_net_reads
+      - expr: label_replace(label_replace(node_nfs_requests_total, "proto", "$1", "version", "(.+)"), "method", "$1", "procedure", "(.+)")
+        record: node_nfs_procedures
+      - expr: node_nfs_rpc_authentication_refreshes_total
+        record: node_nfs_rpc_authentication_refreshes
+      - expr: node_nfs_rpcs_total
+        record: node_nfs_rpc_operations
+      - expr: node_nfs_rpc_retransmissions_total
+        record: node_nfs_rpc_retransmissions
+  - name: node_exporter-16-textfile
+    rules:
+      - expr: node_textfile_mtime_seconds
+        record: node_textfile_mtime

--- a/docs/example-16-compatibility-rules.yml
+++ b/docs/example-16-compatibility-rules.yml
@@ -1,201 +1,201 @@
 groups:
-- name: node_exporter-16-bcache
-  rules:
-  - record: node_bcache_cache_read_races
-    expr: node_bcache_cache_read_races_total
-- name: node_exporter-16-buddyinfo
-  rules:
-  - record: node_buddyinfo_blocks
-    expr: node_buddyinfo_count
-- name: node_exporter-16-stat
-  rules:
-  - record: node_boot_time_seconds
-    expr: node_boot_time
-  - record: node_time_seconds
-    expr: node_time
-  - record: node_context_switches_total
-    expr: node_context_switches
-  - record: node_forks_total
-    expr: node_forks
-  - record: node_intr_total
-    expr: node_intr
-- name: node_exporter-16-cpu
-  rules:
-  - record: node_cpu_seconds_total
-    expr: label_replace(node_cpu, "cpu", "$1", "cpu", "cpu(.+)")
-- name: node_exporter-16-diskstats
-  rules:
-  - record: node_disk_read_bytes_total
-    expr: node_disk_bytes_read
-  - record: node_disk_written_bytes_total
-    expr: node_disk_bytes_written
-  - record: node_disk_io_time_seconds_total
-    expr: node_disk_io_time_ms / 1000
-  - record: node_disk_io_time_weighted_seconds_total
-    expr: node_disk_io_time_weighted
-  - record: node_disk_reads_completed_total
-    expr: node_disk_reads_completed
-  - record: node_disk_reads_merged_total
-    expr: node_disk_reads_merged
-  - record: node_disk_read_time_seconds_total
-    expr: node_disk_read_time_ms / 1000
-  - record: node_disk_writes_completed_total
-    expr: node_disk_writes_completed
-  - record: node_disk_writes_merged_total
-    expr: node_disk_writes_merged
-  - record: node_disk_write_time_seconds_total
-    expr: node_disk_write_time_ms / 1000
-- name: node_exporter-16-filesystem
-  rules:
-  - record: node_filesystem_free_bytes
-    expr: node_filesystem_free
-  - record: node_filesystem_avail_bytes
-    expr: node_filesystem_avail
-  - record: node_filesystem_size_bytes
-    expr: node_filesystem_size
-- name: node_exporter-16-infiniband
-  rules:
-  - record: node_infiniband_port_data_received_bytes_total
-    expr: node_infiniband_port_data_received_bytes
-  - record: node_infiniband_port_data_transmitted_bytes_total
-    expr: node_infiniband_port_data_transmitted_bytes
-- name: node_exporter-16-interrupts
-  rules:
-  - record: node_interrupts_total
-    expr: node_interrupts
-- name: node_exporter-16-memory
-  rules:
-  - record: node_memory_Active_bytes
-    expr: node_memory_Active
-  - record: node_memory_Active_anon_bytes
-    expr: node_memory_Active_anon
-  - record: node_memory_Active_file_bytes
-    expr: node_memory_Active_file
-  - record: node_memory_AnonHugePages_bytes
-    expr: node_memory_AnonHugePages
-  - record: node_memory_AnonPages_bytes
-    expr: node_memory_AnonPages
-  - record: node_memory_Bounce_bytes
-    expr: node_memory_Bounce
-  - record: node_memory_Buffers_bytes
-    expr: node_memory_Buffers
-  - record: node_memory_Cached_bytes
-    expr: node_memory_Cached
-  - record: node_memory_CommitLimit_bytes
-    expr: node_memory_CommitLimit
-  - record: node_memory_Committed_AS_bytes
-    expr: node_memory_Committed_AS
-  - record: node_memory_DirectMap2M_bytes
-    expr: node_memory_DirectMap2M
-  - record: node_memory_DirectMap4k_bytes
-    expr: node_memory_DirectMap4k
-  - record: node_memory_Dirty_bytes
-    expr: node_memory_Dirty
-  - record: node_memory_HardwareCorrupted_bytes
-    expr: node_memory_HardwareCorrupted
-  - record: node_memory_Hugepagesize_bytes
-    expr: node_memory_Hugepagesize
-  - record: node_memory_Inactive_bytes
-    expr: node_memory_Inactive
-  - record: node_memory_Inactive_anon_bytes
-    expr: node_memory_Inactive_anon
-  - record: node_memory_Inactive_file_bytes
-    expr: node_memory_Inactive_file
-  - record: node_memory_KernelStack_bytes
-    expr: node_memory_KernelStack
-  - record: node_memory_Mapped_bytes
-    expr: node_memory_Mapped
-  - record: node_memory_MemAvailable_bytes
-    expr: node_memory_MemAvailable
-  - record: node_memory_MemFree_bytes
-    expr: node_memory_MemFree
-  - record: node_memory_MemTotal_bytes
-    expr: node_memory_MemTotal
-  - record: node_memory_Mlocked_bytes
-    expr: node_memory_Mlocked
-  - record: node_memory_NFS_Unstable_bytes
-    expr: node_memory_NFS_Unstable
-  - record: node_memory_PageTables_bytes
-    expr: node_memory_PageTables
-  - record: node_memory_Shmem_bytes
-    expr: node_memory_Shmem
-  - record: node_memory_ShmemHugePages_bytes
-    expr: node_memory_ShmemHugePages
-  - record: node_memory_ShmemPmdMapped_bytes
-    expr: node_memory_ShmemPmdMapped
-  - record: node_memory_Slab_bytes
-    expr: node_memory_Slab
-  - record: node_memory_SReclaimable_bytes
-    expr: node_memory_SReclaimable
-  - record: node_memory_SUnreclaim_bytes
-    expr: node_memory_SUnreclaim
-  - record: node_memory_SwapCached_bytes
-    expr: node_memory_SwapCached
-  - record: node_memory_SwapFree_bytes
-    expr: node_memory_SwapFree
-  - record: node_memory_SwapTotal_bytes
-    expr: node_memory_SwapTotal
-  - record: node_memory_Unevictable_bytes
-    expr: node_memory_Unevictable
-  - record: node_memory_VmallocChunk_bytes
-    expr: node_memory_VmallocChunk
-  - record: node_memory_VmallocTotal_bytes
-    expr: node_memory_VmallocTotal
-  - record: node_memory_VmallocUsed_bytes
-    expr: node_memory_VmallocUsed
-  - record: node_memory_Writeback_bytes
-    expr: node_memory_Writeback
-  - record: node_memory_WritebackTmp_bytes
-    expr: node_memory_WritebackTmp
-- name: node_exporter-16-network
-  rules:
-  - record: node_network_receive_bytes_total
-    expr: node_network_receive_bytes
-  - record: node_network_receive_compressed_total
-    expr: node_network_receive_compressed
-  - record: node_network_receive_drop_total
-    expr: node_network_receive_drop
-  - record: node_network_receive_errs_total
-    expr: node_network_receive_errs
-  - record: node_network_receive_fifo_total
-    expr: node_network_receive_fifo
-  - record: node_network_receive_frame_total
-    expr: node_network_receive_frame
-  - record: node_network_receive_multicast_total
-    expr: node_network_receive_multicast
-  - record: node_network_receive_packets_total
-    expr: node_network_receive_packets
-  - record: node_network_transmit_bytes_total
-    expr: node_network_transmit_bytes
-  - record: node_network_transmit_compressed_total
-    expr: node_network_transmit_compressed
-  - record: node_network_transmit_drop_total
-    expr: node_network_transmit_drop
-  - record: node_network_transmit_errs_total
-    expr: node_network_transmit_errs
-  - record: node_network_transmit_fifo_total
-    expr: node_network_transmit_fifo
-  - record: node_network_transmit_frame_total
-    expr: node_network_transmit_frame
-  - record: node_network_transmit_multicast_total
-    expr: node_network_transmit_multicast
-  - record: node_network_transmit_packets_total
-    expr: node_network_transmit_packets
-- name: node_exporter-16-nfs
-  rules:
-  - record: node_nfs_connections_total
-    expr: node_nfs_net_connections
-  - record: node_nfs_packets_total
-    expr: node_nfs_net_reads
-  - record: node_nfs_requests_total
-    expr: label_replace(label_replace(node_nfs_procedures, "proto", "$1", "version", "(.+)"), "method", "$1", "procedure", "(.+)")
-  - record: node_nfs_rpc_authentication_refreshes_total
-    expr: node_nfs_rpc_authentication_refreshes
-  - record: node_nfs_rpcs_total
-    expr: node_nfs_rpc_operations
-  - record: node_nfs_rpc_retransmissions_total
-    expr: node_nfs_rpc_retransmissions
-- name: node_exporter-16-textfile
-  rules:
-  - record: node_textfile_mtime_seconds
-    expr: node_textfile_mtime
+  - name: node_exporter-16-bcache
+    rules:
+      - record: node_bcache_cache_read_races
+        expr: node_bcache_cache_read_races_total
+  - name: node_exporter-16-buddyinfo
+    rules:
+      - record: node_buddyinfo_blocks
+        expr: node_buddyinfo_count
+  - name: node_exporter-16-stat
+    rules:
+      - record: node_boot_time_seconds
+        expr: node_boot_time
+      - record: node_time_seconds
+        expr: node_time
+      - record: node_context_switches_total
+        expr: node_context_switches
+      - record: node_forks_total
+        expr: node_forks
+      - record: node_intr_total
+        expr: node_intr
+  - name: node_exporter-16-cpu
+    rules:
+      - record: node_cpu_seconds_total
+        expr: label_replace(node_cpu, "cpu", "$1", "cpu", "cpu(.+)")
+  - name: node_exporter-16-diskstats
+    rules:
+      - record: node_disk_read_bytes_total
+        expr: node_disk_bytes_read
+      - record: node_disk_written_bytes_total
+        expr: node_disk_bytes_written
+      - record: node_disk_io_time_seconds_total
+        expr: node_disk_io_time_ms / 1000
+      - record: node_disk_io_time_weighted_seconds_total
+        expr: node_disk_io_time_weighted
+      - record: node_disk_reads_completed_total
+        expr: node_disk_reads_completed
+      - record: node_disk_reads_merged_total
+        expr: node_disk_reads_merged
+      - record: node_disk_read_time_seconds_total
+        expr: node_disk_read_time_ms / 1000
+      - record: node_disk_writes_completed_total
+        expr: node_disk_writes_completed
+      - record: node_disk_writes_merged_total
+        expr: node_disk_writes_merged
+      - record: node_disk_write_time_seconds_total
+        expr: node_disk_write_time_ms / 1000
+  - name: node_exporter-16-filesystem
+    rules:
+      - record: node_filesystem_free_bytes
+        expr: node_filesystem_free
+      - record: node_filesystem_avail_bytes
+        expr: node_filesystem_avail
+      - record: node_filesystem_size_bytes
+        expr: node_filesystem_size
+  - name: node_exporter-16-infiniband
+    rules:
+      - record: node_infiniband_port_data_received_bytes_total
+        expr: node_infiniband_port_data_received_bytes
+      - record: node_infiniband_port_data_transmitted_bytes_total
+        expr: node_infiniband_port_data_transmitted_bytes
+  - name: node_exporter-16-interrupts
+    rules:
+      - record: node_interrupts_total
+        expr: node_interrupts
+  - name: node_exporter-16-memory
+    rules:
+      - record: node_memory_Active_bytes
+        expr: node_memory_Active
+      - record: node_memory_Active_anon_bytes
+        expr: node_memory_Active_anon
+      - record: node_memory_Active_file_bytes
+        expr: node_memory_Active_file
+      - record: node_memory_AnonHugePages_bytes
+        expr: node_memory_AnonHugePages
+      - record: node_memory_AnonPages_bytes
+        expr: node_memory_AnonPages
+      - record: node_memory_Bounce_bytes
+        expr: node_memory_Bounce
+      - record: node_memory_Buffers_bytes
+        expr: node_memory_Buffers
+      - record: node_memory_Cached_bytes
+        expr: node_memory_Cached
+      - record: node_memory_CommitLimit_bytes
+        expr: node_memory_CommitLimit
+      - record: node_memory_Committed_AS_bytes
+        expr: node_memory_Committed_AS
+      - record: node_memory_DirectMap2M_bytes
+        expr: node_memory_DirectMap2M
+      - record: node_memory_DirectMap4k_bytes
+        expr: node_memory_DirectMap4k
+      - record: node_memory_Dirty_bytes
+        expr: node_memory_Dirty
+      - record: node_memory_HardwareCorrupted_bytes
+        expr: node_memory_HardwareCorrupted
+      - record: node_memory_Hugepagesize_bytes
+        expr: node_memory_Hugepagesize
+      - record: node_memory_Inactive_bytes
+        expr: node_memory_Inactive
+      - record: node_memory_Inactive_anon_bytes
+        expr: node_memory_Inactive_anon
+      - record: node_memory_Inactive_file_bytes
+        expr: node_memory_Inactive_file
+      - record: node_memory_KernelStack_bytes
+        expr: node_memory_KernelStack
+      - record: node_memory_Mapped_bytes
+        expr: node_memory_Mapped
+      - record: node_memory_MemAvailable_bytes
+        expr: node_memory_MemAvailable
+      - record: node_memory_MemFree_bytes
+        expr: node_memory_MemFree
+      - record: node_memory_MemTotal_bytes
+        expr: node_memory_MemTotal
+      - record: node_memory_Mlocked_bytes
+        expr: node_memory_Mlocked
+      - record: node_memory_NFS_Unstable_bytes
+        expr: node_memory_NFS_Unstable
+      - record: node_memory_PageTables_bytes
+        expr: node_memory_PageTables
+      - record: node_memory_Shmem_bytes
+        expr: node_memory_Shmem
+      - record: node_memory_ShmemHugePages_bytes
+        expr: node_memory_ShmemHugePages
+      - record: node_memory_ShmemPmdMapped_bytes
+        expr: node_memory_ShmemPmdMapped
+      - record: node_memory_Slab_bytes
+        expr: node_memory_Slab
+      - record: node_memory_SReclaimable_bytes
+        expr: node_memory_SReclaimable
+      - record: node_memory_SUnreclaim_bytes
+        expr: node_memory_SUnreclaim
+      - record: node_memory_SwapCached_bytes
+        expr: node_memory_SwapCached
+      - record: node_memory_SwapFree_bytes
+        expr: node_memory_SwapFree
+      - record: node_memory_SwapTotal_bytes
+        expr: node_memory_SwapTotal
+      - record: node_memory_Unevictable_bytes
+        expr: node_memory_Unevictable
+      - record: node_memory_VmallocChunk_bytes
+        expr: node_memory_VmallocChunk
+      - record: node_memory_VmallocTotal_bytes
+        expr: node_memory_VmallocTotal
+      - record: node_memory_VmallocUsed_bytes
+        expr: node_memory_VmallocUsed
+      - record: node_memory_Writeback_bytes
+        expr: node_memory_Writeback
+      - record: node_memory_WritebackTmp_bytes
+        expr: node_memory_WritebackTmp
+  - name: node_exporter-16-network
+    rules:
+      - record: node_network_receive_bytes_total
+        expr: node_network_receive_bytes
+      - record: node_network_receive_compressed_total
+        expr: node_network_receive_compressed
+      - record: node_network_receive_drop_total
+        expr: node_network_receive_drop
+      - record: node_network_receive_errs_total
+        expr: node_network_receive_errs
+      - record: node_network_receive_fifo_total
+        expr: node_network_receive_fifo
+      - record: node_network_receive_frame_total
+        expr: node_network_receive_frame
+      - record: node_network_receive_multicast_total
+        expr: node_network_receive_multicast
+      - record: node_network_receive_packets_total
+        expr: node_network_receive_packets
+      - record: node_network_transmit_bytes_total
+        expr: node_network_transmit_bytes
+      - record: node_network_transmit_compressed_total
+        expr: node_network_transmit_compressed
+      - record: node_network_transmit_drop_total
+        expr: node_network_transmit_drop
+      - record: node_network_transmit_errs_total
+        expr: node_network_transmit_errs
+      - record: node_network_transmit_fifo_total
+        expr: node_network_transmit_fifo
+      - record: node_network_transmit_frame_total
+        expr: node_network_transmit_frame
+      - record: node_network_transmit_multicast_total
+        expr: node_network_transmit_multicast
+      - record: node_network_transmit_packets_total
+        expr: node_network_transmit_packets
+  - name: node_exporter-16-nfs
+    rules:
+      - record: node_nfs_connections_total
+        expr: node_nfs_net_connections
+      - record: node_nfs_packets_total
+        expr: node_nfs_net_reads
+      - record: node_nfs_requests_total
+        expr: label_replace(label_replace(node_nfs_procedures, "proto", "$1", "version", "(.+)"), "method", "$1", "procedure", "(.+)")
+      - record: node_nfs_rpc_authentication_refreshes_total
+        expr: node_nfs_rpc_authentication_refreshes
+      - record: node_nfs_rpcs_total
+        expr: node_nfs_rpc_operations
+      - record: node_nfs_rpc_retransmissions_total
+        expr: node_nfs_rpc_retransmissions
+  - name: node_exporter-16-textfile
+    rules:
+      - record: node_textfile_mtime_seconds
+        expr: node_textfile_mtime

--- a/docs/example-17-compatibility-rules-new-to-old.yml
+++ b/docs/example-17-compatibility-rules-new-to-old.yml
@@ -1,5 +1,5 @@
 groups:
-- name: node_exporter-17-supervisord
-  rules:
-  - record: node_supervisord_start_time_seconds
-    expr: node_supervisord_uptime + time()
+  - name: node_exporter-17-supervisord
+    rules:
+      - record: node_supervisord_start_time_seconds
+        expr: node_supervisord_uptime + time()

--- a/docs/example-17-compatibility-rules.yml
+++ b/docs/example-17-compatibility-rules.yml
@@ -1,5 +1,5 @@
 groups:
-- name: node_exporter-17-supervisord
-  rules:
-  - record: node_supervisord_uptime
-    expr: time() - node_supervisord_start_time_seconds
+  - name: node_exporter-17-supervisord
+    rules:
+      - record: node_supervisord_uptime
+        expr: time() - node_supervisord_start_time_seconds

--- a/example-rules.yml
+++ b/example-rules.yml
@@ -1,18 +1,18 @@
 groups:
-- name: example-node-exporter-rules
-  rules:
-  # The count of CPUs per node, useful for getting CPU time as a percent of total.
-  - record: instance:node_cpus:count
-    expr: count(node_cpu_seconds_total{mode="idle"}) without (cpu,mode)
+  - name: example-node-exporter-rules
+    rules:
+      # The count of CPUs per node, useful for getting CPU time as a percent of total.
+      - record: instance:node_cpus:count
+        expr: count(node_cpu_seconds_total{mode="idle"}) without (cpu,mode)
 
-  # CPU in use by CPU.
-  - record: instance_cpu:node_cpu_seconds_not_idle:rate5m
-    expr: sum(rate(node_cpu_seconds_total{mode!="idle"}[5m])) without (mode)
+      # CPU in use by CPU.
+      - record: instance_cpu:node_cpu_seconds_not_idle:rate5m
+        expr: sum(rate(node_cpu_seconds_total{mode!="idle"}[5m])) without (mode)
 
-  # CPU in use by mode.
-  - record: instance_mode:node_cpu_seconds:rate5m
-    expr: sum(rate(node_cpu_seconds_total[5m])) without (cpu)
+      # CPU in use by mode.
+      - record: instance_mode:node_cpu_seconds:rate5m
+        expr: sum(rate(node_cpu_seconds_total[5m])) without (cpu)
 
-  # CPU in use ratio.
-  - record: instance:node_cpu_utilization:ratio
-    expr: sum(instance_mode:node_cpu_seconds:rate5m{mode!="idle"}) without (mode) / instance:node_cpus:count
+      # CPU in use ratio.
+      - record: instance:node_cpu_utilization:ratio
+        expr: sum(instance_mode:node_cpu_seconds:rate5m{mode!="idle"}) without (mode) / instance:node_cpus:count


### PR DESCRIPTION
After a recent change in prometheus/prometheus, Makefile.common includes
now a yamllint target which currently fails. This PR adds the missing
yamllint config and fixes the yamllint errors.

Fixes: https://github.com/prometheus/node_exporter/issues/2087

Signed-off-by: Michal Wasilewski <mwasilewski@gmx.com>