### PR TITLE
Implement #2250: Add "isolated" metric on cpu collector on linux

### DIFF
--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -80,11 +80,10 @@ func NewCPUCollector(logger log.Logger) (Collector, error) {
 
 	isolcpus, err := sysfs.IsolatedCPUs()
 	if err != nil {
-		if os.IsNotExist(err) {
-			level.Debug(logger).Log("msg", "Could not open isolated file", "error", err)
-		} else {
+		if !os.IsNotExist(err) {
 			return nil, fmt.Errorf("Unable to get isolated cpus: %w", err)
 		}
+		level.Debug(logger).Log("msg", "Could not open isolated file", "error", err)
 	}
 
 	c := &cpuCollector{

--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -18,6 +18,7 @@ package collector
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -79,8 +80,11 @@ func NewCPUCollector(logger log.Logger) (Collector, error) {
 
 	isolcpus, err := sysfs.IsolatedCPUs()
 	if err != nil {
-		level.Warn(logger).Log("msg", "Unable to get isolated cpus, defaulting to []")
-		isolcpus = []uint16{}
+		if os.IsNotExist(err) {
+			level.Debug(logger).Log("msg", "Could not open isolated file", "error", err)
+		} else {
+			return nil, fmt.Errorf("Unable to get isolated cpus: %w", err)
+		}
 	}
 
 	c := &cpuCollector{

--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -299,34 +299,11 @@ func (c *cpuCollector) updateThermalThrottle(ch chan<- prometheus.Metric) error 
 	return nil
 }
 
-func contains(s []uint16, e uint16) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}
-
 // updateStat reads /proc/stat through procfs and exports CPU-related metrics.
 func (c *cpuCollector) updateIsolated(ch chan<- prometheus.Metric) error {
-	stats, err := c.fs.Stat()
-	if err != nil {
-		return err
-	}
-
-	c.updateCPUStats(stats.CPU)
-
-	// Acquire a lock to read the stats.
-	c.cpuStatsMutex.Lock()
-	defer c.cpuStatsMutex.Unlock()
-	for cpuID, _ := range c.cpuStats {
-		cpuNum := strconv.Itoa(cpuID)
-		isIsolated := 0.0
-		if contains(c.isolatedCpus, uint16(cpuID)) {
-			isIsolated = 1.0
-		}
-		ch <- prometheus.MustNewConstMetric(c.cpuIsolated, prometheus.GaugeValue, isIsolated, cpuNum)
+	for _, cpu := range c.isolatedCpus {
+		cpuNum := strconv.Itoa(int(cpu))
+		ch <- prometheus.MustNewConstMetric(c.cpuIsolated, prometheus.GaugeValue, 1.0, cpuNum)
 	}
 
 	return nil

--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -167,8 +167,8 @@ func (c *cpuCollector) Update(ch chan<- prometheus.Metric) error {
 	if err := c.updateStat(ch); err != nil {
 		return err
 	}
-	if err := c.updateIsolated(ch); err != nil {
-		return err
+	if c.isolatedCpus != nil {
+		c.updateIsolated(ch)
 	}
 	return c.updateThermalThrottle(ch)
 }

--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -79,7 +79,8 @@ func NewCPUCollector(logger log.Logger) (Collector, error) {
 
 	isolcpus, err := sysfs.IsolatedCPUs()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read isolcpus from sysfs: %w", err)
+		level.Warn(logger).Log("msg", "Unable to get isolated cpus, defaulting to []")
+		isolcpus = []uint16{}
 	}
 
 	c := &cpuCollector{

--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -304,14 +304,12 @@ func (c *cpuCollector) updateThermalThrottle(ch chan<- prometheus.Metric) error 
 	return nil
 }
 
-// updateStat reads /proc/stat through procfs and exports CPU-related metrics.
-func (c *cpuCollector) updateIsolated(ch chan<- prometheus.Metric) error {
+// updateIsolated reads /sys/devices/system/cpu/isolated through sysfs and exports isolation level metrics.
+func (c *cpuCollector) updateIsolated(ch chan<- prometheus.Metric) {
 	for _, cpu := range c.isolatedCpus {
 		cpuNum := strconv.Itoa(int(cpu))
 		ch <- prometheus.MustNewConstMetric(c.cpuIsolated, prometheus.GaugeValue, 1.0, cpuNum)
 	}
-
-	return nil
 }
 
 // updateStat reads /proc/stat through procfs and exports CPU-related metrics.

--- a/collector/cpu_linux_test.go
+++ b/collector/cpu_linux_test.go
@@ -104,3 +104,31 @@ func TestCPU(t *testing.T) {
 		t.Fatalf("should have %v CPU Stat: got %v", resetIdle, got)
 	}
 }
+func TestIsolatedParsingCPU(t *testing.T) {
+	var testParams = []struct {
+		in  []byte
+		res []uint16
+		err error
+	}{
+		{[]byte(""), []uint16{}, nil},
+		{[]byte("1\n"), []uint16{1}, nil},
+		{[]byte("1"), []uint16{1}, nil},
+		{[]byte("1,2"), []uint16{1, 2}, nil},
+		{[]byte("1-2"), []uint16{1, 2}, nil},
+		{[]byte("1-3"), []uint16{1, 2, 3}, nil},
+		{[]byte("1,2-4"), []uint16{1, 2, 3, 4}, nil},
+		{[]byte("1,3-4"), []uint16{1, 3, 4}, nil},
+		{[]byte("1,3-4,7,20-21"), []uint16{1, 3, 4, 7, 20, 21}, nil},
+	}
+	for _, params := range testParams {
+		t.Run("blabla", func(t *testing.T) {
+			res, err := parseIsolCpus(params.in)
+			if !reflect.DeepEqual(res, params.res) {
+				t.Fatalf("should have %v result: got %v", params.res, res)
+			}
+			if err != params.err {
+				t.Fatalf("should have %v error: got %v", params.err, err)
+			}
+		})
+	}
+}

--- a/collector/cpu_linux_test.go
+++ b/collector/cpu_linux_test.go
@@ -104,31 +104,3 @@ func TestCPU(t *testing.T) {
 		t.Fatalf("should have %v CPU Stat: got %v", resetIdle, got)
 	}
 }
-func TestIsolatedParsingCPU(t *testing.T) {
-	var testParams = []struct {
-		in  []byte
-		res []uint16
-		err error
-	}{
-		{[]byte(""), []uint16{}, nil},
-		{[]byte("1\n"), []uint16{1}, nil},
-		{[]byte("1"), []uint16{1}, nil},
-		{[]byte("1,2"), []uint16{1, 2}, nil},
-		{[]byte("1-2"), []uint16{1, 2}, nil},
-		{[]byte("1-3"), []uint16{1, 2, 3}, nil},
-		{[]byte("1,2-4"), []uint16{1, 2, 3, 4}, nil},
-		{[]byte("1,3-4"), []uint16{1, 3, 4}, nil},
-		{[]byte("1,3-4,7,20-21"), []uint16{1, 3, 4, 7, 20, 21}, nil},
-	}
-	for _, params := range testParams {
-		t.Run("blabla", func(t *testing.T) {
-			res, err := parseIsolCpus(params.in)
-			if !reflect.DeepEqual(res, params.res) {
-				t.Fatalf("should have %v result: got %v", params.res, res)
-			}
-			if err != params.err {
-				t.Fatalf("should have %v error: got %v", params.err, err)
-			}
-		})
-	}
-}

--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -297,6 +297,13 @@ node_cpu_guest_seconds_total{cpu="6",mode="nice"} 0.07
 node_cpu_guest_seconds_total{cpu="6",mode="user"} 0.08
 node_cpu_guest_seconds_total{cpu="7",mode="nice"} 0.08
 node_cpu_guest_seconds_total{cpu="7",mode="user"} 0.09
+# HELP node_cpu_isolated Whether each core is isolated, information from /sys/devices/system/cpu/isolated.
+# TYPE node_cpu_isolated gauge
+node_cpu_isolated{cpu="1"} 1
+node_cpu_isolated{cpu="3"} 1
+node_cpu_isolated{cpu="4"} 1
+node_cpu_isolated{cpu="5"} 1
+node_cpu_isolated{cpu="9"} 1
 # HELP node_cpu_package_throttles_total Number of times this CPU package has been throttled.
 # TYPE node_cpu_package_throttles_total counter
 node_cpu_package_throttles_total{package="0"} 30

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -319,6 +319,16 @@ node_cpu_info{cachesize="8192 KB",core="2",cpu="2",family="6",microcode="0xb4",m
 node_cpu_info{cachesize="8192 KB",core="2",cpu="6",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
 node_cpu_info{cachesize="8192 KB",core="3",cpu="3",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
 node_cpu_info{cachesize="8192 KB",core="3",cpu="7",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
+# HELP node_cpu_isolated Whether each core is isolated, information from /sys/devices/system/cpu/isolated.
+# TYPE node_cpu_isolated gauge
+node_cpu_isolated{cpu="0"} 0
+node_cpu_isolated{cpu="1"} 1
+node_cpu_isolated{cpu="2"} 0
+node_cpu_isolated{cpu="3"} 1
+node_cpu_isolated{cpu="4"} 1
+node_cpu_isolated{cpu="5"} 1
+node_cpu_isolated{cpu="6"} 0
+node_cpu_isolated{cpu="7"} 0
 # HELP node_cpu_package_throttles_total Number of times this CPU package has been throttled.
 # TYPE node_cpu_package_throttles_total counter
 node_cpu_package_throttles_total{package="0"} 30

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -321,14 +321,11 @@ node_cpu_info{cachesize="8192 KB",core="3",cpu="3",family="6",microcode="0xb4",m
 node_cpu_info{cachesize="8192 KB",core="3",cpu="7",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
 # HELP node_cpu_isolated Whether each core is isolated, information from /sys/devices/system/cpu/isolated.
 # TYPE node_cpu_isolated gauge
-node_cpu_isolated{cpu="0"} 0
 node_cpu_isolated{cpu="1"} 1
-node_cpu_isolated{cpu="2"} 0
 node_cpu_isolated{cpu="3"} 1
 node_cpu_isolated{cpu="4"} 1
 node_cpu_isolated{cpu="5"} 1
-node_cpu_isolated{cpu="6"} 0
-node_cpu_isolated{cpu="7"} 0
+node_cpu_isolated{cpu="9"} 1
 # HELP node_cpu_package_throttles_total Number of times this CPU package has been throttled.
 # TYPE node_cpu_package_throttles_total counter
 node_cpu_package_throttles_total{package="0"} 30

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -3540,6 +3540,11 @@ Lines: 1
 1
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/cpu/isolated
+Lines: 1
+1,3-5,9
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/devices/system/edac
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Hi
This PR adds the "isolated" label on `cpu` collector for linux. 
I'm not sure if it should be added as a label on this collector or as a new metric, please let me know.

This is my first time writing go :grimacing:  so please let me know if I should be doing things differently