### PR TITLE
fix the following markdownlint issues

### DIFF
--- a/docs/node-mixin/README.md
+++ b/docs/node-mixin/README.md
@@ -10,33 +10,36 @@ for Grafana.
 
 To use them, you need to have `jsonnet` (v0.16+) and `jb` installed. If you
 have a working Go development environment, it's easiest to run the following:
+
 ```bash
-$ go install github.com/google/go-jsonnet/cmd/jsonnet@latest
-$ go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
-$ go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
 ```
 
 Next, install the dependencies by running the following command in this
 directory:
+
 ```bash
-$ jb install
+jb install
 ```
 
 You can then build the Prometheus rules files `node_alerts.yaml` and
 `node_rules.yaml`:
+
 ```bash
-$ make node_alerts.yaml node_rules.yaml
+make node_alerts.yaml node_rules.yaml
 ```
 
 You can also build a directory `dashboard_out` with the JSON dashboard files
 for Grafana:
+
 ```bash
-$ make dashboards_out
+make dashboards_out
 ```
 
 Note that some of the generated dashboards require recording rules specified in
 the previously generated `node_rules.yaml`.
 
 For more advanced uses of mixins, see
-https://github.com/monitoring-mixins/docs.
-
+<https://github.com/monitoring-mixins/docs>.


### PR DESCRIPTION
@SuperQ @discordianfish

fix the following markdownlint errors (and some more):

[..]mixins/node-exporter/README.md:13: MD031 Fenced code blocks should be surrounded by blank lines
[..]mixins/node-exporter/README.md:21: MD031 Fenced code blocks should be surrounded by blank lines
[..]mixins/node-exporter/README.md:27: MD031 Fenced code blocks should be surrounded by blank lines
[..]mixins/node-exporter/README.md:33: MD031 Fenced code blocks should be surrounded by blank lines
[..]mixins/node-exporter/README.md:41: MD034 Bare URL used
A detailed description of the rules is available at https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md