### PR TITLE
filesystem_linux: exclude mounts under /var/lib/containers/storage

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	defMountPointsExcluded = "^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+)($|/)"
+	defMountPointsExcluded = "^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($|/)"
 	defFSTypesExcluded     = "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"
 )
 


### PR DESCRIPTION
analogous to the /var/lib/docker exclude added in
https://github.com/prometheus/node_exporter/pull/814

podman rootful containers mount eg. shm filesystems at
/var/lib/containers/storage/*-containers/*/userdata/shm. these should be
treated like things under /var/lib/docker by default.

Signed-off-by: Lauri Tirkkonen <lauri@hacktheplanet.fi>

@SuperQ 