### PR TITLE
bump perf-utils to v0.3.0

### DIFF
--- a/collector/perf_linux.go
+++ b/collector/perf_linux.go
@@ -284,26 +284,38 @@ func NewPerfCollector(logger log.Logger) (Collector, error) {
 	for _, cpu := range cpus {
 		// Use -1 to profile all processes on the CPU, see:
 		// man perf_event_open
-		hwProf := perf.NewHardwareProfiler(-1, cpu)
-		if err := hwProf.Start(); err != nil {
-			return nil, err
+		hwProf, err := perf.NewHardwareProfiler(-1, cpu)
+		if err != nil {
+			level.Error(logger).Log("msg", "Failed to create hardware profiler", "err", err)
+		} else {
+			if err := hwProf.Start(); err != nil {
+				return nil, err
+			}
+			collector.perfHwProfilers[cpu] = &hwProf
+			collector.hwProfilerCPUMap[&hwProf] = cpu
 		}
-		collector.perfHwProfilers[cpu] = &hwProf
-		collector.hwProfilerCPUMap[&hwProf] = cpu
 
-		swProf := perf.NewSoftwareProfiler(-1, cpu)
-		if err := swProf.Start(); err != nil {
-			return nil, err
+		swProf, err := perf.NewSoftwareProfiler(-1, cpu)
+		if err != nil {
+			level.Error(logger).Log("msg", "Failed to create software profiler", "err", err)
+		} else {
+			if err := swProf.Start(); err != nil {
+				return nil, err
+			}
+			collector.perfSwProfilers[cpu] = &swProf
+			collector.swProfilerCPUMap[&swProf] = cpu
 		}
-		collector.perfSwProfilers[cpu] = &swProf
-		collector.swProfilerCPUMap[&swProf] = cpu
 
-		cacheProf := perf.NewCacheProfiler(-1, cpu)
-		if err := cacheProf.Start(); err != nil {
-			return nil, err
+		cacheProf, err := perf.NewCacheProfiler(-1, cpu)
+		if err != nil {
+			level.Error(logger).Log("msg", "Failed to create cache profiler", "err", err)
+		} else {
+			if err := cacheProf.Start(); err != nil {
+				return nil, err
+			}
+			collector.perfCacheProfilers[cpu] = &cacheProf
+			collector.cacheProfilerCPUMap[&cacheProf] = cpu
 		}
-		collector.perfCacheProfilers[cpu] = &cacheProf
-		collector.cacheProfilerCPUMap[&cacheProf] = cpu
 	}
 
 	collector.desc = map[string]*prometheus.Desc{

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-kit/log v0.1.0
 	github.com/godbus/dbus v0.0.0-20190402143921-271e53dc4968
 	github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e
-	github.com/hodgesds/perf-utils v0.2.5
+	github.com/hodgesds/perf-utils v0.3.0
 	github.com/illumos/go-kstat v0.0.0-20210513183136-173c9b0a9973
 	github.com/jsimonetti/rtnetlink v0.0.0-20210713125558-2bfdf1dbdbd6
 	github.com/lufia/iostat v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e h1:v1d9+AJMP
 github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e/go.mod h1:/NlxCzN2D4C4L2uDE6ux/h6jM+n98VFQM14nnCIfHJU=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hodgesds/perf-utils v0.2.5 h1:X992/V3OaNJRM8Ivcram8Hhxz4JhWiKI0T8iGCJwk2k=
-github.com/hodgesds/perf-utils v0.2.5/go.mod h1:X3dAE1IoPfsSKR2MDhorGY1mORNDOJTZ+0XTrtmoHFI=
+github.com/hodgesds/perf-utils v0.3.0 h1:DMlil1ekDrhvocID1J9f6ke4NY0Q6Mvj8/BCxSkxbBg=
+github.com/hodgesds/perf-utils v0.3.0/go.mod h1:oH2rI7A/UyTAlIxaP4CwSE11vDH8kGQeTBA6Oz3ltfQ=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/illumos/go-kstat v0.0.0-20210513183136-173c9b0a9973 h1:hk4LPqXIY/c9XzRbe7dA6qQxaT6Axcbny0L/G5a4owQ=
 github.com/illumos/go-kstat v0.0.0-20210513183136-173c9b0a9973/go.mod h1:PoK3ejP3LJkGTzKqRlpvCIFas3ncU02v8zzWDW+g0FY=


### PR DESCRIPTION
Bumps perf-utils to v0.3.0, which improves error handling on profiler initialization.