### PR TITLE
Add device filter flags to arp collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [BUGFIX]
 
 * [ENHANCEMENT] Add node_softirqs_total metric #2221
+* [ENHANCEMENT] Add device filter flags to arp collector #2254
 
 ## 1.3.1 / 2021-12-01
 

--- a/collector/fixtures/proc/net/arp
+++ b/collector/fixtures/proc/net/arp
@@ -5,3 +5,4 @@ IP address       HW type     Flags       HW address            Mask     Device
 192.168.1.4    0x1         0x2         dd:ee:ff:aa:bb:cc     *        eth1
 192.168.1.5    0x1         0x2         ee:ff:aa:bb:cc:dd     *        eth1
 192.168.1.6    0x1         0x2         ff:aa:bb:cc:dd:ee     *        eth1
+10.0.0.1       0x1         0x2         de:ad:be:ef:00:00     *        nope

--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -109,6 +109,7 @@ fi
   --collector.textfile.directory="collector/fixtures/textfile/two_metric_files/" \
   --collector.wifi.fixtures="collector/fixtures/wifi" \
   --collector.qdisc.fixtures="collector/fixtures/qdisc/" \
+  --collector.arp.device-exclude="nope" \
   --collector.netclass.ignored-devices="(dmz|int)" \
   --collector.netclass.ignore-invalid-speed \
   --collector.bcache.priorityStats \


### PR DESCRIPTION
Allow filtering APR entries based on device. Useful for ignoring
entries for network namespaces (containers).

Signed-off-by: Ben Kochie <superq@gmail.com>