### PR TITLE
exclude cifs(smb) and fuse file systems in unix.Statfs call

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	defMountPointsExcluded = "^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($|/)"
-	defFSTypesExcluded     = "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"
+	defFSTypesExcluded     = "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs|cifs|fuse)$"
 )
 
 var mountTimeout = kingpin.Flag("collector.filesystem.mount-timeout",


### PR DESCRIPTION
This PR tries to exclude cifs(smb) and fuse file systems in [unix.Statfs](https://github.com/prometheus/node_exporter/blob/996563f9729588660d5d32826c46b0d7169b1334/collector/filesystem_linux.go#L80) call

We found that node-exporter would call statfs per mount point per minute by default, if there are 50 pods are using cifs(smb) mounts on one node, there would be 50 mount points, finally there would be100 calls per minute (cifs mount would be duplicated in “mount | grep cifs”), that's a large overload for smb server, same for fuse driver.