### PR TITLE
Add flag to disable guest CPU metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * [ENHANCEMENT]
 * [BUGFIX]
 
+* [ENHANCEMENT] Add flag to disable guest CPU metrics #2123
+
 ## 1.2.2 / 2021-08-06
 
 * [BUGFIX] Fix processes collector long int parsing #2112


### PR DESCRIPTION
In high scale virtualized / cloud environments there are typically
no guest VMs. Add a boolean flag to allow disabling the Linux guest
CPU metrics.

Signed-off-by: Ben Kochie <superq@gmail.com>