### PR TITLE
netstat collector also covers /proc/net/snmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ mdadm | Exposes statistics about devices in `/proc/mdstat` (does nothing if no `
 meminfo | Exposes memory statistics. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD
 netclass | Exposes network interface info from `/sys/class/net/` | Linux
 netdev | Exposes network interface statistics such as bytes transferred. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD
-netstat | Exposes network statistics from `/proc/net/netstat`. This is the same information as `netstat -s`. | Linux
+netstat | Exposes network statistics from `/proc/net/netstat` and `/proc/net/snmp`. This is the same information as `netstat -s`. | Linux
 nfs | Exposes NFS client statistics from `/proc/net/rpc/nfs`. This is the same information as `nfsstat -c`. | Linux
 nfsd | Exposes NFS kernel server statistics from `/proc/net/rpc/nfsd`. This is the same information as `nfsstat -s`. | Linux
 nvme | Exposes NVMe info from `/sys/class/nvme/` | Linux


### PR DESCRIPTION
make clear that the netstat collector also reads 
/proc/net/snmp (#85) and not just /proc/net/netstat to avoid
confusions like #2179