### PR TITLE
add additional vm_stat memory metrics for darwin

### DIFF
--- a/collector/meminfo_darwin.go
+++ b/collector/meminfo_darwin.go
@@ -68,6 +68,8 @@ func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 		"free_bytes":              ps * float64(vmstat.free_count),
 		"swapped_in_bytes_total":  ps * float64(vmstat.pageins),
 		"swapped_out_bytes_total": ps * float64(vmstat.pageouts),
+		"internal_bytes":          ps * float64(vmstat.internal_page_count),
+		"purgeable_bytes":         ps * float64(vmstat.purgeable_count),
 		"total_bytes":             float64(total),
 		"swap_used_bytes":         float64(swap.xsu_used),
 		"swap_total_bytes":        float64(swap.xsu_total),


### PR DESCRIPTION
I was recently working on some changes to the mixin for Darwin dashboards (see https://github.com/prometheus/node_exporter/pull/2236), specfically around memory usage, and noticed that the way I was calculating the memory is likely incorrect. I'm attempting to calculate the memory usage statistics as close to what Apple's Activity Monitor does (e.g. App Memory in this case).  From what I can tell App Memory is calculated from `(vmstat.internal_page_count - vmstat.purgeable_count) * pageSize` 

Please let me know if there's any issues with exposing these additional values from vmstat in the Darwin meminfoCollector.