### PR TITLE
Fix timer GC delays in the Linux filesystem collector

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -50,28 +50,6 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 		return nil, err
 	}
 	stats := []filesystemStats{}
-	mountCheckTimer := time.NewTimer(*mountTimeout)
-	defer mountCheckTimer.Stop()
-	// stuckMountWatcher listens on the given success channel and if the channel closes
-	// then the watcher does nothing. If instead the timeout is reached, the
-	// mount point that is being watched is marked as stuck.
-	stuckMountWatcher := func(mountPoint string, success chan struct{}, logger log.Logger) {
-		select {
-		case <-success:
-			// Success
-		case <-mountCheckTimer.C:
-			// Timed out, mark mount as stuck
-			stuckMountsMtx.Lock()
-			select {
-			case <-success:
-				// Success came in just after the timeout was reached, don't label the mount as stuck
-			default:
-				level.Debug(logger).Log("msg", "Mount point timed out, it is being labeled as stuck and will not be monitored", "mountpoint", mountPoint)
-				stuckMounts[mountPoint] = struct{}{}
-			}
-			stuckMountsMtx.Unlock()
-		}
-	}
 	for _, labels := range mps {
 		if c.excludedMountPointsPattern.MatchString(labels.mountPoint) {
 			level.Debug(c.logger).Log("msg", "Ignoring mount point", "mountpoint", labels.mountPoint)
@@ -138,6 +116,29 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 		})
 	}
 	return stats, nil
+}
+
+// stuckMountWatcher listens on the given success channel and if the channel closes
+// then the watcher does nothing. If instead the timeout is reached, the
+// mount point that is being watched is marked as stuck.
+func stuckMountWatcher(mountPoint string, success chan struct{}, logger log.Logger) {
+	mountCheckTimer := time.NewTimer(*mountTimeout)
+	defer mountCheckTimer.Stop()
+	select {
+	case <-success:
+		// Success
+	case <-mountCheckTimer.C:
+		// Timed out, mark mount as stuck
+		stuckMountsMtx.Lock()
+		select {
+		case <-success:
+			// Success came in just after the timeout was reached, don't label the mount as stuck
+		default:
+			level.Debug(logger).Log("msg", "Mount point timed out, it is being labeled as stuck and will not be monitored", "mountpoint", mountPoint)
+			stuckMounts[mountPoint] = struct{}{}
+		}
+		stuckMountsMtx.Unlock()
+	}
 }
 
 func mountPointDetails(logger log.Logger) ([]filesystemLabels, error) {


### PR DESCRIPTION
Hello,I found a potential hazard in `filesystem_linux.go` that may cause memory leaks,the details are as follows:
function `GetStats` will loop through mount points, according to the number of all mount points.
Recently I encountered a problem: the number of mount points of a certain system in the production environment is abnormal, as many as more than 500,000 rows; mainly because the for loop is blocked, and then the `Timer Heap objects`  in the statement `for {select case->time.After`  cause accumulation, and eventually a memory leak occurs.
It may be a better way to control the number of mount points to be checked, but this may require more changes; therefore, I only made a slight optimization for this problem: change `time.After` to `time.NewTimer`.
Expect to be accepted or answered.