### PR TITLE
ethtool: Add test case with leading spaces

### DIFF
--- a/collector/ethtool_linux_test.go
+++ b/collector/ethtool_linux_test.go
@@ -270,6 +270,7 @@ func TestBuildEthtoolFQName(t *testing.T) {
 		"Tx LPI entry count":           "node_ethtool_transmitted_lpi_entry_count",
 		"port.VF_admin_queue_requests": "node_ethtool_port_vf_admin_queue_requests",
 		"[3]: tx_bytes":                "node_ethtool_3_transmitted_bytes",
+		"     err":                     "node_ethtool_err",
 	}
 
 	for metric, expected := range testcases {

--- a/collector/helper_test.go
+++ b/collector/helper_test.go
@@ -70,6 +70,7 @@ func TestSanitizeMetricName(t *testing.T) {
 		"Tx LPI entry count":           "Tx_LPI_entry_count",
 		"port.VF_admin_queue_requests": "port_VF_admin_queue_requests",
 		"[3]: tx_bytes":                "_3_tx_bytes",
+		"     err":                     "_err",
 	}
 
 	for metricName, expected := range testcases {


### PR DESCRIPTION
Add test case for ethtool metrics with leading spaces reported in #2185:

```
$ ethtool -S
NIC statistics:
     Tx Queue#: 0
       TSO pkts tx: 0
       TSO bytes tx: 0
       ucast pkts tx: 20487
       ucast bytes tx: 1908107
       mcast pkts tx: 83
       mcast bytes tx: 5906
       bcast pkts tx: 4
       bcast bytes tx: 168
       pkts tx err: 0
       pkts tx discard: 0
       drv dropped tx total: 0
          too many frags: 0
          giant hdr: 0
          hdr err: 0
          tso: 0
       ring full: 0
       pkts linearized: 0
       hdr cloned: 0
       giant hdr: 0
     Rx Queue#: 0
       LRO pkts rx: 0
       LRO byte rx: 0
       ucast pkts rx: 25086
       ucast bytes rx: 2404103
       mcast pkts rx: 0
       mcast bytes rx: 0
       bcast pkts rx: 0
       bcast bytes rx: 0
       pkts rx OOB: 0
       pkts rx err: 0
       drv dropped rx total: 0
          err: 0
          fcs: 0
       rx buf alloc fail: 0
     tx timeout count: 0
```