### PR TITLE
qdisk-linux: Add exclude and include flags for interface name

### DIFF
--- a/collector/qdisc_linux.go
+++ b/collector/qdisc_linux.go
@@ -18,6 +18,7 @@ package collector
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
@@ -28,18 +29,21 @@ import (
 )
 
 type qdiscStatCollector struct {
-	bytes      typedDesc
-	packets    typedDesc
-	drops      typedDesc
-	requeues   typedDesc
-	overlimits typedDesc
-	qlength    typedDesc
-	backlog    typedDesc
-	logger     log.Logger
+	logger       log.Logger
+	deviceFilter netDevFilter
+	bytes        typedDesc
+	packets      typedDesc
+	drops        typedDesc
+	requeues     typedDesc
+	overlimits   typedDesc
+	qlength      typedDesc
+	backlog      typedDesc
 }
 
 var (
-	collectorQdisc = kingpin.Flag("collector.qdisc.fixtures", "test fixtures to use for qdisc collector end-to-end testing").Default("").String()
+	collectorQdisc              = kingpin.Flag("collector.qdisc.fixtures", "test fixtures to use for qdisc collector end-to-end testing").Default("").String()
+	collectorQdiskDeviceInclude = kingpin.Flag("collector.qdisk.device-include", "Regexp of qdisk devices to include (mutually exclusive to device-exclude).").String()
+	collectorQdiskDeviceExclude = kingpin.Flag("collector.qdisk.device-exclude", "Regexp of qdisk devices to exclude (mutually exclusive to device-include).").String()
 )
 
 func init() {
@@ -48,6 +52,10 @@ func init() {
 
 // NewQdiscStatCollector returns a new Collector exposing queuing discipline statistics.
 func NewQdiscStatCollector(logger log.Logger) (Collector, error) {
+	if *collectorQdiskDeviceExclude != "" && *collectorQdiskDeviceInclude != "" {
+		return nil, fmt.Errorf("collector.qdisk.device-include and collector.qdisk.device-exclude are mutaly exclusive")
+	}
+
 	return &qdiscStatCollector{
 		bytes: typedDesc{prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "qdisc", "bytes_total"),
@@ -84,7 +92,8 @@ func NewQdiscStatCollector(logger log.Logger) (Collector, error) {
 			"Number of bytes currently in queue to be sent.",
 			[]string{"device", "kind"}, nil,
 		), prometheus.GaugeValue},
-		logger: logger,
+		logger:       logger,
+		deviceFilter: newNetDevFilter(*collectorQdiskDeviceExclude, *collectorQdiskDeviceExclude),
 	}, nil
 }
 
@@ -119,6 +128,10 @@ func (c *qdiscStatCollector) Update(ch chan<- prometheus.Metric) error {
 	for _, msg := range msgs {
 		// Only report root qdisc information.
 		if msg.Parent != 0 {
+			continue
+		}
+
+		if c.deviceFilter.ignored(msg.IfaceName) {
 			continue
 		}
 

--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -109,6 +109,7 @@ fi
   --collector.textfile.directory="collector/fixtures/textfile/two_metric_files/" \
   --collector.wifi.fixtures="collector/fixtures/wifi" \
   --collector.qdisc.fixtures="collector/fixtures/qdisc/" \
+  --collector.qdisk.device-include="(wlan0|eth0)" \
   --collector.arp.device-exclude="nope" \
   --collector.netclass.ignored-devices="(dmz|int)" \
   --collector.netclass.ignore-invalid-speed \


### PR DESCRIPTION
Signed-off-by: binjip978 <pdp.eleven11@gmail.com>

fixes https://github.com/prometheus/node_exporter/issues/2246