### PR TITLE
Ignore filesystems flagged as MNT_IGNORE.

### DIFF
--- a/collector/filesystem_freebsd.go
+++ b/collector/filesystem_freebsd.go
@@ -54,6 +54,11 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 			continue
 		}
 
+		if (fs.Flags & unix.MNT_IGNORE) != 0 {
+			level.Debug(c.logger).Log("msg", "Ignoring mount flagged as ignore", "mountpoint", mountpoint)
+			continue
+		}
+
 		var ro float64
 		if (fs.Flags & readOnly) != 0 {
 			ro = 1

--- a/collector/filesystem_freebsd.go
+++ b/collector/filesystem_freebsd.go
@@ -24,18 +24,16 @@ import (
 const (
 	defMountPointsExcluded = "^/(dev)($|/)"
 	defFSTypesExcluded     = "^devfs$"
-	readOnly               = 0x1 // MNT_RDONLY
-	noWait                 = 0x2 // MNT_NOWAIT
 )
 
 // Expose filesystem fullness.
 func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
-	n, err := unix.Getfsstat(nil, noWait)
+	n, err := unix.Getfsstat(nil, unix.MNT_NOWAIT)
 	if err != nil {
 		return nil, err
 	}
 	buf := make([]unix.Statfs_t, n)
-	_, err = unix.Getfsstat(buf, noWait)
+	_, err = unix.Getfsstat(buf, unix.MNT_NOWAIT)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +58,7 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 		}
 
 		var ro float64
-		if (fs.Flags & readOnly) != 0 {
+		if (fs.Flags & unix.MNT_RDONLY) != 0 {
 			ro = 1
 		}
 


### PR DESCRIPTION
Closes #2152.

I noticed that `MNT_READONLY` and `MNT_NOWAIT` are available under `unix` dependency as well, is there a reason they were defined as local constants instead of relying on the external library?

In this PR I made the shortest change possible and used the library for the new flag, but if you'd like me to use this PR to change those two as well (or, on the opposite, define also this third one as local constant), tell me.