### PR TITLE
Update go.mod to resolve 2x vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,8 +49,8 @@ require (
 	github.com/siebenmann/go-kstat v0.0.0-20210513183136-173c9b0a9973 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
-	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
+	golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b // indirect
+	golang.org/x/net v0.0.0-20220906165146-f3363e06e74c // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
 	golang.org/x/text v0.3.7 // indirect


### PR DESCRIPTION
To resolve vulnerable components:
golang.org/x/crypto - CVE-2022-27191 (High severity) golang.org/x/net - CVE-2022-27664 (High severity)

Signed-off-by: Jason Culligan <jason.culligan@intel.com>