### PR TITLE
breakchange: disable ipvs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ filefd | Exposes file descriptor statistics from `/proc/sys/fs/file-nr`. | Linux
 filesystem | Exposes filesystem statistics, such as disk space used. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD
 hwmon | Expose hardware monitoring and sensor data from `/sys/class/hwmon/`. | Linux
 infiniband | Exposes network statistics specific to InfiniBand and Intel OmniPath configurations. | Linux
-ipvs | Exposes IPVS status from `/proc/net/ip_vs` and stats from `/proc/net/ip_vs_stats`. | Linux
 loadavg | Exposes load average. | Darwin, Dragonfly, FreeBSD, Linux, NetBSD, OpenBSD, Solaris
 mdadm | Exposes statistics about devices in `/proc/mdstat` (does nothing if no `/proc/mdstat` present). | Linux
 meminfo | Exposes memory statistics. | Darwin, Dragonfly, FreeBSD, Linux, OpenBSD
@@ -213,6 +212,7 @@ systemd | Exposes service and system status from [systemd](http://www.freedeskto
 tcpstat | Exposes TCP connection status information from `/proc/net/tcp` and `/proc/net/tcp6`. (Warning: the current version has potential performance issues in high load situations.) | Linux
 wifi | Exposes WiFi device and station statistics. | Linux
 zoneinfo | Exposes NUMA memory zone metrics. | Linux
+ipvs | Exposes IPVS status from `/proc/net/ip_vs` and stats from `/proc/net/ip_vs_stats`. | Linux
 
 
 ### Textfile Collector

--- a/collector/ipvs_linux.go
+++ b/collector/ipvs_linux.go
@@ -68,7 +68,7 @@ var (
 )
 
 func init() {
-	registerCollector("ipvs", defaultEnabled, NewIPVSCollector)
+	registerCollector("ipvs", defaultDisabled, NewIPVSCollector)
 }
 
 // NewIPVSCollector sets up a new collector for IPVS metrics. It accepts the


### PR DESCRIPTION
Fix: https://github.com/prometheus/node_exporter/issues/2388

Signed-off-by: Xu Yixin <xyx530538772@gmail.com>