### PR TITLE
Datasource template variable should be labelled 'Data Source'

### DIFF
--- a/docs/node-mixin/dashboards/node.libsonnet
+++ b/docs/node-mixin/dashboards/node.libsonnet
@@ -215,7 +215,7 @@ local gauge = promgrafonnet.gauge;
             value: 'Prometheus',
           },
           hide: 0,
-          label: null,
+          label: 'Data Source',
           name: 'datasource',
           options: [],
           query: 'prometheus',

--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -13,7 +13,7 @@ local datasourceTemplate = {
     value: 'Prometheus',
   },
   hide: 0,
-  label: null,
+  label: 'Data Source',
   name: 'datasource',
   options: [],
   query: 'prometheus',


### PR DESCRIPTION
We're building a dashboard linter and this is one of the things that came up. Super minor nit, sorry about that.

Signed-off-by: Tom Wilkie <tom@grafana.com>