### PR TITLE
Bump perf-utils version to 0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/hashicorp/go-envparse v0.1.0
-	github.com/hodgesds/perf-utils v0.5.1
+	github.com/hodgesds/perf-utils v0.6.0
 	github.com/illumos/go-kstat v0.0.0-20210513183136-173c9b0a9973
 	github.com/josharian/native v1.0.0
 	github.com/jsimonetti/rtnetlink v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/hashicorp/go-envparse v0.1.0 h1:bE++6bhIsNCPLvgDZkYqo3nA+/PFI51pkrHdm
 github.com/hashicorp/go-envparse v0.1.0/go.mod h1:OHheN1GoygLlAkTlXLXvAdnXdZxy8JUweQ1rAXx1xnc=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hodgesds/perf-utils v0.5.1 h1:Dlk4yYRQAzLnqiFqvwKj9+a1XysINFuHmRfcIduuXxo=
-github.com/hodgesds/perf-utils v0.5.1/go.mod h1:LAklqfDadNKpkxoAJNHpD5tkY0rkZEVdnCEWN5k4QJY=
+github.com/hodgesds/perf-utils v0.6.0 h1:t/rlpa1ztEuLYgCg84yT45iLQQOosPfzD0ylo6Z7jgk=
+github.com/hodgesds/perf-utils v0.6.0/go.mod h1:LAklqfDadNKpkxoAJNHpD5tkY0rkZEVdnCEWN5k4QJY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/illumos/go-kstat v0.0.0-20210513183136-173c9b0a9973 h1:hk4LPqXIY/c9XzRbe7dA6qQxaT6Axcbny0L/G5a4owQ=
 github.com/illumos/go-kstat v0.0.0-20210513183136-173c9b0a9973/go.mod h1:PoK3ejP3LJkGTzKqRlpvCIFas3ncU02v8zzWDW+g0FY=


### PR DESCRIPTION
This change updates the perf-utils library to 0.6.0 which has some fixes for automatically detecting the correct tracefs mountpoint if available.

Tested locally with:
```
curl localhost:9100/metrics | grep perf | head
# HELP node_nfs_rpc_authentication_refreshes_total Number of RPC authentication refreshes performed.
# HELP node_nfs_rpc_retransmissions_total Number of RPC transmissions performed.
# HELP node_nfs_rpcs_total Total number of RPCs performed.
# HELP node_perf_branch_instructions_total Number of CPU branch instructions
# TYPE node_perf_branch_instructions_total counter
node_perf_branch_instructions_total{cpu=0} 5.9196044e+07
node_perf_branch_instructions_total{cpu=1} 4.7814633e+07
node_perf_branch_instructions_total{cpu=10} 7.1260328e+07
node_perf_branch_instructions_total{cpu=11} 5.1564527e+07
node_perf_branch_instructions_total{cpu=12} 6.071945e+07
```

Signed-off-by: Daniel Hodges <hodges.daniel.scott@gmail.com>