### PR TITLE
Support number of threads in each state

### DIFF
--- a/collector/processes_linux_test.go
+++ b/collector/processes_linux_test.go
@@ -34,7 +34,7 @@ func TestReadProcessStatus(t *testing.T) {
 		t.Errorf("failed to open procfs: %v", err)
 	}
 	c := processCollector{fs: fs, logger: log.NewNopLogger()}
-	pids, states, threads, err := c.getAllocatedThreads()
+	pids, states, threads, _, err := c.getAllocatedThreads()
 	if err != nil {
 		t.Fatalf("Cannot retrieve data from procfs getAllocatedThreads function: %v ", err)
 	}


### PR DESCRIPTION
Node exporter support  node_processes_state metrics to expose number of processes in each state, but this is not enough for the whole system.  This PR is to support number of threads in each state. 