### PR TITLE
nvme: workaround for error handling when /sys/class/nvme does not exist.

### DIFF
--- a/collector/nvme_linux.go
+++ b/collector/nvme_linux.go
@@ -17,9 +17,8 @@
 package collector
 
 import (
-	"errors"
 	"fmt"
-	"os"
+	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -52,7 +51,8 @@ func NewNVMeCollector(logger log.Logger) (Collector, error) {
 func (c *nvmeCollector) Update(ch chan<- prometheus.Metric) error {
 	devices, err := c.fs.NVMeClass()
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if strings.Contains(err.Error(),
+			"/sys/class/nvme: no such file or directory") {
 			level.Debug(c.logger).Log("msg", "nvme statistics not found, skipping")
 			return ErrNoData
 		}


### PR DESCRIPTION
@discordianfish this is not the most elegant solution, but do a workaround of the problem for the same functionality.

Fixes #2086

Error type is not matching `os.ErrNotExist` if error is "no such file or directory",
which is a common case if a system does not have a NVME device.

Signed-off-by: Mario Trangoni <mjtrangoni@gmail.com>