### PR TITLE
Add btrfs device error stats

### DIFF
--- a/collector/btrfs_linux.go
+++ b/collector/btrfs_linux.go
@@ -23,6 +23,7 @@ import (
 
 	dennwc "github.com/dennwc/btrfs"
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs/btrfs"
 )
@@ -126,6 +127,10 @@ func (c *btrfsCollector) getIoctlStats() (map[string]*ioctlFsStats, error) {
 		if err != nil {
 			// failed to open this mount point, maybe we didn't have permission
 			// maybe we'll find another mount point for this FS later
+			level.Debug(c.logger).Log(
+				"msg", "Error inspecting btrfs mountpoint",
+				"mountPoint", mount.mountPoint,
+				"err", err)
 			continue
 		}
 
@@ -133,6 +138,10 @@ func (c *btrfsCollector) getIoctlStats() (map[string]*ioctlFsStats, error) {
 		if err != nil {
 			// Failed to get the FS info for some reason,
 			// perhaps it'll work with a different mount point
+			level.Debug(c.logger).Log(
+				"msg", "Error querying btrfs filesystem",
+				"mountPoint", mount.mountPoint,
+				"err", err)
 			continue
 		}
 
@@ -144,6 +153,10 @@ func (c *btrfsCollector) getIoctlStats() (map[string]*ioctlFsStats, error) {
 
 		deviceStats, err := c.getIoctlDeviceStats(fs, &fsInfo)
 		if err != nil {
+			level.Debug(c.logger).Log(
+				"msg", "Error querying btrfs device stats",
+				"mountPoint", mount.mountPoint,
+				"err", err)
 			return nil, err
 		}
 

--- a/collector/btrfs_linux.go
+++ b/collector/btrfs_linux.go
@@ -18,6 +18,7 @@ package collector
 
 import (
 	"fmt"
+	"path"
 	"strings"
 	"syscall"
 
@@ -294,9 +295,10 @@ func (c *btrfsCollector) getMetrics(s *btrfs.Stats, ioctlStats *btrfsIoctlFsStat
 	}
 
 	for _, dev := range ioctlStats.devices {
-		// trim the /dev/ prefix from the device name so the value should match
-		// the value used in the fallback branch above
-		device := strings.TrimPrefix(dev.path, "/dev/")
+		// trim the path prefix from the device name so the value should match
+		// the value used in the fallback branch above.
+		// e.g. /dev/sda -> sda, /rootfs/dev/md1 -> md1
+		_, device := path.Split(dev.path)
 
 		extraLabels := []string{"device", "device_uuid"}
 		extraLabelValues := []string{device, dev.uuid}

--- a/collector/btrfs_linux.go
+++ b/collector/btrfs_linux.go
@@ -300,7 +300,7 @@ func (c *btrfsCollector) getMetrics(s *btrfs.Stats, ioctlStats *btrfsIoctlFsStat
 		// e.g. /dev/sda -> sda, /rootfs/dev/md1 -> md1
 		_, device := path.Split(dev.path)
 
-		extraLabels := []string{"device", "device_uuid"}
+		extraLabels := []string{"device", "btrfs_dev_uuid"}
 		extraLabelValues := []string{device, dev.uuid}
 
 		metrics = append(metrics,

--- a/collector/btrfs_linux.go
+++ b/collector/btrfs_linux.go
@@ -73,14 +73,6 @@ func (c *btrfsCollector) Update(ch chan<- prometheus.Metric) error {
 	return nil
 }
 
-var errorStatTypeNames = []string{
-	"write",
-	"read",
-	"flush",
-	"corruption",
-	"generation",
-}
-
 type ioctlFsDeviceStats struct {
 	path string
 	uuid string
@@ -88,6 +80,9 @@ type ioctlFsDeviceStats struct {
 	bytesUsed  uint64
 	totalBytes uint64
 
+	// The error stats below match the following upstream lists:
+	// https://github.com/dennwc/btrfs/blob/b3db0b2dedac3bf580f412034d77e0bf4b420167/btrfs.go#L132-L140
+	// https://github.com/torvalds/linux/blob/70d605cbeecb408dd884b1f0cd3963eeeaac144c/include/uapi/linux/btrfs.h#L680-L692
 	writeErrs      uint64
 	readErrs       uint64
 	flushErrs      uint64
@@ -325,7 +320,15 @@ func (c *btrfsCollector) getMetrics(s *btrfs.Stats, iocStats *ioctlFsStats) []bt
 				dev.corruptionErrs,
 				dev.generationErrs,
 			}
-			for i, errorType := range errorStatTypeNames {
+			btrfsErrorTypeNames := []string{
+				"write",
+				"read",
+				"flush",
+				"corruption",
+				"generation",
+			}
+
+			for i, errorType := range btrfsErrorTypeNames {
 				metrics = append(metrics,
 					btrfsMetric{
 						name:            "device_errors_total",

--- a/collector/btrfs_linux.go
+++ b/collector/btrfs_linux.go
@@ -17,7 +17,11 @@
 package collector
 
 import (
+	"bytes"
 	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -52,14 +56,212 @@ func NewBtrfsCollector(logger log.Logger) (Collector, error) {
 func (c *btrfsCollector) Update(ch chan<- prometheus.Metric) error {
 	stats, err := c.fs.Stats()
 	if err != nil {
-		return fmt.Errorf("failed to retrieve Btrfs stats: %w", err)
+		return fmt.Errorf("failed to retrieve Btrfs stats from procfs: %w", err)
+	}
+
+	ioctlStatsMap, err := c.getIoctlStats()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve Btrfs stats with ioctl: %w", err)
 	}
 
 	for _, s := range stats {
-		c.updateBtrfsStats(ch, s)
+		// match up procfs and ioctl info by filesystem UUID
+		ioctlStats := ioctlStatsMap[s.UUID]
+		c.updateBtrfsStats(ch, s, ioctlStats)
 	}
 
 	return nil
+}
+
+type ioctlFsDeviceStats struct {
+	path string
+	uuid string
+
+	bytesUsed  uint64
+	totalBytes uint64
+
+	writeErrors      uint64
+	readErrors       uint64
+	flushErrors      uint64
+	corruptionErrors uint64
+	generationErrors uint64
+}
+
+type ioctlFsStats struct {
+	uuid       string
+	mountPoint string
+	devices    []ioctlFsDeviceStats
+}
+
+func (c *btrfsCollector) getIoctlStats() (map[string]*ioctlFsStats, error) {
+	// Instead of introducing more ioctl calls to scan for all btrfs
+	// filesytems re-use our mount point utils to find known mounts
+	mountsList, err := mountPointDetails(c.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	btrfsMounts := []string{}
+	for _, mount := range mountsList {
+		if mount.fsType == "btrfs" {
+			btrfsMounts = append(btrfsMounts, mount.mountPoint)
+		}
+	}
+
+	var statsMap = make(map[string]*ioctlFsStats, len(btrfsMounts))
+
+	for _, mountPoint := range btrfsMounts {
+		ioctlStats, err := c.getIoctlFsStats(mountPoint)
+		if err != nil {
+			return nil, err
+		}
+		statsMap[ioctlStats.uuid] = ioctlStats
+	}
+
+	return statsMap, nil
+}
+
+// Magic constants for ioctl
+//nolint:revive
+const (
+	_BTRFS_IOC_FS_INFO       = 0x8400941F
+	_BTRFS_IOC_DEV_INFO      = 0xD000941E
+	_BTRFS_IOC_GET_DEV_STATS = 0x00c4089434
+)
+
+// Known/supported device stats fields
+//nolint:revive
+const (
+	// direct indicators of I/O failures:
+
+	_BTRFS_DEV_STAT_WRITE_ERRS = iota
+	_BTRFS_DEV_STAT_READ_ERRS
+	_BTRFS_DEV_STAT_FLUSH_ERRS
+
+	// indirect indicators of I/O failures:
+
+	_BTRFS_DEV_STAT_CORRUPTION_ERRS // checksum error, bytenr error or contents is illegal
+	_BTRFS_DEV_STAT_GENERATION_ERRS // an indication that blocks have not been written
+
+	_BTRFS_DEV_STAT_VALUES_MAX // counter to indicate the number of known stats we support
+)
+
+type _UuidBytes [16]byte
+
+func (id _UuidBytes) String() string {
+	return fmt.Sprintf("%x-%x-%x-%x-%x", id[0:4], id[4:6], id[6:8], id[8:10], id[10:])
+}
+
+//name matches linux struct
+//nolint:revive
+type btrfs_ioctl_fs_info_args struct {
+	maxID          uint64          // out
+	numDevices     uint64          // out
+	fsID           _UuidBytes      // out
+	nodeSize       uint32          // out
+	sectorSize     uint32          // out
+	cloneAlignment uint32          // out
+	_              [122*8 + 4]byte // pad to 1k
+}
+
+//name matches linux struct
+//nolint:revive
+type btrfs_ioctl_dev_info_args struct {
+	deviceID   uint64      // in/out
+	uuid       _UuidBytes  // in/out
+	bytesUsed  uint64      // out
+	totalBytes uint64      // out
+	_          [379]uint64 // pad to 4k
+	path       [1024]byte  // out
+}
+
+//name matches linux struct
+//nolint:revive
+type btrfs_ioctl_get_dev_stats struct {
+	deviceID  uint64                                       // in
+	itemCount uint64                                       // in/out
+	flags     uint64                                       // in/out
+	values    [_BTRFS_DEV_STAT_VALUES_MAX]uint64           // out values
+	_         [128 - 2 - _BTRFS_DEV_STAT_VALUES_MAX]uint64 // pad to 1k
+}
+
+func (c *btrfsCollector) getIoctlFsStats(mountPoint string) (*ioctlFsStats, error) {
+	fd, err := os.Open(mountPoint)
+	if err != nil {
+		return nil, err
+	}
+
+	var fsInfo = btrfs_ioctl_fs_info_args{}
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		fd.Fd(),
+		_BTRFS_IOC_FS_INFO,
+		uintptr(unsafe.Pointer(&fsInfo)))
+	if errno != 0 {
+		return nil, err
+	}
+
+	devices := make([]ioctlFsDeviceStats, 0, fsInfo.numDevices)
+
+	var deviceInfo btrfs_ioctl_dev_info_args
+	var deviceStats btrfs_ioctl_get_dev_stats
+
+	for i := uint64(0); i <= fsInfo.maxID; i++ {
+		deviceInfo = btrfs_ioctl_dev_info_args{
+			deviceID: i,
+		}
+		deviceStats = btrfs_ioctl_get_dev_stats{
+			deviceID:  i,
+			itemCount: _BTRFS_DEV_STAT_VALUES_MAX,
+		}
+
+		_, _, errno := syscall.Syscall(
+			syscall.SYS_IOCTL,
+			fd.Fd(),
+			uintptr(_BTRFS_IOC_DEV_INFO),
+			uintptr(unsafe.Pointer(&deviceInfo)))
+
+		if errno == syscall.ENODEV {
+			// device IDs do not consistently start at 0, so we expect this
+			continue
+		}
+		if errno != 0 {
+			return nil, errno
+		}
+
+		_, _, errno = syscall.Syscall(
+			syscall.SYS_IOCTL,
+			fd.Fd(),
+			uintptr(_BTRFS_IOC_GET_DEV_STATS),
+			uintptr(unsafe.Pointer(&deviceStats)))
+
+		if errno != 0 {
+			return nil, errno
+		}
+
+		devices = append(devices, ioctlFsDeviceStats{
+			path:       string(bytes.Trim(deviceInfo.path[:], "\x00")),
+			uuid:       deviceInfo.uuid.String(),
+			bytesUsed:  deviceInfo.bytesUsed,
+			totalBytes: deviceInfo.totalBytes,
+
+			writeErrors:      deviceStats.values[_BTRFS_DEV_STAT_WRITE_ERRS],
+			readErrors:       deviceStats.values[_BTRFS_DEV_STAT_READ_ERRS],
+			flushErrors:      deviceStats.values[_BTRFS_DEV_STAT_FLUSH_ERRS],
+			corruptionErrors: deviceStats.values[_BTRFS_DEV_STAT_CORRUPTION_ERRS],
+			generationErrors: deviceStats.values[_BTRFS_DEV_STAT_GENERATION_ERRS],
+		})
+
+		if uint64(len(devices)) == fsInfo.numDevices {
+			break
+		}
+	}
+
+	return &ioctlFsStats{
+		mountPoint: mountPoint,
+		uuid:       fsInfo.fsID.String(),
+		devices:    devices,
+	}, nil
 }
 
 // btrfsMetric represents a single Btrfs metric that is converted into a Prometheus Metric.
@@ -72,14 +274,18 @@ type btrfsMetric struct {
 }
 
 // updateBtrfsStats collects statistics for one bcache ID.
-func (c *btrfsCollector) updateBtrfsStats(ch chan<- prometheus.Metric, s *btrfs.Stats) {
+func (c *btrfsCollector) updateBtrfsStats(ch chan<- prometheus.Metric, s *btrfs.Stats, iocStats *ioctlFsStats) {
 	const subsystem = "btrfs"
 
 	// Basic information about the filesystem.
 	devLabels := []string{"uuid"}
 
+	if iocStats != nil {
+		devLabels = append(devLabels, "mountpoint")
+	}
+
 	// Retrieve the metrics.
-	metrics := c.getMetrics(s)
+	metrics := c.getMetrics(s, iocStats)
 
 	// Convert all gathered metrics to Prometheus Metrics and add to channel.
 	for _, m := range metrics {
@@ -93,6 +299,9 @@ func (c *btrfsCollector) updateBtrfsStats(ch chan<- prometheus.Metric, s *btrfs.
 		)
 
 		labelValues := []string{s.UUID}
+		if iocStats != nil {
+			labelValues = append(labelValues, iocStats.mountPoint)
+		}
 		if len(m.extraLabelValue) > 0 {
 			labelValues = append(labelValues, m.extraLabelValue...)
 		}
@@ -107,7 +316,7 @@ func (c *btrfsCollector) updateBtrfsStats(ch chan<- prometheus.Metric, s *btrfs.
 }
 
 // getMetrics returns metrics for the given Btrfs statistics.
-func (c *btrfsCollector) getMetrics(s *btrfs.Stats) []btrfsMetric {
+func (c *btrfsCollector) getMetrics(s *btrfs.Stats, iocStats *ioctlFsStats) []btrfsMetric {
 	metrics := []btrfsMetric{
 		{
 			name:            "info",
@@ -124,14 +333,73 @@ func (c *btrfsCollector) getMetrics(s *btrfs.Stats) []btrfsMetric {
 	}
 
 	// Information about devices.
-	for n, dev := range s.Devices {
-		metrics = append(metrics, btrfsMetric{
-			name:            "device_size_bytes",
-			desc:            "Size of a device that is part of the filesystem.",
-			value:           float64(dev.Size),
-			extraLabel:      []string{"device"},
-			extraLabelValue: []string{n},
-		})
+	if iocStats == nil {
+		for n, dev := range s.Devices {
+			metrics = append(metrics, btrfsMetric{
+				name:            "device_size_bytes",
+				desc:            "Size of a device that is part of the filesystem.",
+				value:           float64(dev.Size),
+				extraLabel:      []string{"device"},
+				extraLabelValue: []string{n},
+			})
+		}
+	} else {
+		for _, dev := range iocStats.devices {
+			extraLabels := []string{"device", "device_uuid"}
+			extraLabelValues := []string{dev.path, dev.uuid}
+			metrics = append(metrics,
+				btrfsMetric{
+					name:            "device_size_bytes",
+					desc:            "Size of a device that is part of the filesystem.",
+					value:           float64(dev.totalBytes),
+					extraLabel:      extraLabels,
+					extraLabelValue: extraLabelValues,
+				},
+				btrfsMetric{
+					name:            "device_used_bytes",
+					desc:            "Bytes used on a device that is part of the filesystem.",
+					value:           float64(dev.bytesUsed),
+					extraLabel:      extraLabels,
+					extraLabelValue: extraLabelValues,
+				},
+				// TODO should the below metrics be a single metric with a varying 'error_type' label?
+				btrfsMetric{
+					name:            "device_write_errors",
+					desc:            "TODO",
+					value:           float64(dev.writeErrors),
+					extraLabel:      extraLabels,
+					extraLabelValue: extraLabelValues,
+				},
+				btrfsMetric{
+					name:            "device_read_errors",
+					desc:            "TODO",
+					value:           float64(dev.readErrors),
+					extraLabel:      extraLabels,
+					extraLabelValue: extraLabelValues,
+				},
+				btrfsMetric{
+					name:            "device_flush_errors",
+					desc:            "TODO",
+					value:           float64(dev.flushErrors),
+					extraLabel:      extraLabels,
+					extraLabelValue: extraLabelValues,
+				},
+				btrfsMetric{
+					name:            "device_corruption_errors",
+					desc:            "TODO",
+					value:           float64(dev.corruptionErrors),
+					extraLabel:      extraLabels,
+					extraLabelValue: extraLabelValues,
+				},
+				btrfsMetric{
+					name:            "device_generation_errors",
+					desc:            "TODO",
+					value:           float64(dev.generationErrors),
+					extraLabel:      extraLabels,
+					extraLabelValue: extraLabelValues,
+				},
+			)
+		}
 	}
 
 	// Information about data, metadata and system data.

--- a/collector/btrfs_linux_test.go
+++ b/collector/btrfs_linux_test.go
@@ -27,8 +27,6 @@ var expectedBtrfsMetrics = [][]btrfsMetric{
 	{
 		{name: "info", value: 1, extraLabel: []string{"label"}, extraLabelValue: []string{"fixture"}},
 		{name: "global_rsv_size_bytes", value: 1.6777216e+07},
-		{name: "device_size_bytes", value: 1.073741824e+10, extraLabel: []string{"device"}, extraLabelValue: []string{"loop25"}},
-		{name: "device_size_bytes", value: 1.073741824e+10, extraLabel: []string{"device"}, extraLabelValue: []string{"loop26"}},
 		{name: "reserved_bytes", value: 0, extraLabel: []string{"block_group_type"}, extraLabelValue: []string{"data"}},
 		{name: "used_bytes", value: 8.08189952e+08, extraLabel: []string{"block_group_type", "mode"}, extraLabelValue: []string{"data", "raid0"}},
 		{name: "size_bytes", value: 2.147483648e+09, extraLabel: []string{"block_group_type", "mode"}, extraLabelValue: []string{"data", "raid0"}},
@@ -41,14 +39,12 @@ var expectedBtrfsMetrics = [][]btrfsMetric{
 		{name: "used_bytes", value: 16384, extraLabel: []string{"block_group_type", "mode"}, extraLabelValue: []string{"system", "raid1"}},
 		{name: "size_bytes", value: 8.388608e+06, extraLabel: []string{"block_group_type", "mode"}, extraLabelValue: []string{"system", "raid1"}},
 		{name: "allocation_ratio", value: 2, extraLabel: []string{"block_group_type", "mode"}, extraLabelValue: []string{"system", "raid1"}},
+		{name: "device_size_bytes", value: 1.073741824e+10, extraLabel: []string{"device"}, extraLabelValue: []string{"loop25"}},
+		{name: "device_size_bytes", value: 1.073741824e+10, extraLabel: []string{"device"}, extraLabelValue: []string{"loop26"}},
 	},
 	{
 		{name: "info", value: 1, extraLabel: []string{"label"}, extraLabelValue: []string{""}},
 		{name: "global_rsv_size_bytes", value: 1.6777216e+07},
-		{name: "device_size_bytes", value: 1.073741824e+10, extraLabel: []string{"device"}, extraLabelValue: []string{"loop22"}},
-		{name: "device_size_bytes", value: 1.073741824e+10, extraLabel: []string{"device"}, extraLabelValue: []string{"loop23"}},
-		{name: "device_size_bytes", value: 1.073741824e+10, extraLabel: []string{"device"}, extraLabelValue: []string{"loop24"}},
-		{name: "device_size_bytes", value: 1.073741824e+10, extraLabel: []string{"device"}, extraLabelValue: []string{"loop25"}},
 		{name: "reserved_bytes", value: 0, extraLabel: []string{"block_group_type"}, extraLabelValue: []string{"data"}},
 		{name: "used_bytes", value: 0, extraLabel: []string{"block_group_type", "mode"}, extraLabelValue: []string{"data", "raid5"}},
 		{name: "size_bytes", value: 6.44087808e+08, extraLabel: []string{"block_group_type", "mode"}, extraLabelValue: []string{"data", "raid5"}},
@@ -61,6 +57,10 @@ var expectedBtrfsMetrics = [][]btrfsMetric{
 		{name: "used_bytes", value: 16384, extraLabel: []string{"block_group_type", "mode"}, extraLabelValue: []string{"system", "raid6"}},
 		{name: "size_bytes", value: 1.6777216e+07, extraLabel: []string{"block_group_type", "mode"}, extraLabelValue: []string{"system", "raid6"}},
 		{name: "allocation_ratio", value: 2, extraLabel: []string{"block_group_type", "mode"}, extraLabelValue: []string{"system", "raid6"}},
+		{name: "device_size_bytes", value: 1.073741824e+10, extraLabel: []string{"device"}, extraLabelValue: []string{"loop22"}},
+		{name: "device_size_bytes", value: 1.073741824e+10, extraLabel: []string{"device"}, extraLabelValue: []string{"loop23"}},
+		{name: "device_size_bytes", value: 1.073741824e+10, extraLabel: []string{"device"}, extraLabelValue: []string{"loop24"}},
+		{name: "device_size_bytes", value: 1.073741824e+10, extraLabel: []string{"device"}, extraLabelValue: []string{"loop25"}},
 	},
 }
 

--- a/collector/btrfs_linux_test.go
+++ b/collector/btrfs_linux_test.go
@@ -104,7 +104,7 @@ func TestBtrfs(t *testing.T) {
 	}
 
 	for i, s := range stats {
-		metrics := collector.getMetrics(s)
+		metrics := collector.getMetrics(s, nil)
 		if len(metrics) != len(expectedBtrfsMetrics[i]) {
 			t.Fatalf("Unexpected number of Btrfs metrics: expected %v, got %v", len(expectedBtrfsMetrics[i]), len(metrics))
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/prometheus/node_exporter
 require (
 	github.com/beevik/ntp v0.3.0
 	github.com/coreos/go-systemd/v22 v22.3.2
+	github.com/dennwc/btrfs v0.0.0-20220403080356-b3db0b2dedac
 	github.com/ema/qdisc v0.0.0-20200603082823-62d0308e3e00
 	github.com/go-kit/log v0.2.0
 	github.com/godbus/dbus/v5 v5.1.0

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,10 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dennwc/btrfs v0.0.0-20220403080356-b3db0b2dedac h1:cjfIEKdg/lZ+ewJk8FYoYZTN2HY/okVSPtmHLaYMAvE=
+github.com/dennwc/btrfs v0.0.0-20220403080356-b3db0b2dedac/go.mod h1:MYsOV9Dgsec3FFSOjywi0QK5r6TeBbdWxdrMGtiYXHA=
+github.com/dennwc/ioctl v1.0.0 h1:DsWAAjIxRqNcLn9x6mwfuf2pet3iB7aK90K4tF16rLg=
+github.com/dennwc/ioctl v1.0.0/go.mod h1:ellh2YB5ldny99SBU/VX7Nq0xiZbHphf1DrtHxxjMk0=
 github.com/ema/qdisc v0.0.0-20200603082823-62d0308e3e00 h1:0GHzegkDz/zSrt+Zph1OueNImPdUxoToypnkhhRYTjI=
 github.com/ema/qdisc v0.0.0-20200603082823-62d0308e3e00/go.mod h1:ix4kG2zvdUd8kEKSW0ZTr1XLks0epFpI4j745DXxlNE=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
Makes ioctl syscalls to load the device error stats you'd normally see using `btrfs device stats /mnt/myFs`.

On the command line, you'd normally see this kind of info via:
```
sudo btrfs device stats /mnt/fakebtrfs2
[/dev/loop1].write_io_errs    0
[/dev/loop1].read_io_errs     0
[/dev/loop1].flush_io_errs    0
[/dev/loop1].corruption_errs  0
[/dev/loop1].generation_errs  0
[/dev/loop2].write_io_errs    0
[/dev/loop2].read_io_errs     0
[/dev/loop2].flush_io_errs    0
[/dev/loop2].corruption_errs  0
[/dev/loop2].generation_errs  0
```

All feedback appreciated!

Requested in #2173 & #1100