### PR TITLE
mixin: Add fallback for MemAvailable

### DIFF
--- a/docs/node-mixin/rules/rules.libsonnet
+++ b/docs/node-mixin/rules/rules.libsonnet
@@ -44,6 +44,16 @@
             expr: |||
               1 - (
                 node_memory_MemAvailable_bytes{%(nodeExporterSelector)s}
+                or
+                (
+                  node_memory_Buffers_bytes{%(nodeExporterSelector)s}
+                  +
+                  node_memory_Cached_bytes{%(nodeExporterSelector)s}
+                  +
+                  node_memory_MemFree_bytes{%(nodeExporterSelector)s}
+                  +
+                  node_memory_Slab_bytes{%(nodeExporterSelector)s}
+                )
               /
                 node_memory_MemTotal_bytes{%(nodeExporterSelector)s}
               )


### PR DESCRIPTION
Add a fallback to Buffers+Cached+MemFree+Slab for older Linux kernels
where the MemAvailable metric is not available for memory utilization.

Signed-off-by: Ben Kochie <superq@gmail.com>