### PR TITLE
rapl_collector: fix issue with invalid metric name (#2299)

### DIFF
--- a/collector/rapl_linux.go
+++ b/collector/rapl_linux.go
@@ -80,7 +80,7 @@ func (c *raplCollector) Update(ch chan<- prometheus.Metric) error {
 		index := strconv.Itoa(rz.Index)
 
 		descriptor := prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "rapl", rz.Name+"_joules_total"),
+			prometheus.BuildFQName(namespace, "rapl", SanitizeMetricName(rz.Name+"_joules_total")),
 			"Current RAPL "+rz.Name+" value in joules",
 			[]string{"index", "path"}, nil,
 		)


### PR DESCRIPTION
Fixes https://github.com/prometheus/node_exporter/issues/2299 by wrapping metric name in `SanitizeMetricName()` as suggested by @discordianfish 