### PR TITLE
collector: replace fmt.Sprintf with strconv.Itoa in perfCollector

### DIFF
--- a/collector/perf_linux.go
+++ b/collector/perf_linux.go
@@ -160,13 +160,14 @@ func (c *perfTracepointCollector) update(ch chan<- prometheus.Metric) error {
 
 // updateCPU is used to update metrics per CPU profiler.
 func (c *perfTracepointCollector) updateCPU(cpu int, ch chan<- prometheus.Metric) error {
-	cpuStr := fmt.Sprintf("%d", cpu)
 	profiler := c.profilers[cpu]
 	p, err := profiler.Profile()
 	if err != nil {
 		level.Error(c.logger).Log("msg", "Failed to collect tracepoint profile", "err", err)
 		return err
 	}
+
+	cpuid := strconv.Itoa(cpu)
 
 	for i, value := range p.Values {
 		// Get the Desc from the ordered group value.
@@ -176,7 +177,7 @@ func (c *perfTracepointCollector) updateCPU(cpu int, ch chan<- prometheus.Metric
 			c.descs[descKeySlice[0]][descKeySlice[1]],
 			prometheus.CounterValue,
 			float64(value),
-			cpuStr,
+			cpuid,
 		)
 	}
 	return nil
@@ -584,8 +585,6 @@ func (c *perfCollector) Update(ch chan<- prometheus.Metric) error {
 
 func (c *perfCollector) updateHardwareStats(ch chan<- prometheus.Metric) error {
 	for _, profiler := range c.perfHwProfilers {
-		cpuid := c.hwProfilerCPUMap[profiler]
-		cpuStr := strconv.Itoa(cpuid)
 		hwProfile, err := (*profiler).Profile()
 		if err != nil {
 			return err
@@ -594,11 +593,13 @@ func (c *perfCollector) updateHardwareStats(ch chan<- prometheus.Metric) error {
 			continue
 		}
 
+		cpuid := strconv.Itoa(c.hwProfilerCPUMap[profiler])
+
 		if hwProfile.CPUCycles != nil {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cpucycles_total"],
 				prometheus.CounterValue, float64(*hwProfile.CPUCycles),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -606,7 +607,7 @@ func (c *perfCollector) updateHardwareStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["instructions_total"],
 				prometheus.CounterValue, float64(*hwProfile.Instructions),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -614,7 +615,7 @@ func (c *perfCollector) updateHardwareStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["branch_instructions_total"],
 				prometheus.CounterValue, float64(*hwProfile.BranchInstr),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -622,7 +623,7 @@ func (c *perfCollector) updateHardwareStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["branch_misses_total"],
 				prometheus.CounterValue, float64(*hwProfile.BranchMisses),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -630,7 +631,7 @@ func (c *perfCollector) updateHardwareStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cache_refs_total"],
 				prometheus.CounterValue, float64(*hwProfile.CacheRefs),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -638,7 +639,7 @@ func (c *perfCollector) updateHardwareStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cache_misses_total"],
 				prometheus.CounterValue, float64(*hwProfile.CacheMisses),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -646,7 +647,7 @@ func (c *perfCollector) updateHardwareStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["ref_cpucycles_total"],
 				prometheus.CounterValue, float64(*hwProfile.RefCPUCycles),
-				cpuStr,
+				cpuid,
 			)
 		}
 	}
@@ -656,8 +657,6 @@ func (c *perfCollector) updateHardwareStats(ch chan<- prometheus.Metric) error {
 
 func (c *perfCollector) updateSoftwareStats(ch chan<- prometheus.Metric) error {
 	for _, profiler := range c.perfSwProfilers {
-		cpuid := c.swProfilerCPUMap[profiler]
-		cpuStr := fmt.Sprintf("%d", cpuid)
 		swProfile, err := (*profiler).Profile()
 		if err != nil {
 			return err
@@ -666,11 +665,13 @@ func (c *perfCollector) updateSoftwareStats(ch chan<- prometheus.Metric) error {
 			continue
 		}
 
+		cpuid := strconv.Itoa(c.swProfilerCPUMap[profiler])
+
 		if swProfile.PageFaults != nil {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["page_faults_total"],
 				prometheus.CounterValue, float64(*swProfile.PageFaults),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -678,7 +679,7 @@ func (c *perfCollector) updateSoftwareStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["context_switches_total"],
 				prometheus.CounterValue, float64(*swProfile.ContextSwitches),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -686,7 +687,7 @@ func (c *perfCollector) updateSoftwareStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cpu_migrations_total"],
 				prometheus.CounterValue, float64(*swProfile.CPUMigrations),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -694,7 +695,7 @@ func (c *perfCollector) updateSoftwareStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["minor_faults_total"],
 				prometheus.CounterValue, float64(*swProfile.MinorPageFaults),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -702,7 +703,7 @@ func (c *perfCollector) updateSoftwareStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["major_faults_total"],
 				prometheus.CounterValue, float64(*swProfile.MajorPageFaults),
-				cpuStr,
+				cpuid,
 			)
 		}
 	}
@@ -712,8 +713,6 @@ func (c *perfCollector) updateSoftwareStats(ch chan<- prometheus.Metric) error {
 
 func (c *perfCollector) updateCacheStats(ch chan<- prometheus.Metric) error {
 	for _, profiler := range c.perfCacheProfilers {
-		cpuid := c.cacheProfilerCPUMap[profiler]
-		cpuStr := fmt.Sprintf("%d", cpuid)
 		cacheProfile, err := (*profiler).Profile()
 		if err != nil {
 			return err
@@ -722,11 +721,13 @@ func (c *perfCollector) updateCacheStats(ch chan<- prometheus.Metric) error {
 			continue
 		}
 
+		cpuid := strconv.Itoa(c.cacheProfilerCPUMap[profiler])
+
 		if cacheProfile.L1DataReadHit != nil {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cache_l1d_read_hits_total"],
 				prometheus.CounterValue, float64(*cacheProfile.L1DataReadHit),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -734,7 +735,7 @@ func (c *perfCollector) updateCacheStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cache_l1d_read_misses_total"],
 				prometheus.CounterValue, float64(*cacheProfile.L1DataReadMiss),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -742,7 +743,7 @@ func (c *perfCollector) updateCacheStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cache_l1d_write_hits_total"],
 				prometheus.CounterValue, float64(*cacheProfile.L1DataWriteHit),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -750,7 +751,7 @@ func (c *perfCollector) updateCacheStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cache_l1_instr_read_misses_total"],
 				prometheus.CounterValue, float64(*cacheProfile.L1InstrReadMiss),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -758,7 +759,7 @@ func (c *perfCollector) updateCacheStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cache_tlb_instr_read_hits_total"],
 				prometheus.CounterValue, float64(*cacheProfile.InstrTLBReadHit),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -766,7 +767,7 @@ func (c *perfCollector) updateCacheStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cache_tlb_instr_read_misses_total"],
 				prometheus.CounterValue, float64(*cacheProfile.InstrTLBReadMiss),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -774,7 +775,7 @@ func (c *perfCollector) updateCacheStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cache_ll_read_hits_total"],
 				prometheus.CounterValue, float64(*cacheProfile.LastLevelReadHit),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -782,7 +783,7 @@ func (c *perfCollector) updateCacheStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cache_ll_read_misses_total"],
 				prometheus.CounterValue, float64(*cacheProfile.LastLevelReadMiss),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -790,7 +791,7 @@ func (c *perfCollector) updateCacheStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cache_ll_write_hits_total"],
 				prometheus.CounterValue, float64(*cacheProfile.LastLevelWriteHit),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -798,7 +799,7 @@ func (c *perfCollector) updateCacheStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cache_ll_write_misses_total"],
 				prometheus.CounterValue, float64(*cacheProfile.LastLevelWriteMiss),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -806,7 +807,7 @@ func (c *perfCollector) updateCacheStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cache_bpu_read_hits_total"],
 				prometheus.CounterValue, float64(*cacheProfile.BPUReadHit),
-				cpuStr,
+				cpuid,
 			)
 		}
 
@@ -814,7 +815,7 @@ func (c *perfCollector) updateCacheStats(ch chan<- prometheus.Metric) error {
 			ch <- prometheus.MustNewConstMetric(
 				c.desc["cache_bpu_read_misses_total"],
 				prometheus.CounterValue, float64(*cacheProfile.BPUReadMiss),
-				cpuStr,
+				cpuid,
 			)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

No need to make use of reflection or a temporary variable for these one-liner conversions.