### PR TITLE
node-mixins/config: Switch fsAvailable warning and critical thresholds

### DIFF
--- a/docs/node-mixin/config.libsonnet
+++ b/docs/node-mixin/config.libsonnet
@@ -49,8 +49,8 @@
 
     // Available disk space (%) thresholds on which to trigger the
     // 'NodeFilesystemAlmostOutOfSpace' alerts.
-    fsSpaceAvailableCriticalThreshold: 5,
-    fsSpaceAvailableWarningThreshold: 3,
+    fsSpaceAvailableWarningThreshold: 5,
+    fsSpaceAvailableCriticalThreshold: 3,
 
     rateInterval: '5m',
     // Opt-in for multi-cluster support.


### PR DESCRIPTION
Problem: In 0b50eb7294da9908f59e1af897010743bc0bd535 the usage of the
threshold variables was adjusted. The values had been switched as well
resulting in reversed thresholds after the commit above. Warnings now
have a smaller threshold than critical alerts.

Solution: Adjust thresholds to reflect that warnings should be alerted
on before critical alerts.

Issues: https://github.com/prometheus/node_exporter/pull/2352

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>