### PR TITLE
Allow configuring timezone in node-mixin

### DIFF
--- a/docs/node-mixin/config.libsonnet
+++ b/docs/node-mixin/config.libsonnet
@@ -59,5 +59,7 @@
 
     dashboardNamePrefix: 'Node Exporter / ',
     dashboardTags: ['node-exporter-mixin'],
+
+    dashboardTimezone: 'utc',
   },
 }

--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -148,7 +148,7 @@ local diskSpaceUtilisation =
                              '%sUSE Method / Node' % $._config.dashboardNamePrefix,
                              time_from='now-1h',
                              tags=($._config.dashboardTags),
-                             timezone='utc',
+                             timezone=$._config.dashboardTimezone,
                              refresh='30s',
                              graphTooltip='shared_crosshair'
                            )
@@ -213,7 +213,7 @@ local diskSpaceUtilisation =
                              '%sUSE Method / Cluster' % $._config.dashboardNamePrefix,
                              time_from='now-1h',
                              tags=($._config.dashboardTags),
-                             timezone='utc',
+                             timezone=$._config.dashboardTimezone,
                              refresh='30s',
                              graphTooltip='shared_crosshair'
                            )
@@ -324,7 +324,7 @@ local diskSpaceUtilisation =
                              '%sUSE Method / Multi-cluster' % $._config.dashboardNamePrefix,
                              time_from='now-1h',
                              tags=($._config.dashboardTags),
-                             timezone='utc',
+                             timezone=$._config.dashboardTimezone,
                              refresh='30s',
                              graphTooltip='shared_crosshair'
                            )

--- a/docs/node-mixin/lib/prom-mixin.libsonnet
+++ b/docs/node-mixin/lib/prom-mixin.libsonnet
@@ -482,7 +482,7 @@ local table = grafana70.panel.table;
         '%sNodes' % config.dashboardNamePrefix,
         time_from='now-1h',
         tags=(config.dashboardTags),
-        timezone='utc',
+        timezone=config.dashboardTimezone,
         refresh='30s',
         graphTooltip='shared_crosshair'
       )
@@ -493,7 +493,7 @@ local table = grafana70.panel.table;
         '%sMacOS' % config.dashboardNamePrefix,
         time_from='now-1h',
         tags=(config.dashboardTags),
-        timezone='utc',
+        timezone=config.dashboardTimezone,
         refresh='30s',
         graphTooltip='shared_crosshair'
       )


### PR DESCRIPTION
The dashboards current have the timezone set to UTC. This adds a `dashboardTimezone` configuration parameter.

Adding a mention per the guidelines: @SuperQ

Signed-off-by: Shiv Jha-Mathur <shiv@shivjm.in>