### PR TITLE
Fix hwmon label sanitizer

### DIFF
--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -931,18 +931,18 @@ node_hwmon_pwm_weight_temp_step_tol{chip="nct6779",sensor="pwm1"} 0
 # TYPE node_hwmon_sensor_label gauge
 node_hwmon_sensor_label{chip="hwmon4",label="foosensor",sensor="temp1"} 1
 node_hwmon_sensor_label{chip="hwmon4",label="foosensor",sensor="temp2"} 1
-node_hwmon_sensor_label{chip="platform_applesmc_768",label="left_side",sensor="fan1"} 1
-node_hwmon_sensor_label{chip="platform_applesmc_768",label="right_side",sensor="fan2"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_0",label="core_0",sensor="temp2"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_0",label="core_1",sensor="temp3"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_0",label="core_2",sensor="temp4"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_0",label="core_3",sensor="temp5"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_0",label="physical_id_0",sensor="temp1"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_1",label="core_0",sensor="temp2"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_1",label="core_1",sensor="temp3"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_1",label="core_2",sensor="temp4"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_1",label="core_3",sensor="temp5"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_1",label="physical_id_0",sensor="temp1"} 1
+node_hwmon_sensor_label{chip="platform_applesmc_768",label="Left side  ",sensor="fan1"} 1
+node_hwmon_sensor_label{chip="platform_applesmc_768",label="Right side ",sensor="fan2"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_0",label="Core 0",sensor="temp2"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_0",label="Core 1",sensor="temp3"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_0",label="Core 2",sensor="temp4"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_0",label="Core 3",sensor="temp5"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_0",label="Physical id 0",sensor="temp1"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_1",label="Core 0",sensor="temp2"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_1",label="Core 1",sensor="temp3"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_1",label="Core 2",sensor="temp4"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_1",label="Core 3",sensor="temp5"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_1",label="Physical id 0",sensor="temp1"} 1
 # HELP node_hwmon_temp_celsius Hardware monitor for temperature (input)
 # TYPE node_hwmon_temp_celsius gauge
 node_hwmon_temp_celsius{chip="hwmon4",sensor="temp1"} 55

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -953,18 +953,18 @@ node_hwmon_pwm_weight_temp_step_tol{chip="nct6779",sensor="pwm1"} 0
 # TYPE node_hwmon_sensor_label gauge
 node_hwmon_sensor_label{chip="hwmon4",label="foosensor",sensor="temp1"} 1
 node_hwmon_sensor_label{chip="hwmon4",label="foosensor",sensor="temp2"} 1
-node_hwmon_sensor_label{chip="platform_applesmc_768",label="left_side",sensor="fan1"} 1
-node_hwmon_sensor_label{chip="platform_applesmc_768",label="right_side",sensor="fan2"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_0",label="core_0",sensor="temp2"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_0",label="core_1",sensor="temp3"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_0",label="core_2",sensor="temp4"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_0",label="core_3",sensor="temp5"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_0",label="physical_id_0",sensor="temp1"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_1",label="core_0",sensor="temp2"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_1",label="core_1",sensor="temp3"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_1",label="core_2",sensor="temp4"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_1",label="core_3",sensor="temp5"} 1
-node_hwmon_sensor_label{chip="platform_coretemp_1",label="physical_id_0",sensor="temp1"} 1
+node_hwmon_sensor_label{chip="platform_applesmc_768",label="Left side  ",sensor="fan1"} 1
+node_hwmon_sensor_label{chip="platform_applesmc_768",label="Right side ",sensor="fan2"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_0",label="Core 0",sensor="temp2"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_0",label="Core 1",sensor="temp3"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_0",label="Core 2",sensor="temp4"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_0",label="Core 3",sensor="temp5"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_0",label="Physical id 0",sensor="temp1"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_1",label="Core 0",sensor="temp2"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_1",label="Core 1",sensor="temp3"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_1",label="Core 2",sensor="temp4"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_1",label="Core 3",sensor="temp5"} 1
+node_hwmon_sensor_label{chip="platform_coretemp_1",label="Physical id 0",sensor="temp1"} 1
 # HELP node_hwmon_temp_celsius Hardware monitor for temperature (input)
 # TYPE node_hwmon_temp_celsius gauge
 node_hwmon_temp_celsius{chip="hwmon4",sensor="temp1"} 55

--- a/collector/hwmon_linux.go
+++ b/collector/hwmon_linux.go
@@ -192,12 +192,10 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) er
 
 		labels := []string{hwmonName, sensor}
 		if labelText, ok := sensorData["label"]; ok {
-			label := cleanMetricName(labelText)
-			if label != "" {
-				desc := prometheus.NewDesc("node_hwmon_sensor_label", "Label for given chip and sensor",
-					[]string{"chip", "sensor", "label"}, nil)
-				ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, 1.0, hwmonName, sensor, label)
-			}
+			label := strings.ToValidUTF8(labelText, "�")
+			desc := prometheus.NewDesc("node_hwmon_sensor_label", "Label for given chip and sensor",
+				[]string{"chip", "sensor", "label"}, nil)
+			ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, 1.0, hwmonName, sensor, label)
 		}
 
 		if sensorType == "beep_enable" {


### PR DESCRIPTION
We don't need to fully sanitize the hwmon label values to metric/label name strings.
* Just make sure they're valid UTF-8.
* Always included the label metric to avoid group_left failures.

Signed-off-by: Ben Kochie <superq@gmail.com>