### PR TITLE
Remove redundant nil check

### DIFF
--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -142,10 +142,7 @@ func (c *cpuCollector) Update(ch chan<- prometheus.Metric) error {
 	if err := c.updateStat(ch); err != nil {
 		return err
 	}
-	if err := c.updateThermalThrottle(ch); err != nil {
-		return err
-	}
-	return nil
+	return c.updateThermalThrottle(ch)
 }
 
 // updateInfo reads /proc/cpuinfo

--- a/collector/drm_linux.go
+++ b/collector/drm_linux.go
@@ -99,11 +99,7 @@ func NewDrmCollector(logger log.Logger) (Collector, error) {
 }
 
 func (c *drmCollector) Update(ch chan<- prometheus.Metric) error {
-	if err := c.updateAMDCards(ch); err != nil {
-		return err
-	}
-
-	return nil
+	return c.updateAMDCards(ch)
 }
 
 func (c *drmCollector) updateAMDCards(ch chan<- prometheus.Metric) error {


### PR DESCRIPTION
'make' command fails because of 'golangci-lint'

```
collector/cpu_linux.go:145:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
        if err := c.updateThermalThrottle(ch); err != nil {
                return err
        }
collector/drm_linux.go:102:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
        if err := c.updateAMDCards(ch); err != nil {
                return err
        }
```