### PR TITLE
ethtool: Prevent duplicate metric names

### DIFF
--- a/collector/fixtures/ethtool/eth0/statistics
+++ b/collector/fixtures/ethtool/eth0/statistics
@@ -13,3 +13,5 @@ NIC statistics:
      rx_multicast: 23973
      tx_aborted: 0
      tx_underrun: 0
+     duplicate metric: 1
+     duplicate_metric: 2


### PR DESCRIPTION
Sanitizing the metric names can lead to duplicate metric names:

```
caller=level.go:63 level=error caller="error gathering metrics: [from Gatherer #2] collected metric \"node_ethtool_giant_hdr\" { label:<name:\"device\" value:\"ens192\" > untyped:<value:0" msg=" > } was collected before with the same name and label values"
```

Generate a map from the sanitized metric names to the metric names from ethtool. In case of duplicate sanitized metric names drop both metrics, because it is unknown which one to take.

Fixes: https://github.com/prometheus/node_exporter/issues/2185