### PR TITLE
fix: only release ref when fetch thermal return success

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ softnet | Exposes statistics from `/proc/net/softnet_stat`. | Linux
 stat | Exposes various statistics from `/proc/stat`. This includes boot time, forks and interrupts. | Linux
 tapestats | Exposes statistics from `/sys/class/scsi_tape`. | Linux
 textfile | Exposes statistics read from local disk. The `--collector.textfile.directory` flag must be set. | _any_
-thermal | Exposes thermal statistics like `pmset -g therm`. | Darwin
+thermal | Exposes thermal statistics like `pmset -g therm`. | Darwin (does not support Apple Silicon)
 thermal\_zone | Exposes thermal zone & cooling device statistics from `/sys/class/thermal`. | Linux
 time | Exposes the current system time. | _any_
 timex | Exposes selected adjtimex(2) system call stats. | Linux

--- a/collector/thermal_darwin.go
+++ b/collector/thermal_darwin.go
@@ -118,7 +118,9 @@ func (c *thermCollector) Update(ch chan<- prometheus.Metric) error {
 func fetchCPUPowerStatus() (map[string]int, error) {
 	cfDictRef, _ := C.FetchThermal()
 	defer func() {
-		C.CFRelease(C.CFTypeRef(cfDictRef.ref))
+		if C.kIOReturnSuccess == cfDictRef.ret {
+			C.CFRelease(C.CFTypeRef(cfDictRef.ref))
+		}
 	}()
 
 	if C.kIOReturnNotFound == cfDictRef.ret {


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

fix: #2218

`thermal` collector for Apple M1 might not work well, because `IOPMCopyCPUPowerStatus` returns nothing on Apple M1. 

This PR only fix the panic crash on Apple M1.

Changes:

- Only release the reference when `FetchThermal()` returns `kIOReturnSuccess`