### PR TITLE
Disable soon to deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,15 @@
 linters:
   enable:
   - golint
+  disable:
+    # Disable soon to deprecated[1] linters that lead to false
+    # positives when build tags disable certain files[2]
+    # 1: https://github.com/golangci/golangci-lint/issues/1841
+    # 2: https://github.com/prometheus/node_exporter/issues/1545
+  - deadcode
+  - unused
+  - structcheck
+  - varcheck
 
 issues:
   exclude-rules:


### PR DESCRIPTION
These lead to false positives when build tags disable certain files as
reported in https://github.com/prometheus/node_exporter/issues/1545

They'll get deprecated and removed eventually anyway:
https://github.com/golangci/golangci-lint/issues/1841