### PR TITLE
powersupplyclass_darwin: extra includes to build against older macOS SDK

### DIFF
--- a/collector/powersupplyclass_darwin.go
+++ b/collector/powersupplyclass_darwin.go
@@ -18,9 +18,11 @@ package collector
 
 /*
 #cgo LDFLAGS: -framework IOKit -framework CoreFoundation
+#include <CoreFoundation/CFNumber.h>
+#include <CoreFoundation/CFRunLoop.h>
+#include <CoreFoundation/CFString.h>
 #include <IOKit/ps/IOPowerSources.h>
 #include <IOKit/ps/IOPSKeys.h>
-#include <CoreFoundation/CFArray.h>
 
 // values collected from IOKit Power Source APIs
 // Functions documentation available at


### PR DESCRIPTION
this is necessary to build on darwin using nix, as nix-darwin uses an older macOS SDK, built from apple's open source releases.
