### PR TITLE
Add support for labels from ifAlias for network metrics

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -92,7 +92,7 @@ func DisableDefaultCollectors() {
 	}
 }
 
-func EnableNetworkLabelsFromDescr() {
+func EnableNetworkLabelsFromIfAlias() {
 	labelsFromIfAlias = true
 }
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -55,6 +55,7 @@ var (
 	initiatedCollectors    = make(map[string]Collector)
 	collectorState         = make(map[string]*bool)
 	forcedCollectors       = map[string]bool{} // collectors which have been explicitly enabled or disabled
+	labelsFromIfAlias      bool
 )
 
 func registerCollector(collector string, isDefaultEnabled bool, factory func(logger log.Logger) (Collector, error)) {
@@ -89,6 +90,10 @@ func DisableDefaultCollectors() {
 			*collectorState[c] = false
 		}
 	}
+}
+
+func EnableNetworkLabelsFromDescr() {
+	labelsFromIfAlias = true
 }
 
 // collectorFlagAction generates a new action function for the given collector

--- a/collector/ethtool_linux_test.go
+++ b/collector/ethtool_linux_test.go
@@ -83,17 +83,17 @@ func NewEthtoolTestCollector(logger log.Logger) (Collector, error) {
 
 func TestEthtoolCollector(t *testing.T) {
 	testcases := []string{
-		prometheus.NewDesc("node_ethtool_align_errors", "Network interface align_errors", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_received_broadcast", "Network interface rx_broadcast", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_received_errors_total", "Number of received frames with errors", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_received_missed", "Network interface rx_missed", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_received_multicast", "Network interface rx_multicast", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_received_packets_total", "Network interface packets received", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_received_unicast", "Network interface rx_unicast", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_transmitted_aborted", "Network interface tx_aborted", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_transmitted_errors_total", "Number of sent frames with errors", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_transmitted_multi_collisions", "Network interface tx_multi_collisions", []string{"device"}, nil).String(),
-		prometheus.NewDesc("node_ethtool_transmitted_packets_total", "Network interface packets sent", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_align_errors_total", "Network interface align_errors", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_received_broadcast_total", "Network interface rx_broadcast", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_received_errors_total", "Network interface rx_errors", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_received_missed_total", "Network interface rx_missed", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_received_multicast_total", "Network interface rx_multicast", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_received_packets_total", "Network interface rx_packets", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_received_unicast_total", "Network interface rx_unicast", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_transmitted_aborted_total", "Network interface tx_aborted", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_transmitted_errors_total", "Network interface tx_errors", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_transmitted_multi_collisions_total", "Network interface tx_multi_collisions", []string{"device"}, nil).String(),
+		prometheus.NewDesc("node_ethtool_transmitted_packets_total", "Network interface tx_packets", []string{"device"}, nil).String(),
 	}
 
 	*sysPath = "fixtures/sys"

--- a/collector/netclass_linux.go
+++ b/collector/netclass_linux.go
@@ -72,10 +72,14 @@ func (c *netClassCollector) Update(ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("could not get net class info: %w", err)
 	}
 	for _, ifaceInfo := range netClass {
+		labels := getLabelsFromIfAlias(ifaceInfo.Name)
+		labelKeys := append([]string{"device"}, labels.keys()...)
+		labelValues := append([]string{ifaceInfo.Name}, labels.values()...)
+
 		upDesc := prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, c.subsystem, "up"),
 			"Value is 1 if operstate is 'up', 0 otherwise.",
-			[]string{"device"},
+			labelKeys,
 			nil,
 		)
 		upValue := 0.0
@@ -83,103 +87,103 @@ func (c *netClassCollector) Update(ch chan<- prometheus.Metric) error {
 			upValue = 1.0
 		}
 
-		ch <- prometheus.MustNewConstMetric(upDesc, prometheus.GaugeValue, upValue, ifaceInfo.Name)
+		ch <- prometheus.MustNewConstMetric(upDesc, prometheus.GaugeValue, upValue, labelValues...)
 
 		infoDesc := prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, c.subsystem, "info"),
 			"Non-numeric data from /sys/class/net/<iface>, value is always 1.",
-			[]string{"device", "address", "broadcast", "duplex", "operstate", "ifalias"},
+			append([]string{"device", "address", "broadcast", "duplex", "operstate", "ifalias"}, labels.keys()...),
 			nil,
 		)
 		infoValue := 1.0
 
-		ch <- prometheus.MustNewConstMetric(infoDesc, prometheus.GaugeValue, infoValue, ifaceInfo.Name, ifaceInfo.Address, ifaceInfo.Broadcast, ifaceInfo.Duplex, ifaceInfo.OperState, ifaceInfo.IfAlias)
+		ch <- prometheus.MustNewConstMetric(infoDesc, prometheus.GaugeValue, infoValue, append([]string{ifaceInfo.Name, ifaceInfo.Address, ifaceInfo.Broadcast, ifaceInfo.Duplex, ifaceInfo.OperState, ifaceInfo.IfAlias}, labels.values()...)...)
 
 		if ifaceInfo.AddrAssignType != nil {
-			pushMetric(ch, c.subsystem, "address_assign_type", *ifaceInfo.AddrAssignType, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "address_assign_type", *ifaceInfo.AddrAssignType, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.Carrier != nil {
-			pushMetric(ch, c.subsystem, "carrier", *ifaceInfo.Carrier, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "carrier", *ifaceInfo.Carrier, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.CarrierChanges != nil {
-			pushMetric(ch, c.subsystem, "carrier_changes_total", *ifaceInfo.CarrierChanges, ifaceInfo.Name, prometheus.CounterValue)
+			pushMetric(ch, c.subsystem, "carrier_changes_total", *ifaceInfo.CarrierChanges, labelKeys, labelValues, prometheus.CounterValue)
 		}
 
 		if ifaceInfo.CarrierUpCount != nil {
-			pushMetric(ch, c.subsystem, "carrier_up_changes_total", *ifaceInfo.CarrierUpCount, ifaceInfo.Name, prometheus.CounterValue)
+			pushMetric(ch, c.subsystem, "carrier_up_changes_total", *ifaceInfo.CarrierUpCount, labelKeys, labelValues, prometheus.CounterValue)
 		}
 
 		if ifaceInfo.CarrierDownCount != nil {
-			pushMetric(ch, c.subsystem, "carrier_down_changes_total", *ifaceInfo.CarrierDownCount, ifaceInfo.Name, prometheus.CounterValue)
+			pushMetric(ch, c.subsystem, "carrier_down_changes_total", *ifaceInfo.CarrierDownCount, labelKeys, labelValues, prometheus.CounterValue)
 		}
 
 		if ifaceInfo.DevID != nil {
-			pushMetric(ch, c.subsystem, "device_id", *ifaceInfo.DevID, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "device_id", *ifaceInfo.DevID, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.Dormant != nil {
-			pushMetric(ch, c.subsystem, "dormant", *ifaceInfo.Dormant, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "dormant", *ifaceInfo.Dormant, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.Flags != nil {
-			pushMetric(ch, c.subsystem, "flags", *ifaceInfo.Flags, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "flags", *ifaceInfo.Flags, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.IfIndex != nil {
-			pushMetric(ch, c.subsystem, "iface_id", *ifaceInfo.IfIndex, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "iface_id", *ifaceInfo.IfIndex, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.IfLink != nil {
-			pushMetric(ch, c.subsystem, "iface_link", *ifaceInfo.IfLink, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "iface_link", *ifaceInfo.IfLink, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.LinkMode != nil {
-			pushMetric(ch, c.subsystem, "iface_link_mode", *ifaceInfo.LinkMode, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "iface_link_mode", *ifaceInfo.LinkMode, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.MTU != nil {
-			pushMetric(ch, c.subsystem, "mtu_bytes", *ifaceInfo.MTU, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "mtu_bytes", *ifaceInfo.MTU, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.NameAssignType != nil {
-			pushMetric(ch, c.subsystem, "name_assign_type", *ifaceInfo.NameAssignType, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "name_assign_type", *ifaceInfo.NameAssignType, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.NetDevGroup != nil {
-			pushMetric(ch, c.subsystem, "net_dev_group", *ifaceInfo.NetDevGroup, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "net_dev_group", *ifaceInfo.NetDevGroup, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.Speed != nil {
 			// Some devices return -1 if the speed is unknown.
 			if *ifaceInfo.Speed >= 0 || !*netclassInvalidSpeed {
 				speedBytes := int64(*ifaceInfo.Speed * 1000 * 1000 / 8)
-				pushMetric(ch, c.subsystem, "speed_bytes", speedBytes, ifaceInfo.Name, prometheus.GaugeValue)
+				pushMetric(ch, c.subsystem, "speed_bytes", speedBytes, labelKeys, labelValues, prometheus.GaugeValue)
 			}
 		}
 
 		if ifaceInfo.TxQueueLen != nil {
-			pushMetric(ch, c.subsystem, "transmit_queue_length", *ifaceInfo.TxQueueLen, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "transmit_queue_length", *ifaceInfo.TxQueueLen, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 
 		if ifaceInfo.Type != nil {
-			pushMetric(ch, c.subsystem, "protocol_type", *ifaceInfo.Type, ifaceInfo.Name, prometheus.GaugeValue)
+			pushMetric(ch, c.subsystem, "protocol_type", *ifaceInfo.Type, labelKeys, labelValues, prometheus.GaugeValue)
 		}
 	}
 
 	return nil
 }
 
-func pushMetric(ch chan<- prometheus.Metric, subsystem string, name string, value int64, ifaceName string, valueType prometheus.ValueType) {
+func pushMetric(ch chan<- prometheus.Metric, subsystem string, name string, value int64, labelKeys []string, labelValues []string, valueType prometheus.ValueType) {
 	fieldDesc := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, subsystem, name),
 		fmt.Sprintf("%s value of /sys/class/net/<iface>.", name),
-		[]string{"device"},
+		labelKeys,
 		nil,
 	)
 
-	ch <- prometheus.MustNewConstMetric(fieldDesc, valueType, float64(value), ifaceName)
+	ch <- prometheus.MustNewConstMetric(fieldDesc, valueType, float64(value), labelValues...)
 }
 
 func (c *netClassCollector) getNetClassInfo() (sysfs.NetClass, error) {

--- a/collector/netdev_labels.go
+++ b/collector/netdev_labels.go
@@ -1,0 +1,67 @@
+package collector
+
+import (
+	"io/ioutil"
+	"runtime"
+	"strings"
+)
+
+type label struct {
+	key   string
+	value string
+}
+
+type labels []label
+
+func (l labels) keys() []string {
+	ret := make([]string, 0, len(l))
+
+	for _, la := range l {
+		ret = append(ret, la.key)
+	}
+
+	return ret
+}
+
+func (l labels) values() []string {
+	ret := make([]string, 0, len(l))
+
+	for _, la := range l {
+		ret = append(ret, la.value)
+	}
+
+	return ret
+}
+
+func getLabelsFromIfAlias(ifName string) labels {
+	if runtime.GOOS != "linux" {
+		return nil
+	}
+
+	if !labelsFromIfAlias {
+		return nil
+	}
+
+	ifAliasBytes, err := ioutil.ReadFile("/sys/class/net/" + ifName + "/ifalias")
+	if err != nil {
+		return nil
+	}
+
+	ifAlias := strings.TrimSpace(string(ifAliasBytes))
+	keyValueStrings := strings.Split(ifAlias, ",")
+	ret := make(labels, 0, len(keyValueStrings))
+
+	for _, kv := range keyValueStrings {
+		parts := strings.Split(kv, "=")
+		if len(parts) != 2 {
+			continue
+		}
+
+		ret = append(ret, label{
+			key:   parts[0],
+			value: parts[1],
+		})
+	}
+
+	return ret
+}

--- a/collector/netdev_labels.go
+++ b/collector/netdev_labels.go
@@ -1,3 +1,15 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package collector
 
 import (

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -185,7 +185,7 @@ func main() {
 	}
 
 	if *enableNetworkLabelsFromIfAlias {
-		collector.EnableNetworkLabelsFromDescr()
+		collector.EnableNetworkLabelsFromIfAlias()
 	}
 
 	level.Info(logger).Log("msg", "Starting node_exporter", "version", version.Info())

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -166,6 +166,10 @@ func main() {
 			"web.config",
 			"[EXPERIMENTAL] Path to config yaml file that can enable TLS or authentication.",
 		).Default("").String()
+		enableNetworkLabelsFromIfAlias = kingpin.Flag(
+			"net.labels-from-ifAlias",
+			"[EXPERIMENTAL] Enable network labels from ifAlias (Linux only)",
+		).Bool()
 	)
 
 	promlogConfig := &promlog.Config{}
@@ -179,6 +183,11 @@ func main() {
 	if *disableDefaultCollectors {
 		collector.DisableDefaultCollectors()
 	}
+
+	if *enableNetworkLabelsFromIfAlias {
+		collector.EnableNetworkLabelsFromDescr()
+	}
+
 	level.Info(logger).Log("msg", "Starting node_exporter", "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", "build_context", version.BuildContext())
 	if user, err := user.Current(); err == nil && user.Uid == "0" {


### PR DESCRIPTION
As proposed in my email on the ML (https://groups.google.com/g/prometheus-developers/c/fWjiEw-GL1g) I've implemented support for adding custom labels to network interface metrics. Having additional labels on interface metrics makes both silencing and querying a lot simpler when operating networks.

This is a follow up of #2059. As proposed by @SuperQ I'm taking the labels now from /sys/class/net/x/ifAlias.