### PR TITLE
collector: use ByteSliceToString from golang.org/x/sys/unix

### DIFF
--- a/collector/filesystem_freebsd.go
+++ b/collector/filesystem_freebsd.go
@@ -39,14 +39,14 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 	}
 	stats := []filesystemStats{}
 	for _, fs := range buf {
-		mountpoint := bytesToString(fs.Mntonname[:])
+		mountpoint := unix.ByteSliceToString(fs.Mntonname[:])
 		if c.excludedMountPointsPattern.MatchString(mountpoint) {
 			level.Debug(c.logger).Log("msg", "Ignoring mount point", "mountpoint", mountpoint)
 			continue
 		}
 
-		device := bytesToString(fs.Mntfromname[:])
-		fstype := bytesToString(fs.Fstypename[:])
+		device := unix.ByteSliceToString(fs.Mntfromname[:])
+		fstype := unix.ByteSliceToString(fs.Fstypename[:])
 		if c.excludedFSTypesPattern.MatchString(fstype) {
 			level.Debug(c.logger).Log("msg", "Ignoring fs type", "type", fstype)
 			continue

--- a/collector/helper.go
+++ b/collector/helper.go
@@ -14,7 +14,6 @@
 package collector
 
 import (
-	"bytes"
 	"io/ioutil"
 	"regexp"
 	"strconv"
@@ -31,19 +30,6 @@ func readUintFromFile(path string) (uint64, error) {
 		return 0, err
 	}
 	return value, nil
-}
-
-// Take a []byte{} and return a string based on null termination.
-// This is useful for situations where the OS has returned a null terminated
-// string to use.
-// If this function happens to receive a byteArray that contains no nulls, we
-// simply convert the array to a string with no bounding.
-func bytesToString(byteArray []byte) string {
-	n := bytes.IndexByte(byteArray, 0)
-	if n < 0 {
-		return string(byteArray)
-	}
-	return string(byteArray[:n])
 }
 
 var metricNameRegex = regexp.MustCompile(`_*[^0-9A-Za-z_]+_*`)

--- a/collector/helper_test.go
+++ b/collector/helper_test.go
@@ -17,51 +17,6 @@ import (
 	"testing"
 )
 
-func TestBytesToString(t *testing.T) {
-	tests := []struct {
-		name     string
-		b        []byte
-		expected string
-	}{
-		{
-			"Single null byte",
-			[]byte{0},
-			"",
-		},
-		{
-			"Empty byte array",
-			[]byte{},
-			"",
-		},
-		{
-			"Not null terminated",
-			[]byte{65, 66, 67},
-			"ABC",
-		},
-		{
-			"Null randomly in array",
-			[]byte{65, 66, 67, 0, 65, 0, 65},
-			"ABC",
-		},
-		{
-			"Array starts with null and contains other valid bytes",
-			[]byte{0, 65, 66, 67, 0},
-			"",
-		},
-	}
-
-	for _, tt := range tests {
-		name := tt.name
-		b := tt.b
-		result := bytesToString(b)
-		expected := tt.expected
-
-		if result != expected {
-			t.Errorf("bytesToString(%#v): Name: %s, expected %#v, got %#v)", b, name, expected, result)
-		}
-	}
-}
-
 func TestSanitizeMetricName(t *testing.T) {
 	testcases := map[string]string{
 		"":                             "",

--- a/collector/uname_bsd.go
+++ b/collector/uname_bsd.go
@@ -18,7 +18,6 @@
 package collector
 
 import (
-	"bytes"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -33,10 +32,10 @@ func getUname() (uname, error) {
 	nodeName, domainName := parseHostNameAndDomainName(utsname)
 
 	output := uname{
-		SysName:    string(utsname.Sysname[:bytes.IndexByte(utsname.Sysname[:], 0)]),
-		Release:    string(utsname.Release[:bytes.IndexByte(utsname.Release[:], 0)]),
-		Version:    string(utsname.Version[:bytes.IndexByte(utsname.Version[:], 0)]),
-		Machine:    string(utsname.Machine[:bytes.IndexByte(utsname.Machine[:], 0)]),
+		SysName:    unix.ByteSliceToString(utsname.Sysname[:]),
+		Release:    unix.ByteSliceToString(utsname.Release[:]),
+		Version:    unix.ByteSliceToString(utsname.Version[:]),
+		Machine:    unix.ByteSliceToString(utsname.Machine[:]),
 		NodeName:   nodeName,
 		DomainName: domainName,
 	}
@@ -47,7 +46,7 @@ func getUname() (uname, error) {
 // parseHostNameAndDomainName for FreeBSD,OpenBSD,Darwin.
 // Attempts to emulate what happens in the Linux uname calls since these OS doesn't have a Domainname.
 func parseHostNameAndDomainName(utsname unix.Utsname) (hostname string, domainname string) {
-	nodename := string(utsname.Nodename[:bytes.IndexByte(utsname.Nodename[:], 0)])
+	nodename := unix.ByteSliceToString(utsname.Nodename[:])
 	split := strings.SplitN(nodename, ".", 2)
 
 	// We'll always have at least a single element in the array. We assume this

--- a/collector/uname_linux.go
+++ b/collector/uname_linux.go
@@ -16,11 +16,7 @@
 
 package collector
 
-import (
-	"bytes"
-
-	"golang.org/x/sys/unix"
-)
+import "golang.org/x/sys/unix"
 
 func getUname() (uname, error) {
 	var utsname unix.Utsname
@@ -29,12 +25,12 @@ func getUname() (uname, error) {
 	}
 
 	output := uname{
-		SysName:    string(utsname.Sysname[:bytes.IndexByte(utsname.Sysname[:], 0)]),
-		Release:    string(utsname.Release[:bytes.IndexByte(utsname.Release[:], 0)]),
-		Version:    string(utsname.Version[:bytes.IndexByte(utsname.Version[:], 0)]),
-		Machine:    string(utsname.Machine[:bytes.IndexByte(utsname.Machine[:], 0)]),
-		NodeName:   string(utsname.Nodename[:bytes.IndexByte(utsname.Nodename[:], 0)]),
-		DomainName: string(utsname.Domainname[:bytes.IndexByte(utsname.Domainname[:], 0)]),
+		SysName:    unix.ByteSliceToString(utsname.Sysname[:]),
+		Release:    unix.ByteSliceToString(utsname.Release[:]),
+		Version:    unix.ByteSliceToString(utsname.Version[:]),
+		Machine:    unix.ByteSliceToString(utsname.Machine[:]),
+		NodeName:   unix.ByteSliceToString(utsname.Nodename[:]),
+		DomainName: unix.ByteSliceToString(utsname.Domainname[:]),
 	}
 
 	return output, nil


### PR DESCRIPTION
Use `unix.ByteSliceToString` to convert `Utsname` `[]byte` fields to strings.

This also allows to drop the `bytesToString` helper which serves the same
purpose and matches `ByteSliceToString`'s implementation.