### PR TITLE
Add additional perf counters for stalled frontend/backend cycles

### DIFF
--- a/collector/perf_linux.go
+++ b/collector/perf_linux.go
@@ -411,7 +411,7 @@ func NewPerfCollector(logger log.Logger) (Collector, error) {
 			prometheus.BuildFQName(
 				namespace,
 				perfSubsystem,
-				"stalled_cycles_frontend",
+				"stalled_cycles_frontend_total",
 			),
 			"Number of stalled fronted CPU cycles",
 			[]string{"cpu"},

--- a/collector/perf_linux.go
+++ b/collector/perf_linux.go
@@ -397,6 +397,26 @@ func NewPerfCollector(logger log.Logger) (Collector, error) {
 			[]string{"cpu"},
 			nil,
 		),
+		"stalled_cycles_backend": prometheus.NewDesc(
+			prometheus.BuildFQName(
+				namespace,
+				perfSubsystem,
+				"stalled_cycles_backend",
+			),
+			"Number of stalled backend CPU cycles",
+			[]string{"cpu"},
+			nil,
+		),
+		"stalled_cycles_frontend": prometheus.NewDesc(
+			prometheus.BuildFQName(
+				namespace,
+				perfSubsystem,
+				"stalled_cycles_frontend",
+			),
+			"Number of stalled fronted CPU cycles",
+			[]string{"cpu"},
+			nil,
+		),
 		"page_faults_total": prometheus.NewDesc(
 			prometheus.BuildFQName(
 				namespace,
@@ -598,6 +618,9 @@ func (c *perfCollector) updateHardwareStats(ch chan<- prometheus.Metric) error {
 		if err := (*profiler).Profile(hwProfile); err != nil {
 			return err
 		}
+		if hwProfile == nil {
+			continue
+		}
 
 		cpuid := strconv.Itoa(c.hwProfilerCPUMap[profiler])
 
@@ -656,6 +679,22 @@ func (c *perfCollector) updateHardwareStats(ch chan<- prometheus.Metric) error {
 				cpuid,
 			)
 		}
+
+		if hwProfile.StalledCyclesBackend != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.desc["stalled_cycles_backend"],
+				prometheus.CounterValue, float64(*hwProfile.StalledCyclesBackend),
+				cpuid,
+			)
+		}
+
+		if hwProfile.StalledCyclesFrontend != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.desc["stalled_cycles_frontend"],
+				prometheus.CounterValue, float64(*hwProfile.StalledCyclesFrontend),
+				cpuid,
+			)
+		}
 	}
 
 	return nil
@@ -666,6 +705,9 @@ func (c *perfCollector) updateSoftwareStats(ch chan<- prometheus.Metric) error {
 		swProfile := &perf.SoftwareProfile{}
 		if err := (*profiler).Profile(swProfile); err != nil {
 			return err
+		}
+		if swProfile == nil {
+			continue
 		}
 
 		cpuid := strconv.Itoa(c.swProfilerCPUMap[profiler])
@@ -719,6 +761,9 @@ func (c *perfCollector) updateCacheStats(ch chan<- prometheus.Metric) error {
 		cacheProfile := &perf.CacheProfile{}
 		if err := (*profiler).Profile(cacheProfile); err != nil {
 			return err
+		}
+		if cacheProfile == nil {
+			continue
 		}
 
 		cpuid := strconv.Itoa(c.cacheProfilerCPUMap[profiler])

--- a/collector/perf_linux.go
+++ b/collector/perf_linux.go
@@ -397,23 +397,23 @@ func NewPerfCollector(logger log.Logger) (Collector, error) {
 			[]string{"cpu"},
 			nil,
 		),
-		"stalled_cycles_backend": prometheus.NewDesc(
+		"stalled_cycles_backend_total": prometheus.NewDesc(
 			prometheus.BuildFQName(
 				namespace,
 				perfSubsystem,
-				"stalled_cycles_backend",
+				"stalled_cycles_backend_total",
 			),
 			"Number of stalled backend CPU cycles",
 			[]string{"cpu"},
 			nil,
 		),
-		"stalled_cycles_frontend": prometheus.NewDesc(
+		"stalled_cycles_frontend_total": prometheus.NewDesc(
 			prometheus.BuildFQName(
 				namespace,
 				perfSubsystem,
 				"stalled_cycles_frontend_total",
 			),
-			"Number of stalled fronted CPU cycles",
+			"Number of stalled frontend CPU cycles",
 			[]string{"cpu"},
 			nil,
 		),
@@ -682,7 +682,7 @@ func (c *perfCollector) updateHardwareStats(ch chan<- prometheus.Metric) error {
 
 		if hwProfile.StalledCyclesBackend != nil {
 			ch <- prometheus.MustNewConstMetric(
-				c.desc["stalled_cycles_backend"],
+				c.desc["stalled_cycles_backend_total"],
 				prometheus.CounterValue, float64(*hwProfile.StalledCyclesBackend),
 				cpuid,
 			)
@@ -690,7 +690,7 @@ func (c *perfCollector) updateHardwareStats(ch chan<- prometheus.Metric) error {
 
 		if hwProfile.StalledCyclesFrontend != nil {
 			ch <- prometheus.MustNewConstMetric(
-				c.desc["stalled_cycles_frontend"],
+				c.desc["stalled_cycles_frontend_total"],
 				prometheus.CounterValue, float64(*hwProfile.StalledCyclesFrontend),
 				cpuid,
 			)


### PR DESCRIPTION
This change adds additional perf counter values for stalled frontend/backend cycles. There is a decent [post](https://stackoverflow.com/questions/22165299/what-are-stalled-cycles-frontend-and-stalled-cycles-backend-in-perf-stat-resul) that describes stalled cycles and how they are used in the `perf` subsystem.

Tested locally:
```
curl  localhost:9100/metrics | grep perf | grep 'cpu="0"'
node_perf_branch_instructions_total{cpu="0"} 7.25668184e+08
node_perf_branch_misses_total{cpu="0"} 1.5600914e+07
node_perf_cache_bpu_read_hits_total{cpu="0"} 7.23401709e+08
node_perf_cache_bpu_read_misses_total{cpu="0"} 1.5085842e+07
node_perf_cache_l1_instr_read_misses_total{cpu="0"} 1.3356764e+07
node_perf_cache_l1d_read_hits_total{cpu="0"} 1.379718659e+09
node_perf_cache_l1d_read_misses_total{cpu="0"} 7.1330055e+07
node_perf_cache_misses_total{cpu="0"} 6.1721286e+07
node_perf_cache_refs_total{cpu="0"} 2.58693056e+08
node_perf_cache_tlb_instr_read_hits_total{cpu="0"} 3.248673e+06
node_perf_cache_tlb_instr_read_misses_total{cpu="0"} 676975
node_perf_context_switches_total{cpu="0"} 172104
node_perf_cpu_migrations_total{cpu="0"} 1143
node_perf_cpucycles_total{cpu="0"} 7.39622432e+09
node_perf_instructions_total{cpu="0"} 3.57493954e+09
node_perf_major_faults_total{cpu="0"} 57
node_perf_minor_faults_total{cpu="0"} 53728
node_perf_page_faults_total{cpu="0"} 53787
node_perf_stalled_cycles_backend{cpu="0"} 8.534653e+08
node_perf_stalled_cycles_frontend{cpu="0"} 6.45603887e+08
```