### PR TITLE
[BROKEN MASTER] Fix imports when building on MacOS

### DIFF
--- a/collector/thermal_darwin.go
+++ b/collector/thermal_darwin.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !notherm
 // +build !notherm
 
 package collector
@@ -46,7 +47,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"unsafe"
 )


### PR DESCRIPTION
While rebasing https://github.com/prometheus/node_exporter/pull/1777 I figured out I could not compile on darwing because of a broken import.