### PR TITLE
Rename netDevFilter helper

### DIFF
--- a/collector/arp_linux.go
+++ b/collector/arp_linux.go
@@ -34,7 +34,7 @@ var (
 )
 
 type arpCollector struct {
-	deviceFilter netDevFilter
+	deviceFilter deviceFilter
 	entries      *prometheus.Desc
 	logger       log.Logger
 }
@@ -46,7 +46,7 @@ func init() {
 // NewARPCollector returns a new Collector exposing ARP stats.
 func NewARPCollector(logger log.Logger) (Collector, error) {
 	return &arpCollector{
-		deviceFilter: newNetDevFilter(*arpDeviceExclude, *arpDeviceInclude),
+		deviceFilter: newDeviceFilter(*arpDeviceExclude, *arpDeviceInclude),
 		entries: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "arp", "entries"),
 			"ARP entries by device",

--- a/collector/device_filter.go
+++ b/collector/device_filter.go
@@ -17,12 +17,12 @@ import (
 	"regexp"
 )
 
-type netDevFilter struct {
+type deviceFilter struct {
 	ignorePattern *regexp.Regexp
 	acceptPattern *regexp.Regexp
 }
 
-func newNetDevFilter(ignoredPattern, acceptPattern string) (f netDevFilter) {
+func newDeviceFilter(ignoredPattern, acceptPattern string) (f deviceFilter) {
 	if ignoredPattern != "" {
 		f.ignorePattern = regexp.MustCompile(ignoredPattern)
 	}
@@ -35,7 +35,7 @@ func newNetDevFilter(ignoredPattern, acceptPattern string) (f netDevFilter) {
 }
 
 // ignores returns whether the device should be ignored
-func (f *netDevFilter) ignored(name string) bool {
+func (f *deviceFilter) ignored(name string) bool {
 	return ((f.ignorePattern != nil && f.ignorePattern.MatchString(name)) ||
 		(f.acceptPattern != nil && !f.acceptPattern.MatchString(name)))
 }

--- a/collector/device_filter_test.go
+++ b/collector/device_filter_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 )
 
-func TestNetDevFilter(t *testing.T) {
+func TestDeviceFilter(t *testing.T) {
 	tests := []struct {
 		ignore         string
 		accept         string
@@ -33,7 +33,7 @@ func TestNetDevFilter(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		filter := newNetDevFilter(test.ignore, test.accept)
+		filter := newDeviceFilter(test.ignore, test.accept)
 		result := filter.ignored(test.name)
 
 		if result != test.expectedResult {

--- a/collector/ethtool_linux.go
+++ b/collector/ethtool_linux.go
@@ -76,7 +76,7 @@ type ethtoolCollector struct {
 	entries        map[string]*prometheus.Desc
 	entriesMutex   sync.Mutex
 	ethtool        Ethtool
-	deviceFilter   netDevFilter
+	deviceFilter   deviceFilter
 	infoDesc       *prometheus.Desc
 	metricsPattern *regexp.Regexp
 	logger         log.Logger
@@ -100,7 +100,7 @@ func makeEthtoolCollector(logger log.Logger) (*ethtoolCollector, error) {
 	return &ethtoolCollector{
 		fs:             fs,
 		ethtool:        &ethtoolLibrary{e},
-		deviceFilter:   newNetDevFilter(*ethtoolDeviceExclude, *ethtoolDeviceInclude),
+		deviceFilter:   newDeviceFilter(*ethtoolDeviceExclude, *ethtoolDeviceInclude),
 		metricsPattern: regexp.MustCompile(*ethtoolIncludedMetrics),
 		logger:         logger,
 		entries: map[string]*prometheus.Desc{

--- a/collector/netdev_bsd.go
+++ b/collector/netdev_bsd.go
@@ -34,7 +34,7 @@ import (
 */
 import "C"
 
-func getNetDevStats(filter *netDevFilter, logger log.Logger) (netDevStats, error) {
+func getNetDevStats(filter *deviceFilter, logger log.Logger) (netDevStats, error) {
 	netDev := netDevStats{}
 
 	var ifap, ifa *C.struct_ifaddrs

--- a/collector/netdev_common.go
+++ b/collector/netdev_common.go
@@ -40,7 +40,7 @@ var (
 
 type netDevCollector struct {
 	subsystem        string
-	deviceFilter     netDevFilter
+	deviceFilter     deviceFilter
 	metricDescsMutex sync.Mutex
 	metricDescs      map[string]*prometheus.Desc
 	logger           log.Logger
@@ -86,7 +86,7 @@ func NewNetDevCollector(logger log.Logger) (Collector, error) {
 
 	return &netDevCollector{
 		subsystem:    "network",
-		deviceFilter: newNetDevFilter(*netdevDeviceExclude, *netdevDeviceInclude),
+		deviceFilter: newDeviceFilter(*netdevDeviceExclude, *netdevDeviceInclude),
 		metricDescs:  map[string]*prometheus.Desc{},
 		logger:       logger,
 	}, nil

--- a/collector/netdev_darwin.go
+++ b/collector/netdev_darwin.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func getNetDevStats(filter *netDevFilter, logger log.Logger) (netDevStats, error) {
+func getNetDevStats(filter *deviceFilter, logger log.Logger) (netDevStats, error) {
 	netDev := netDevStats{}
 
 	ifs, err := net.Interfaces()

--- a/collector/netdev_linux.go
+++ b/collector/netdev_linux.go
@@ -34,7 +34,7 @@ var (
 	procNetDevFieldSep    = regexp.MustCompile(` +`)
 )
 
-func getNetDevStats(filter *netDevFilter, logger log.Logger) (netDevStats, error) {
+func getNetDevStats(filter *deviceFilter, logger log.Logger) (netDevStats, error) {
 	file, err := os.Open(procFilePath("net/dev"))
 	if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func getNetDevStats(filter *netDevFilter, logger log.Logger) (netDevStats, error
 	return parseNetDevStats(file, filter, logger)
 }
 
-func parseNetDevStats(r io.Reader, filter *netDevFilter, logger log.Logger) (netDevStats, error) {
+func parseNetDevStats(r io.Reader, filter *deviceFilter, logger log.Logger) (netDevStats, error) {
 	scanner := bufio.NewScanner(r)
 	scanner.Scan() // skip first header
 	scanner.Scan()

--- a/collector/netdev_linux_test.go
+++ b/collector/netdev_linux_test.go
@@ -27,7 +27,7 @@ func TestNetDevStatsIgnore(t *testing.T) {
 	}
 	defer file.Close()
 
-	filter := newNetDevFilter("^veth", "")
+	filter := newDeviceFilter("^veth", "")
 
 	netStats, err := parseNetDevStats(file, &filter, log.NewNopLogger())
 	if err != nil {
@@ -70,7 +70,7 @@ func TestNetDevStatsAccept(t *testing.T) {
 	}
 	defer file.Close()
 
-	filter := newNetDevFilter("", "^💩0$")
+	filter := newDeviceFilter("", "^💩0$")
 	netStats, err := parseNetDevStats(file, &filter, log.NewNopLogger())
 	if err != nil {
 		t.Fatal(err)

--- a/collector/netdev_openbsd.go
+++ b/collector/netdev_openbsd.go
@@ -31,7 +31,7 @@ import (
 */
 import "C"
 
-func getNetDevStats(filter *netDevFilter, logger log.Logger) (netDevStats, error) {
+func getNetDevStats(filter *deviceFilter, logger log.Logger) (netDevStats, error) {
 	netDev := netDevStats{}
 
 	var ifap, ifa *C.struct_ifaddrs

--- a/collector/netdev_openbsd_amd64.go
+++ b/collector/netdev_openbsd_amd64.go
@@ -24,7 +24,7 @@ import (
 	"unsafe"
 )
 
-func getNetDevStats(filter *netDevFilter, logger log.Logger) (netDevStats, error) {
+func getNetDevStats(filter *deviceFilter, logger log.Logger) (netDevStats, error) {
 	netDev := netDevStats{}
 
 	mib := [6]_C_int{unix.CTL_NET, unix.AF_ROUTE, 0, 0, unix.NET_RT_IFLIST, 0}


### PR DESCRIPTION
Rename the network device filter to a more generic device filter.

Signed-off-by: Ben Kochie <superq@gmail.com>