### PR TITLE
Update README dcgm-exporter repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ in Go with pluggable metric collectors.
 
 The [Windows exporter](https://github.com/prometheus-community/windows_exporter) is recommended for Windows users.
 To expose NVIDIA GPU metrics, [prometheus-dcgm
-](https://github.com/NVIDIA/gpu-monitoring-tools#dcgm-exporter)
+](https://github.com/NVIDIA/dcgm-exporter)
 can be used.
 
 ## Installation and Usage


### PR DESCRIPTION
Nvidia archived gpu-monitoring-tools and created new repos for each of it's 3 projects. This is the new repo for the dcgm-exporter project.