### PR TITLE
Correctly disable ZFS for test cases

### DIFF
--- a/collector/zfs_linux_test.go
+++ b/collector/zfs_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nozfs
+// +build !nozfs
+
 package collector
 
 import (


### PR DESCRIPTION
Disable `collector/zfs_linux_test.go` in case `!nozfs` is set to completely disable ZFS.