### PR TITLE
Fix processes collector long int parsing

### DIFF
--- a/collector/processes_linux.go
+++ b/collector/processes_linux.go
@@ -105,7 +105,7 @@ func (c *processCollector) Update(ch chan<- prometheus.Metric) error {
 func (c *processCollector) getAllocatedThreads() (int, map[string]int32, int, error) {
 	p, err := c.fs.AllProcs()
 	if err != nil {
-		return 0, nil, 0, err
+		return 0, nil, 0, fmt.Errorf("unable to list all processes: %w", err)
 	}
 	pids := 0
 	thread := 0
@@ -118,8 +118,8 @@ func (c *processCollector) getAllocatedThreads() (int, map[string]int32, int, er
 				level.Debug(c.logger).Log("msg", "file not found when retrieving stats for pid", "pid", pid, "err", err)
 				continue
 			}
-			level.Debug(c.logger).Log("msg", "error reading stat for pid", "pid", pid, "err", err)
-			return 0, nil, 0, err
+			level.Debug(c.logger).Log("msg", "error reading stat for pid", "pid", pid.PID, "err", err)
+			return 0, nil, 0, fmt.Errorf("error reading stat for pid %d: %w", pid.PID, err)
 		}
 		pids++
 		procStates[stat.State]++

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.29.0
 	github.com/prometheus/exporter-toolkit v0.6.0
-	github.com/prometheus/procfs v0.7.1
+	github.com/prometheus/procfs v0.7.2
 	github.com/safchain/ethtool v0.0.0-20201023143004-874930cb3ce0
 	github.com/siebenmann/go-kstat v0.0.0-20210513183136-173c9b0a9973 // indirect
 	github.com/soundcloud/go-runit v0.0.0-20150630195641-06ad41a06c4a

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/prometheus/procfs v0.7.1 h1:TlEtJq5GvGqMykEwWzbZWjjztF86swFhsPix1i0bkgA=
-github.com/prometheus/procfs v0.7.1/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/prometheus/procfs v0.7.2 h1:zE6zJjRS9S916ptrZ326OU0++1XRwHgxkvCFflxx6Fo=
+github.com/prometheus/procfs v0.7.2/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/safchain/ethtool v0.0.0-20201023143004-874930cb3ce0 h1:eskphjc5kRCykOJyX7HHVbJCs25/8knprttvrVvEd8o=
 github.com/safchain/ethtool v0.0.0-20201023143004-874930cb3ce0/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=


### PR DESCRIPTION
Update procfs library to include ignored fields ParseInt handling.

Wrap error returns so that the user can know more about what failed.
Returns from getAllocatedThreads() are errors anyway.

Fixes: https://github.com/prometheus/node_exporter/issues/2110

Signed-off-by: Ben Kochie <superq@gmail.com>