### PR TITLE
Bump perf-utils to v0.3.1

### DIFF
--- a/collector/perf_linux.go
+++ b/collector/perf_linux.go
@@ -284,21 +284,39 @@ func NewPerfCollector(logger log.Logger) (Collector, error) {
 	for _, cpu := range cpus {
 		// Use -1 to profile all processes on the CPU, see:
 		// man perf_event_open
-		hwProf := perf.NewHardwareProfiler(-1, cpu)
+		hwProf, err := perf.NewHardwareProfiler(-1, cpu)
+		if err != nil {
+			level.Error(logger).Log(
+			"msg",
+			"Failed to create all hardware profilers, some profilers may still work",
+			"err", err)
+		}
 		if err := hwProf.Start(); err != nil {
 			return nil, err
 		}
 		collector.perfHwProfilers[cpu] = &hwProf
 		collector.hwProfilerCPUMap[&hwProf] = cpu
 
-		swProf := perf.NewSoftwareProfiler(-1, cpu)
+		swProf, err := perf.NewSoftwareProfiler(-1, cpu)
+		if err != nil {
+			level.Error(logger).Log(
+			"msg",
+			"Failed to create all software profilers, some profilers may still work",
+			"err", err)
+		}
 		if err := swProf.Start(); err != nil {
 			return nil, err
 		}
 		collector.perfSwProfilers[cpu] = &swProf
 		collector.swProfilerCPUMap[&swProf] = cpu
 
-		cacheProf := perf.NewCacheProfiler(-1, cpu)
+		cacheProf, err := perf.NewCacheProfiler(-1, cpu)
+		if err != nil {
+			level.Error(logger).Log(
+			"msg",
+			"Failed to create all cache profilers, some profilers may still work",
+			"err", err)
+		}
 		if err := cacheProf.Start(); err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-kit/log v0.1.0
 	github.com/godbus/dbus v0.0.0-20190402143921-271e53dc4968
 	github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e
-	github.com/hodgesds/perf-utils v0.2.5
+	github.com/hodgesds/perf-utils v0.3.1
 	github.com/illumos/go-kstat v0.0.0-20210513183136-173c9b0a9973
 	github.com/jsimonetti/rtnetlink v0.0.0-20210713125558-2bfdf1dbdbd6
 	github.com/lufia/iostat v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e h1:v1d9+AJMP
 github.com/hashicorp/go-envparse v0.0.0-20200406174449-d9cfd743a15e/go.mod h1:/NlxCzN2D4C4L2uDE6ux/h6jM+n98VFQM14nnCIfHJU=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hodgesds/perf-utils v0.2.5 h1:X992/V3OaNJRM8Ivcram8Hhxz4JhWiKI0T8iGCJwk2k=
-github.com/hodgesds/perf-utils v0.2.5/go.mod h1:X3dAE1IoPfsSKR2MDhorGY1mORNDOJTZ+0XTrtmoHFI=
+github.com/hodgesds/perf-utils v0.3.1 h1:iizGJVzJnPW32Gvk1cFZINiGA5lVxjkZS5G0NJ6YQU0=
+github.com/hodgesds/perf-utils v0.3.1/go.mod h1:oH2rI7A/UyTAlIxaP4CwSE11vDH8kGQeTBA6Oz3ltfQ=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/illumos/go-kstat v0.0.0-20210513183136-173c9b0a9973 h1:hk4LPqXIY/c9XzRbe7dA6qQxaT6Axcbny0L/G5a4owQ=
 github.com/illumos/go-kstat v0.0.0-20210513183136-173c9b0a9973/go.mod h1:PoK3ejP3LJkGTzKqRlpvCIFas3ncU02v8zzWDW+g0FY=


### PR DESCRIPTION
I reworked the error handling in the perf-utils library so that when profilers are created an error is returned. However, the interface is not so easy to use as partial error states are "valid". For example, the HardwareProfiler may not have all hardware events on the running system. Internally the profiler will not add invalid profilers so the error returned can logged for reporting purposes. However, when the `Start` method is called on the profiler if it isn't able to start then it is indeed an error.

This logic should be fully backwards compatible and at least propagate the error messages back to the end user. The errors are chained directly from the calls to [`unix.PerfEventOpen`](https://pkg.go.dev/golang.org/x/sys/unix#PerfEventOpen). It's rather tricky to get this code to work properly across combinations of kernels and hardware and this change make it slightly more debuggable.

Tested locally on a AMD based laptop and not all the profilers were able to be created successfully:

Example startup log:
```
level=error ts=2021-09-14T01:59:35.601Z caller=perf_linux.go:289 collector=perf msg="Failed to create all cache profilers, some profilers may st
ill work" err="no such file or directory; no such file or directory"
```

curl localhost:9100 and results still present:
```
node_perf_cache_l1d_read_hits_total{cpu="0"} 1.364622e+07
node_perf_cache_l1d_read_hits_total{cpu="1"} 1.0329348e+07
node_perf_cache_l1d_read_hits_total{cpu="10"} 2.2825967e+07
node_perf_cache_l1d_read_hits_total{cpu="11"} 3.867886e+06
node_perf_cache_l1d_read_hits_total{cpu="12"} 1.9471707e+07
node_perf_cache_l1d_read_hits_total{cpu="13"} 5.208669e+06
node_perf_cache_l1d_read_hits_total{cpu="14"} 1.3620855e+07
node_perf_cache_l1d_read_hits_total{cpu="15"} 9.258234e+06
node_perf_cache_l1d_read_hits_total{cpu="2"} 5.0286912e+07
node_perf_cache_l1d_read_hits_total{cpu="3"} 9.972291e+06
node_perf_cache_l1d_read_hits_total{cpu="4"} 6.7882919e+07
node_perf_cache_l1d_read_hits_total{cpu="5"} 1.2651993e+08
node_perf_cache_l1d_read_hits_total{cpu="6"} 2.9999384e+07
node_perf_cache_l1d_read_hits_total{cpu="7"} 1.3385924e+07
node_perf_cache_l1d_read_hits_total{cpu="8"} 1.9109685e+07
```

Signed-off-by: Daniel Hodges <hodges.daniel.scott@gmail.com>