### PR TITLE
fix compatibility rule to convert to old node_cpu metric

### DIFF
--- a/docs/example-16-compatibility-rules-new-to-old.yml
+++ b/docs/example-16-compatibility-rules-new-to-old.yml
@@ -21,7 +21,7 @@ groups:
         record: node_intr
   - name: node_exporter-16-cpu
     rules:
-      - expr: label_replace(node_cpu_seconds_total, "cpu", "$1", "cpu", "cpu(.+)")
+      - expr: label_replace(node_cpu_seconds_total, "cpu", "cpu$1", "cpu", "(.+)")
         record: node_cpu
   - name: node_exporter-16-diskstats
     rules:


### PR DESCRIPTION
label_replace for new to old rules are wrong for the node_cpu metrics.
I've verified the fix, and it works.
The old node_cpu had labels such as `cpu=cpu0` the new one has `cpu=0` so this converts it correctly.