### PR TITLE
mixin: Cheaper calculation for instance:node_num_cpu:sum

### DIFF
--- a/docs/node-mixin/rules/rules.libsonnet
+++ b/docs/node-mixin/rules/rules.libsonnet
@@ -9,9 +9,7 @@
             record: 'instance:node_num_cpu:sum',
             expr: |||
               count without (cpu) (
-                count without (mode) (
-                  node_cpu_seconds_total{%(nodeExporterSelector)s}
-                )
+                node_cpu_seconds_total{%(nodeExporterSelector)s,mode="idle"}
               )
             ||| % $._config,
           },


### PR DESCRIPTION
Looks like it's about 10x faster on large setups