### PR TITLE
add darwin mixin

### DIFF
--- a/docs/node-mixin/darwin-mixin.libsonnet
+++ b/docs/node-mixin/darwin-mixin.libsonnet
@@ -1,0 +1,4 @@
+(import 'config.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'dashboards/darwin-dashboards.libsonnet') +
+(import 'rules/rules.libsonnet')

--- a/docs/node-mixin/dashboards/darwin-dashboards.libsonnet
+++ b/docs/node-mixin/dashboards/darwin-dashboards.libsonnet
@@ -1,0 +1,2 @@
+(import 'darwin-node.libsonnet') +
+(import 'use.libsonnet')

--- a/docs/node-mixin/dashboards/darwin-node.libsonnet
+++ b/docs/node-mixin/dashboards/darwin-node.libsonnet
@@ -1,0 +1,293 @@
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local row = grafana.row;
+local prometheus = grafana.prometheus;
+local template = grafana.template;
+local graphPanel = grafana.graphPanel;
+local promgrafonnet = import 'github.com/kubernetes-monitoring/kubernetes-mixin/lib/promgrafonnet/promgrafonnet.libsonnet';
+local gauge = promgrafonnet.gauge;
+
+{
+  grafanaDashboards+:: {
+    'nodes.json':
+      local idleCPU =
+        graphPanel.new(
+          'CPU Usage',
+          datasource='$datasource',
+          span=6,
+          format='percentunit',
+          max=1,
+          min=0,
+          stack=true,
+        )
+        .addTarget(prometheus.target(
+          |||
+            (
+              (1 - sum without (mode) (rate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode=~"idle|iowait|steal", instance="$instance"}[$__rate_interval])))
+            / ignoring(cpu) group_left
+              count without (cpu, mode) (node_cpu_seconds_total{%(nodeExporterSelector)s, mode="idle", instance="$instance"})
+            )
+          ||| % $._config,
+          legendFormat='{{cpu}}',
+          intervalFactor=5,
+        ));
+
+      local systemLoad =
+        graphPanel.new(
+          'Load Average',
+          datasource='$datasource',
+          span=6,
+          format='short',
+          min=0,
+          fill=0,
+        )
+        .addTarget(prometheus.target('node_load1{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='1m load average'))
+        .addTarget(prometheus.target('node_load5{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='5m load average'))
+        .addTarget(prometheus.target('node_load15{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='15m load average'))
+        .addTarget(prometheus.target('count(node_cpu_seconds_total{%(nodeExporterSelector)s, instance="$instance", mode="idle"})' % $._config, legendFormat='logical cores'));
+
+      local memoryGraph =
+        graphPanel.new(
+          'Memory Usage',
+          datasource='$datasource',
+          span=9,
+          format='bytes',
+          stack=false,
+          min=0,
+        )
+        .addTarget(prometheus.target(
+          |||
+            (
+              node_memory_total_bytes{%(nodeExporterSelector)s, instance="$instance"}
+            )
+          ||| % $._config, legendFormat='Physical Memory'
+        ))
+        .addTarget(prometheus.target(
+          |||
+            (
+                node_memory_total_bytes{%(nodeExporterSelector)s, instance="$instance"}
+                -
+                (
+                    node_memory_free_bytes{%(nodeExporterSelector)s, instance="$instance"}
+                    +
+                    node_memory_inactive_bytes{%(nodeExporterSelector)s, instance="$instance"}
+                )
+                +
+                node_memory_wired_bytes{%(nodeExporterSelector)s, instance="$instance"}
+                +
+                node_memory_compressed_bytes{%(nodeExporterSelector)s, instance="$instance"}
+            )
+          ||| % $._config, legendFormat='Memory Used'
+        ))
+        .addTarget(prometheus.target(
+          |||
+            (
+                node_memory_total_bytes{%(nodeExporterSelector)s, instance="$instance"}
+                -
+                (
+                    node_memory_free_bytes{%(nodeExporterSelector)s, instance="$instance"}
+                    +
+                    node_memory_inactive_bytes{%(nodeExporterSelector)s, instance="$instance"}
+                )
+            )
+          ||| % $._config, legendFormat='App Memory'
+        ))
+        .addTarget(prometheus.target('node_memory_wired_bytes{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='Wired Memory'))
+        .addTarget(prometheus.target('node_memory_compressed_bytes{%(nodeExporterSelector)s, instance="$instance"}' % $._config, legendFormat='Compressed'));
+
+      // TODO: It would be nicer to have a gauge that gets a 0-1 range and displays it as a percentage 0%-100%.
+      // This needs to be added upstream in the promgrafonnet library and then changed here.
+      // NOTE: avg() is used to circumvent a label change caused by a node_exporter rollout.
+      local memoryGauge = gauge.new(
+        'Memory Usage',
+        |||
+            (
+                (
+                    (
+                        avg(node_memory_total_bytes{%(nodeExporterSelector)s, instance="$instance"})
+                        -
+                        (
+                            avg(node_memory_free_bytes{%(nodeExporterSelector)s, instance="$instance"})
+                            +
+                            avg(node_memory_inactive_bytes{%(nodeExporterSelector)s, instance="$instance"})
+                         )
+                     )
+                     +
+                     avg(node_memory_wired_bytes{%(nodeExporterSelector)s, instance="$instance"})
+                     +
+                     avg(node_memory_compressed_bytes{%(nodeExporterSelector)s, instance="$instance"})
+                )
+                /
+                avg(node_memory_total_bytes{%(nodeExporterSelector)s, instance="$instance"})
+            )
+            *
+            100
+        ||| % $._config,
+      ).withLowerBeingBetter();
+
+      local diskIO =
+        graphPanel.new(
+          'Disk I/O',
+          datasource='$datasource',
+          span=6,
+          min=0,
+          fill=0,
+        )
+        // TODO: Does it make sense to have those three in the same panel?
+        .addTarget(prometheus.target(
+          'rate(node_disk_read_bytes_total{%(nodeExporterSelector)s, instance="$instance", %(diskDeviceSelector)s}[$__rate_interval])' % $._config,
+          legendFormat='{{device}} read',
+        ))
+        .addTarget(prometheus.target(
+          'rate(node_disk_written_bytes_total{%(nodeExporterSelector)s, instance="$instance", %(diskDeviceSelector)s}[$__rate_interval])' % $._config,
+          legendFormat='{{device}} written',
+        ))
+        .addTarget(prometheus.target(
+          'rate(node_disk_io_time_seconds_total{%(nodeExporterSelector)s, instance="$instance", %(diskDeviceSelector)s}[$__rate_interval])' % $._config,
+          legendFormat='{{device}} io time',
+        )) +
+        {
+          seriesOverrides: [
+            {
+              alias: '/ read| written/',
+              yaxis: 1,
+            },
+            {
+              alias: '/ io time/',
+              yaxis: 2,
+            },
+          ],
+          yaxes: [
+            self.yaxe(format='bytes'),
+            self.yaxe(format='s'),
+          ],
+        };
+
+      // TODO: Somehow partition this by device while excluding read-only devices.
+      local diskSpaceUsage =
+        graphPanel.new(
+          'Disk Space Usage',
+          datasource='$datasource',
+          span=6,
+          format='bytes',
+          min=0,
+          fill=1,
+          stack=true,
+        )
+        .addTarget(prometheus.target(
+          |||
+            sum(
+              max by (device) (
+                node_filesystem_size_bytes{%(nodeExporterSelector)s, instance="$instance", %(fsSelector)s}
+              -
+                node_filesystem_avail_bytes{%(nodeExporterSelector)s, instance="$instance", %(fsSelector)s}
+              )
+            )
+          ||| % $._config,
+          legendFormat='used',
+        ))
+        .addTarget(prometheus.target(
+          |||
+            sum(
+              max by (device) (
+                node_filesystem_avail_bytes{%(nodeExporterSelector)s, instance="$instance", %(fsSelector)s}
+              )
+            )
+          ||| % $._config,
+          legendFormat='available',
+        )) +
+        {
+          seriesOverrides: [
+            {
+              alias: 'used',
+              color: '#E0B400',
+            },
+            {
+              alias: 'available',
+              color: '#73BF69',
+            },
+          ],
+        };
+
+      local networkReceived =
+        graphPanel.new(
+          'Network Received',
+          datasource='$datasource',
+          span=6,
+          format='bytes',
+          min=0,
+          fill=0,
+        )
+        .addTarget(prometheus.target(
+          'rate(node_network_receive_bytes_total{%(nodeExporterSelector)s, instance="$instance", device!="lo"}[$__rate_interval])' % $._config,
+          legendFormat='{{device}}',
+        ));
+
+      local networkTransmitted =
+        graphPanel.new(
+          'Network Transmitted',
+          datasource='$datasource',
+          span=6,
+          format='bytes',
+          min=0,
+          fill=0,
+        )
+        .addTarget(prometheus.target(
+          'rate(node_network_transmit_bytes_total{%(nodeExporterSelector)s, instance="$instance", device!="lo"}[$__rate_interval])' % $._config,
+          legendFormat='{{device}}',
+        ));
+
+      dashboard.new(
+        '%sNodes' % $._config.dashboardNamePrefix,
+        time_from='now-1h',
+        tags=($._config.dashboardTags),
+        timezone='utc',
+        refresh='30s',
+        graphTooltip='shared_crosshair'
+      )
+      .addTemplate(
+        {
+          current: {
+            text: 'Prometheus',
+            value: 'Prometheus',
+          },
+          hide: 0,
+          label: 'Data Source',
+          name: 'datasource',
+          options: [],
+          query: 'prometheus',
+          refresh: 1,
+          regex: '',
+          type: 'datasource',
+        },
+      )
+      .addTemplate(
+        template.new(
+          'instance',
+          '$datasource',
+          'label_values(node_exporter_build_info{%(nodeExporterSelector)s}, instance)' % $._config,
+          refresh='time',
+        )
+      )
+      .addRow(
+        row.new()
+        .addPanel(idleCPU)
+        .addPanel(systemLoad)
+      )
+      .addRow(
+        row.new()
+        .addPanel(memoryGraph)
+        .addPanel(memoryGauge)
+      )
+      .addRow(
+        row.new()
+        .addPanel(diskIO)
+        .addPanel(diskSpaceUsage)
+      )
+      .addRow(
+        row.new()
+        .addPanel(networkReceived)
+        .addPanel(networkTransmitted)
+      ),
+  },
+}

--- a/docs/node-mixin/dashboards/darwin-node.libsonnet
+++ b/docs/node-mixin/dashboards/darwin-node.libsonnet
@@ -65,13 +65,9 @@ local gauge = promgrafonnet.gauge;
         .addTarget(prometheus.target(
           |||
             (
-                node_memory_total_bytes{%(nodeExporterSelector)s, instance="$instance"}
+                node_memory_internal_bytes{%(nodeExporterSelector)s, instance="$instance"}
                 -
-                (
-                    node_memory_free_bytes{%(nodeExporterSelector)s, instance="$instance"}
-                    +
-                    node_memory_inactive_bytes{%(nodeExporterSelector)s, instance="$instance"}
-                )
+                node_memory_purgeable_bytes{%(nodeExporterSelector)s, instance="$instance"}
                 +
                 node_memory_wired_bytes{%(nodeExporterSelector)s, instance="$instance"}
                 +
@@ -82,13 +78,9 @@ local gauge = promgrafonnet.gauge;
         .addTarget(prometheus.target(
           |||
             (
-                node_memory_total_bytes{%(nodeExporterSelector)s, instance="$instance"}
+                node_memory_internal_bytes{%(nodeExporterSelector)s, instance="$instance"}
                 -
-                (
-                    node_memory_free_bytes{%(nodeExporterSelector)s, instance="$instance"}
-                    +
-                    node_memory_inactive_bytes{%(nodeExporterSelector)s, instance="$instance"}
-                )
+                node_memory_purgeable_bytes{%(nodeExporterSelector)s, instance="$instance"}
             )
           ||| % $._config, legendFormat='App Memory'
         ))
@@ -103,19 +95,13 @@ local gauge = promgrafonnet.gauge;
         |||
           (
               (
-                  (
-                      avg(node_memory_total_bytes{%(nodeExporterSelector)s, instance="$instance"})
-                      -
-                      (
-                          avg(node_memory_free_bytes{%(nodeExporterSelector)s, instance="$instance"})
-                          +
-                          avg(node_memory_inactive_bytes{%(nodeExporterSelector)s, instance="$instance"})
-                       )
-                   )
-                   +
-                   avg(node_memory_wired_bytes{%(nodeExporterSelector)s, instance="$instance"})
-                   +
-                   avg(node_memory_compressed_bytes{%(nodeExporterSelector)s, instance="$instance"})
+                avg(node_memory_internal_bytes{%(nodeExporterSelector)s, instance="$instance"})
+                -
+                avg(node_memory_purgeable_bytes{%(nodeExporterSelector)s, instance="$instance"})
+                +
+                avg(node_memory_wired_bytes{%(nodeExporterSelector)s, instance="$instance"})
+                +
+                avg(node_memory_compressed_bytes{%(nodeExporterSelector)s, instance="$instance"})
               )
               /
               avg(node_memory_total_bytes{%(nodeExporterSelector)s, instance="$instance"})

--- a/docs/node-mixin/dashboards/darwin-node.libsonnet
+++ b/docs/node-mixin/dashboards/darwin-node.libsonnet
@@ -101,27 +101,27 @@ local gauge = promgrafonnet.gauge;
       local memoryGauge = gauge.new(
         'Memory Usage',
         |||
-            (
-                (
-                    (
-                        avg(node_memory_total_bytes{%(nodeExporterSelector)s, instance="$instance"})
-                        -
-                        (
-                            avg(node_memory_free_bytes{%(nodeExporterSelector)s, instance="$instance"})
-                            +
-                            avg(node_memory_inactive_bytes{%(nodeExporterSelector)s, instance="$instance"})
-                         )
-                     )
-                     +
-                     avg(node_memory_wired_bytes{%(nodeExporterSelector)s, instance="$instance"})
-                     +
-                     avg(node_memory_compressed_bytes{%(nodeExporterSelector)s, instance="$instance"})
-                )
-                /
-                avg(node_memory_total_bytes{%(nodeExporterSelector)s, instance="$instance"})
-            )
-            *
-            100
+          (
+              (
+                  (
+                      avg(node_memory_total_bytes{%(nodeExporterSelector)s, instance="$instance"})
+                      -
+                      (
+                          avg(node_memory_free_bytes{%(nodeExporterSelector)s, instance="$instance"})
+                          +
+                          avg(node_memory_inactive_bytes{%(nodeExporterSelector)s, instance="$instance"})
+                       )
+                   )
+                   +
+                   avg(node_memory_wired_bytes{%(nodeExporterSelector)s, instance="$instance"})
+                   +
+                   avg(node_memory_compressed_bytes{%(nodeExporterSelector)s, instance="$instance"})
+              )
+              /
+              avg(node_memory_total_bytes{%(nodeExporterSelector)s, instance="$instance"})
+          )
+          *
+          100
         ||| % $._config,
       ).withLowerBeingBetter();
 


### PR DESCRIPTION
This PR adds support for Darwin dashboards in the mixin. The memory usage statistics do not work with the existing dashboards as they use metrics gathered from Linux's meminfo collector. This updates the memory sections in Darwin dashboard to use the vmstat metrics collected in meminfo_darwin.go