### PR TITLE
refactor: Use netlink for tcpstat collector

### DIFF
--- a/collector/fixtures/proc/net/tcpstat
+++ b/collector/fixtures/proc/net/tcpstat
@@ -1,3 +1,0 @@
-  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode                                                     
-   0: 00000000:0016 00000000:0000 0A 00000015:00000000 00:00000000 00000000     0        0 2740 1 ffff88003d3af3c0 100 0 0 10 0                      
-   1: 0F02000A:0016 0202000A:8B6B 01 00000015:00000001 02:000AC99B 00000000     0        0 3652 4 ffff88003d3ae040 21 4 31 47 46                     

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/jsimonetti/rtnetlink v1.1.1
 	github.com/lufia/iostat v1.2.1
 	github.com/mattn/go-xmlrpc v0.0.3
+	github.com/mdlayher/netlink v1.6.0
 	github.com/mdlayher/wifi v0.0.0-20220320220353-954ff73a19a5
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0


### PR DESCRIPTION
This changes the implementation of the tcpstat Collector to use netlink instead of reading the /proc/net/tcp(6) file. I tested it against a Host with 1 Million Connections and while the file-based implementation never finished and used all available cpu time, this only takes 1-2 seconds.

Closes #1061