### PR TITLE
feat: expose cpu frequency governor metrics

### DIFF
--- a/collector/cpufreq_common.go
+++ b/collector/cpufreq_common.go
@@ -23,17 +23,17 @@ import (
 var (
 	cpuFreqHertzDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "frequency_hertz"),
-		"Current cpu thread frequency in hertz.",
+		"Current CPU thread frequency in hertz.",
 		[]string{"cpu"}, nil,
 	)
 	cpuFreqMinDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "frequency_min_hertz"),
-		"Minimum cpu thread frequency in hertz.",
+		"Minimum CPU thread frequency in hertz.",
 		[]string{"cpu"}, nil,
 	)
 	cpuFreqMaxDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "frequency_max_hertz"),
-		"Maximum cpu thread frequency in hertz.",
+		"Maximum CPU thread frequency in hertz.",
 		[]string{"cpu"}, nil,
 	)
 	cpuFreqScalingFreqDesc = prometheus.NewDesc(
@@ -50,5 +50,10 @@ var (
 		prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "scaling_frequency_max_hertz"),
 		"Maximum scaled CPU thread frequency in hertz.",
 		[]string{"cpu"}, nil,
+	)
+	cpuFreqScalingGovernorDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "scaling_governor"),
+		"Current enabled CPU frequency governor.",
+		[]string{"cpu", "governor"}, nil,
 	)
 )

--- a/collector/cpufreq_linux.go
+++ b/collector/cpufreq_linux.go
@@ -104,6 +104,22 @@ func (c *cpuFreqCollector) Update(ch chan<- prometheus.Metric) error {
 				stats.Name,
 			)
 		}
+		if stats.Governor != "" {
+			availableGovernors := strings.Split(stats.AvailableGovernors, " ")
+			for _, g := range availableGovernors {
+				state := 0
+				if g == stats.Governor {
+					state = 1
+				}
+				ch <- prometheus.MustNewConstMetric(
+					cpuFreqScalingGovernorDesc,
+					prometheus.GaugeValue,
+					float64(state),
+					stats.Name,
+					g,
+				)
+			}
+		}
 	}
 	return nil
 }

--- a/collector/cpufreq_linux.go
+++ b/collector/cpufreq_linux.go
@@ -18,10 +18,10 @@ package collector
 
 import (
 	"fmt"
-
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs/sysfs"
+	"strings"
 )
 
 type cpuFreqCollector struct {

--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -326,6 +326,16 @@ node_cpu_scaling_frequency_min_hertz{cpu="0"} 8e+08
 node_cpu_scaling_frequency_min_hertz{cpu="1"} 8e+08
 node_cpu_scaling_frequency_min_hertz{cpu="2"} 1e+06
 node_cpu_scaling_frequency_min_hertz{cpu="3"} 1e+06
+# HELP node_cpu_scaling_governor Current enabled CPU frequency governor.
+# TYPE node_cpu_scaling_governor gauge
+node_cpu_scaling_governor{cpu="0",governor="performance"} 0
+node_cpu_scaling_governor{cpu="0",governor="powersave"} 1
+node_cpu_scaling_governor{cpu="1",governor="performance"} 0
+node_cpu_scaling_governor{cpu="1",governor="powersave"} 1
+node_cpu_scaling_governor{cpu="2",governor="performance"} 0
+node_cpu_scaling_governor{cpu="2",governor="powersave"} 1
+node_cpu_scaling_governor{cpu="3",governor="performance"} 0
+node_cpu_scaling_governor{cpu="3",governor="powersave"} 1
 # HELP node_cpu_seconds_total Seconds the CPUs spent in each mode.
 # TYPE node_cpu_seconds_total counter
 node_cpu_seconds_total{cpu="0",mode="idle"} 10870.69

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -348,6 +348,16 @@ node_cpu_scaling_frequency_min_hertz{cpu="0"} 8e+08
 node_cpu_scaling_frequency_min_hertz{cpu="1"} 8e+08
 node_cpu_scaling_frequency_min_hertz{cpu="2"} 1e+06
 node_cpu_scaling_frequency_min_hertz{cpu="3"} 1e+06
+# HELP node_cpu_scaling_governor Current enabled CPU frequency governor.
+# TYPE node_cpu_scaling_governor gauge
+node_cpu_scaling_governor{cpu="0",governor="performance"} 0
+node_cpu_scaling_governor{cpu="0",governor="powersave"} 1
+node_cpu_scaling_governor{cpu="1",governor="performance"} 0
+node_cpu_scaling_governor{cpu="1",governor="powersave"} 1
+node_cpu_scaling_governor{cpu="2",governor="performance"} 0
+node_cpu_scaling_governor{cpu="2",governor="powersave"} 1
+node_cpu_scaling_governor{cpu="3",governor="performance"} 0
+node_cpu_scaling_governor{cpu="3",governor="powersave"} 1
 # HELP node_cpu_seconds_total Seconds the CPUs spent in each mode.
 # TYPE node_cpu_seconds_total counter
 node_cpu_seconds_total{cpu="0",mode="idle"} 10870.69


### PR DESCRIPTION
Currently there are no metrics exposed about the CPU frequency governor(s). This PR exposes metrics with info about the available governors and indicate which one is in use. It also fixes inconsistencies in the description of some of the metrics exposed by the changed collector.


Adding a mention per the guidelines: @SuperQ, @discordianfish


Signed-off-by: Lukas Coppens <lukas.coppens@be-mobile.com>