### PR TITLE
diskstats_linux: always scale reads and writes by 512 bytes, not by device units

### DIFF
--- a/collector/diskstats_linux.go
+++ b/collector/diskstats_linux.go
@@ -30,7 +30,8 @@ import (
 const (
 	secondsPerTick = 1.0 / 1000.0
 
-	// Read sectors and write sectors are the "standard UNIX 512-byte sectors, not any device- or filesystem-specific block size.
+	// Read sectors and write sectors are the "standard UNIX 512-byte sectors, not any device- or filesystem-specific block size."
+	// See also https://www.kernel.org/doc/Documentation/block/stat.txt
 	unixSectorSize = 512.0
 )
 

--- a/collector/diskstats_linux.go
+++ b/collector/diskstats_linux.go
@@ -29,6 +29,9 @@ import (
 
 const (
 	secondsPerTick = 1.0 / 1000.0
+
+	// Read sectors and write sectors are the "standard UNIX 512-byte sectors, not any device- or filesystem-specific block size.
+	unixSectorSize = 512.0
 )
 
 var (
@@ -195,14 +198,6 @@ func (c *diskstatsCollector) Update(ch chan<- prometheus.Metric) error {
 			continue
 		}
 
-		diskSectorSize := 512.0
-		blockQueue, err := c.fs.SysBlockDeviceQueueStats(dev)
-		if err != nil {
-			level.Debug(c.logger).Log("msg", "Error getting queue stats", "device", dev, "err", err)
-		} else {
-			diskSectorSize = float64(blockQueue.LogicalBlockSize)
-		}
-
 		ch <- c.infoDesc.mustNewConstMetric(1.0, dev, fmt.Sprint(stats.MajorNumber), fmt.Sprint(stats.MinorNumber))
 
 		statCount := stats.IoStatsCount - 3 // Total diskstats record count, less MajorNumber, MinorNumber and DeviceName
@@ -210,11 +205,11 @@ func (c *diskstatsCollector) Update(ch chan<- prometheus.Metric) error {
 		for i, val := range []float64{
 			float64(stats.ReadIOs),
 			float64(stats.ReadMerges),
-			float64(stats.ReadSectors) * diskSectorSize,
+			float64(stats.ReadSectors) * unixSectorSize,
 			float64(stats.ReadTicks) * secondsPerTick,
 			float64(stats.WriteIOs),
 			float64(stats.WriteMerges),
-			float64(stats.WriteSectors) * diskSectorSize,
+			float64(stats.WriteSectors) * unixSectorSize,
 			float64(stats.WriteTicks) * secondsPerTick,
 			float64(stats.IOsInProgress),
 			float64(stats.IOsTotalTicks) * secondsPerTick,


### PR DESCRIPTION
Fixes #2310

Signed-off-by: W. Andrew Denton <git@flying-snail.net>