### PR TITLE
Fix up copyright date change

### DIFF
--- a/collector/cpu_openbsd.go
+++ b/collector/cpu_openbsd.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Prometheus Authors
+// Copyright 2018 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
Return the copyright date in `collector/cpu_openbsd.go` to the original
value.

Minor change revert on https://github.com/prometheus/node_exporter/pull/1971

Signed-off-by: Ben Kochie <superq@gmail.com>