### PR TITLE
Log current value of GOMAXPROCS

### DIFF
--- a/node_exporter.go
+++ b/node_exporter.go
@@ -183,7 +183,7 @@ func main() {
 		level.Warn(logger).Log("msg", "Node Exporter is running as root user. This exporter is designed to run as unprivileged user, root is not required.")
 	}
 	runtime.GOMAXPROCS(*maxProcs)
-	level.Debug(logger).Log("msg", "Go MAXPROCS", "procs", *maxProcs)
+	level.Debug(logger).Log("msg", "Go MAXPROCS", "procs", runtime.GOMAXPROCS(0))
 
 	http.Handle(*metricsPath, newHandler(!*disableExporterMetrics, *maxRequests, logger))
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
With `--runtime.gomaxprocs=0`, the GOMAXPROXS value will default to the number of logical CPUs. In this case, it is more useful to log the actual value than the value set by the user via the command-line.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>