### PR TITLE
Add rapl zone label option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 * [ENHANCEMENT] Add node_softirqs_total metric #2221
 * [ENHANCEMENT] Add device filter flags to arp collector #2254
+* [ENHANCEMENT] Add rapl zone name label option #2401
+* [BUGFIX] Sanitize rapl zone names #2299
 
 ## 1.3.1 / 2021-12-01
 


### PR DESCRIPTION
Add an optional flag to set the RAPL zone as a label, instead of as part
of the metric name.

Fixes: https://github.com/prometheus/node_exporter/issues/2299

Signed-off-by: Ben Kochie <superq@gmail.com>