### PR TITLE
Include IPv4 Packet Reassembly in netstat metrics 

### DIFF
--- a/collector/netstat_linux.go
+++ b/collector/netstat_linux.go
@@ -36,7 +36,7 @@ const (
 )
 
 var (
-	netStatFields = kingpin.Flag("collector.netstat.fields", "Regexp of fields to return for netstat collector.").Default("^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(Listen.*|Syncookies.*|TCPSynRetrans|TCPTimeouts)|Tcp_(ActiveOpens|InSegs|OutSegs|OutRsts|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts|RcvbufErrors|SndbufErrors))$").String()
+	netStatFields = kingpin.Flag("collector.netstat.fields", "Regexp of fields to return for netstat collector.").Default("^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(Listen.*|Syncookies.*|TCPSynRetrans|TCPTimeouts)|Tcp_(ActiveOpens|InSegs|OutSegs|OutRsts|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts|RcvbufErrors|SndbufErrors)|Ip_(ReasmTimeout|ReasmReqds|ReasmOKs|ReasmFails))$").String()
 )
 
 type netStatCollector struct {


### PR DESCRIPTION
Addition of following IPv4 Packet Reassembly metrics from /proc/net/snmp. This is helpful for identifying reassemble statistics on host server.

IpReasmTimeout - number of timeouts that occurred when attempting to reassemble IP fragments because all fragments were not received
IpReasmReqds - total number of fragments received by this IP instance that required reassembly
IpReasmOKs - number of successful reassembles into IP packets at this IP instance
IpReasmFails - number of reassembly failures detected by the IP re-assembly algorithm on this IP instance

Signed-off-by: Aditya Borgaonkar borg.aditya@gmail.com