### PR TITLE
mixin: update units for disk and networking panels

### DIFF
--- a/docs/node-mixin/lib/prom-mixin.libsonnet
+++ b/docs/node-mixin/lib/prom-mixin.libsonnet
@@ -212,7 +212,7 @@ local gaugePanel = grafana70.panel.gauge;
           },
         ],
         yaxes: [
-          self.yaxe(format='bytes'),
+          self.yaxe(format='Bps'),
           self.yaxe(format='s'),
         ],
       },
@@ -266,28 +266,30 @@ local gaugePanel = grafana70.panel.gauge;
     local networkReceived =
       graphPanel.new(
         'Network Received',
+        description="Network received (bits/s)",
         datasource='$datasource',
         span=6,
-        format='bytes',
+        format='bps',
         min=0,
         fill=0,
       )
       .addTarget(prometheus.target(
-        'rate(node_network_receive_bytes_total{%(nodeExporterSelector)s, instance="$instance", device!="lo"}[$__rate_interval])' % config,
+        'rate(node_network_receive_bytes_total{%(nodeExporterSelector)s, instance="$instance", device!="lo"}[$__rate_interval]) * 8' % config,
         legendFormat='{{device}}',
       )),
 
     local networkTransmitted =
       graphPanel.new(
         'Network Transmitted',
+        description="Network transmitted (bits/s)",
         datasource='$datasource',
         span=6,
-        format='bytes',
+        format='bps',
         min=0,
         fill=0,
       )
       .addTarget(prometheus.target(
-        'rate(node_network_transmit_bytes_total{%(nodeExporterSelector)s, instance="$instance", device!="lo"}[$__rate_interval])' % config,
+        'rate(node_network_transmit_bytes_total{%(nodeExporterSelector)s, instance="$instance", device!="lo"}[$__rate_interval]) * 8' % config,
         legendFormat='{{device}}',
       )),
 

--- a/docs/node-mixin/lib/prom-mixin.libsonnet
+++ b/docs/node-mixin/lib/prom-mixin.libsonnet
@@ -191,14 +191,17 @@ local gaugePanel = grafana70.panel.gauge;
       .addTarget(prometheus.target(
         'rate(node_disk_read_bytes_total{%(nodeExporterSelector)s, instance="$instance", %(diskDeviceSelector)s}[$__rate_interval])' % config,
         legendFormat='{{device}} read',
+        intervalFactor=1,
       ))
       .addTarget(prometheus.target(
         'rate(node_disk_written_bytes_total{%(nodeExporterSelector)s, instance="$instance", %(diskDeviceSelector)s}[$__rate_interval])' % config,
         legendFormat='{{device}} written',
+        intervalFactor=1,
       ))
       .addTarget(prometheus.target(
         'rate(node_disk_io_time_seconds_total{%(nodeExporterSelector)s, instance="$instance", %(diskDeviceSelector)s}[$__rate_interval])' % config,
         legendFormat='{{device}} io time',
+        intervalFactor=1,
       )) +
       {
         seriesOverrides: [
@@ -213,7 +216,7 @@ local gaugePanel = grafana70.panel.gauge;
         ],
         yaxes: [
           self.yaxe(format='Bps'),
-          self.yaxe(format='s'),
+          self.yaxe(format='percentunit'),
         ],
       },
 
@@ -266,7 +269,7 @@ local gaugePanel = grafana70.panel.gauge;
     local networkReceived =
       graphPanel.new(
         'Network Received',
-        description="Network received (bits/s)",
+        description='Network received (bits/s)',
         datasource='$datasource',
         span=6,
         format='bps',
@@ -276,12 +279,13 @@ local gaugePanel = grafana70.panel.gauge;
       .addTarget(prometheus.target(
         'rate(node_network_receive_bytes_total{%(nodeExporterSelector)s, instance="$instance", device!="lo"}[$__rate_interval]) * 8' % config,
         legendFormat='{{device}}',
+        intervalFactor=1,
       )),
 
     local networkTransmitted =
       graphPanel.new(
         'Network Transmitted',
-        description="Network transmitted (bits/s)",
+        description='Network transmitted (bits/s)',
         datasource='$datasource',
         span=6,
         format='bps',
@@ -291,6 +295,7 @@ local gaugePanel = grafana70.panel.gauge;
       .addTarget(prometheus.target(
         'rate(node_network_transmit_bytes_total{%(nodeExporterSelector)s, instance="$instance", device!="lo"}[$__rate_interval]) * 8' % config,
         legendFormat='{{device}}',
+        intervalFactor=1,
       )),
 
     local cpuRow =


### PR DESCRIPTION
1.    Update units of network and disk graphs

    https://prometheus.io/docs/prometheus/latest/querying/functions/#rate
    rate() calculates per-second average rate, therefore Bps units should be used for disks.
    In networking bandwidth throughput is usually measured in bits/s so network graphs' units are changed accordingly.
<img width="1369" alt="image" src="https://user-images.githubusercontent.com/14870891/168152227-421c5603-4817-415f-a2a0-68b58b2622a7.png">

2.  Change io time units from seconds to %util

    When applying rate() to seconds we have 'seconds per second' or fractions of the second, so actually it actually can be from 0 to 1.
<img width="687" alt="image" src="https://user-images.githubusercontent.com/14870891/168152135-4f355d74-589c-4d23-9b71-2cde85280710.png">


3.  Update intervalFactor to 1 for better rates


