### PR TITLE
[node-mixin] change current datasource to grafana's default

### DIFF
--- a/docs/node-mixin/dashboards/node.libsonnet
+++ b/docs/node-mixin/dashboards/node.libsonnet
@@ -211,8 +211,8 @@ local gauge = promgrafonnet.gauge;
       .addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: 'Data Source',

--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -9,8 +9,8 @@ local c = import '../config.libsonnet';
 
 local datasourceTemplate = {
   current: {
-    text: 'Prometheus',
-    value: 'Prometheus',
+    text: 'default',
+    value: 'default',
   },
   hide: 0,
   label: 'Data Source',


### PR DESCRIPTION
Currently when dashboard code is generated - datasource with name "Prometheus" is picked up as default one. This change is about using Grafana's default datasource instead of hardcoded "Prometheus" (which not everyone has set)

Done the same way as it is in kubernetes-mixin, thanos-mixin, etc