### PR TITLE
systemd: Expose systemd minor version

### DIFF
--- a/collector/systemd_linux.go
+++ b/collector/systemd_linux.go
@@ -72,7 +72,7 @@ type systemdCollector struct {
 	socketCurrentConnectionsDesc  *prometheus.Desc
 	socketRefusedConnectionsDesc  *prometheus.Desc
 	systemdVersionDesc            *prometheus.Desc
-	systemdVersion                int
+	systemdVersion                float64
 	unitIncludePattern            *regexp.Regexp
 	unitExcludePattern            *regexp.Regexp
 	logger                        log.Logger
@@ -488,7 +488,7 @@ func filterUnits(units []unit, includePattern, excludePattern *regexp.Regexp, lo
 	return filtered
 }
 
-func getSystemdVersion(logger log.Logger) int {
+func getSystemdVersion(logger log.Logger) float64 {
 	conn, err := newSystemdDbusConn()
 	if err != nil {
 		level.Warn(logger).Log("msg", "Unable to get systemd dbus connection, defaulting systemd version to 0", "err", err)
@@ -500,9 +500,9 @@ func getSystemdVersion(logger log.Logger) int {
 		level.Warn(logger).Log("msg", "Unable to get systemd version property, defaulting to 0")
 		return 0
 	}
-	re := regexp.MustCompile(`[0-9][0-9][0-9]`)
+	re := regexp.MustCompile(`[0-9][0-9][0-9](\.[0-9]+)?`)
 	version = re.FindString(version)
-	v, err := strconv.Atoi(version)
+	v, err := strconv.ParseFloat(version, 64)
 	if err != nil {
 		level.Warn(logger).Log("msg", "Got invalid systemd version", "version", version)
 		return 0


### PR DESCRIPTION
systemd patch versions are as important as the major version number;
they indicate security or bug fixes or other behavioural changes between
versions.

Use float64 over float32 as the rounding error with float32 rendered
250.3 as 250.3000030517578 in my testing.

Signed-off-by: Joe Groocock <jgroocock@cloudflare.com>