### PR TITLE
Use include/exclude flags for ethtool filtering

### DIFF
--- a/collector/ethtool_linux_test.go
+++ b/collector/ethtool_linux_test.go
@@ -121,24 +121,6 @@ func NewEthtoolTestCollector(logger log.Logger) (Collector, error) {
 	return collector, nil
 }
 
-func TestSanitizeMetricName(t *testing.T) {
-	testcases := map[string]string{
-		"":                             "",
-		"rx_errors":                    "rx_errors",
-		"Queue[0] AllocFails":          "Queue_0_AllocFails",
-		"Tx LPI entry count":           "Tx_LPI_entry_count",
-		"port.VF_admin_queue_requests": "port_VF_admin_queue_requests",
-		"[3]: tx_bytes":                "_3_tx_bytes",
-	}
-
-	for metricName, expected := range testcases {
-		got := SanitizeMetricName(metricName)
-		if expected != got {
-			t.Errorf("Expected '%s' but got '%s'", expected, got)
-		}
-	}
-}
-
 func TestBuildEthtoolFQName(t *testing.T) {
 	testcases := map[string]string{
 		"rx_errors":                    "node_ethtool_received_errors",
@@ -174,7 +156,6 @@ func TestEthtoolCollector(t *testing.T) {
 		prometheus.NewDesc("node_ethtool_transmitted_packets_total", "Network interface packets sent", []string{"device"}, nil).String(),
 	}
 
-	*ethtoolIgnoredDevices = "^$"
 	*sysPath = "fixtures/sys"
 
 	collector, err := NewEthtoolTestCollector(log.NewNopLogger())

--- a/collector/helper.go
+++ b/collector/helper.go
@@ -16,6 +16,7 @@ package collector
 import (
 	"bytes"
 	"io/ioutil"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -43,4 +44,21 @@ func bytesToString(byteArray []byte) string {
 		return string(byteArray)
 	}
 	return string(byteArray[:n])
+}
+
+var metricNameRegex = regexp.MustCompile(`_*[^0-9A-Za-z_]+_*`)
+
+// Sanitize the given metric name by replacing invalid characters by underscores.
+//
+// OpenMetrics and the Prometheus exposition format require the metric name
+// to consist only of alphanumericals and "_", ":" and they must not start
+// with digits. Since colons in MetricFamily are reserved to signal that the
+// MetricFamily is the result of a calculation or aggregation of a general
+// purpose monitoring system, colons will be replaced as well.
+//
+// Note: If not subsequently prepending a namespace and/or subsystem (e.g.,
+// with prometheus.BuildFQName), the caller must ensure that the supplied
+// metricName does not begin with a digit.
+func SanitizeMetricName(metricName string) string {
+	return metricNameRegex.ReplaceAllString(metricName, "_")
 }

--- a/collector/helper_test.go
+++ b/collector/helper_test.go
@@ -61,3 +61,21 @@ func TestBytesToString(t *testing.T) {
 		}
 	}
 }
+
+func TestSanitizeMetricName(t *testing.T) {
+	testcases := map[string]string{
+		"":                             "",
+		"rx_errors":                    "rx_errors",
+		"Queue[0] AllocFails":          "Queue_0_AllocFails",
+		"Tx LPI entry count":           "Tx_LPI_entry_count",
+		"port.VF_admin_queue_requests": "port_VF_admin_queue_requests",
+		"[3]: tx_bytes":                "_3_tx_bytes",
+	}
+
+	for metricName, expected := range testcases {
+		got := SanitizeMetricName(metricName)
+		if expected != got {
+			t.Errorf("Expected '%s' but got '%s'", expected, got)
+		}
+	}
+}


### PR DESCRIPTION
Use the same flag pattern as netdev to make filtering methods the same.
* Move SanitizeMetricName to helper.go

Signed-off-by: Ben Kochie <superq@gmail.com>