### PR TITLE
docs/node-mixin/alerts: make NodeFilesystemAlmostOutOfSpace fire earlier

### DIFF
--- a/docs/node-mixin/alerts/alerts.libsonnet
+++ b/docs/node-mixin/alerts/alerts.libsonnet
@@ -53,7 +53,7 @@
                 node_filesystem_readonly{%(nodeExporterSelector)s,%(fsSelector)s} == 0
               )
             ||| % $._config,
-            'for': '1h',
+            'for': '30m',
             labels: {
               severity: 'warning',
             },
@@ -71,7 +71,7 @@
                 node_filesystem_readonly{%(nodeExporterSelector)s,%(fsSelector)s} == 0
               )
             ||| % $._config,
-            'for': '1h',
+            'for': '30m',
             labels: {
               severity: '%(nodeCriticalSeverity)s' % $._config,
             },


### PR DESCRIPTION
In our tests in OpenShift it looks like 1h is too long to prevent catastrophic failures.