### PR TITLE
Correct documentation for --web.config.file flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ To see all available configuration flags:
 The exporter supports TLS via a new web configuration file.
 
 ```console
-./node_exporter --web.config=web-config.yml
+./node_exporter --web.config.file=web-config.yml
 ```
 
 See the [exporter-toolkit https package](https://github.com/prometheus/exporter-toolkit/blob/v0.1.0/https/README.md) for more details.


### PR DESCRIPTION
The `--web.config` flag changed to `--web.config.file` in https://github.com/prometheus/node_exporter/commit/440a132c389dddd405b44d2d5e47157d1159e4d0#diff-7907251477470326df65250bf7fa699e0756ce5d6282e27b34c112132a7ef6b5R162 and was realised in the recent v1.5.0 release.

Signed-off-by: Joe Groocock <me@frebib.net>

---

This didn't appear to be noted as a breaking change. I only noticed when my containers updated and everything stopped working:
```
node_exporter: error: unknown long flag '--web.config', try --help
```
```
/ $ /bin/node_exporter --help | grep web.config
      --web.config.file=""       [EXPERIMENTAL] Path to configuration file that
```