### PR TITLE
Workaround LLVM/Clang 11.0 for Darwin builds

### DIFF
--- a/collector/cpu_darwin.go
+++ b/collector/cpu_darwin.go
@@ -39,6 +39,7 @@ import (
 #include <mach/mach_init.h>
 #include <mach/mach_host.h>
 #include <mach/host_info.h>
+#include <TargetConditionals.h>
 #if TARGET_OS_MAC
 #include <libproc.h>
 #endif


### PR DESCRIPTION
LLVM/Clang 11.0 adds a `-Wundef-prefix=TARGET_OS_` build flag which
breaks this build flag.

Signed-off-by: Ben Kochie <superq@gmail.com>