### PR TITLE
Mixin: Convert graph panels to timeseries panels

### DIFF
--- a/docs/node-mixin/config.libsonnet
+++ b/docs/node-mixin/config.libsonnet
@@ -67,7 +67,7 @@
 
     dashboardNamePrefix: 'Node Exporter / ',
     dashboardTags: ['node-exporter-mixin'],
-    dashboardRefresh: "30s",
+    dashboardRefresh: '30s',
     dashboardTimezone: 'utc',
     dashboardInterval: 'now-2h',
   },

--- a/docs/node-mixin/config.libsonnet
+++ b/docs/node-mixin/config.libsonnet
@@ -67,5 +67,8 @@
 
     dashboardNamePrefix: 'Node Exporter / ',
     dashboardTags: ['node-exporter-mixin'],
+    dashboardRefresh: "30s",
+    dashboardTimezone: 'utc',
+    dashboardInterval: 'now-2h',
   },
 }

--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -146,11 +146,11 @@ local diskSpaceUtilisation =
 
                            dashboard.new(
                              '%sUSE Method / Node' % $._config.dashboardNamePrefix,
-                              time_from=$._config.dashboardInterval,
-                              tags=($._config.dashboardTags),
-                              timezone=$._config.dashboardTimezone,
-                              refresh=$._config.dashboardRefresh,
-                              graphTooltip='shared_crosshair'
+                             time_from=$._config.dashboardInterval,
+                             tags=($._config.dashboardTags),
+                             timezone=$._config.dashboardTimezone,
+                             refresh=$._config.dashboardRefresh,
+                             graphTooltip='shared_crosshair'
                            )
                            .addTemplate(datasourceTemplate)
                            .addTemplate($._clusterTemplate)

--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -146,11 +146,11 @@ local diskSpaceUtilisation =
 
                            dashboard.new(
                              '%sUSE Method / Node' % $._config.dashboardNamePrefix,
-                             time_from='now-1h',
-                             tags=($._config.dashboardTags),
-                             timezone='utc',
-                             refresh='30s',
-                             graphTooltip='shared_crosshair'
+                              time_from=$._config.dashboardInterval,
+                              tags=($._config.dashboardTags),
+                              timezone=$._config.dashboardTimezone,
+                              refresh=$._config.dashboardRefresh,
+                              graphTooltip='shared_crosshair'
                            )
                            .addTemplate(datasourceTemplate)
                            .addTemplate($._clusterTemplate)

--- a/docs/node-mixin/lib/panels.libsonnet
+++ b/docs/node-mixin/lib/panels.libsonnet
@@ -1,0 +1,3 @@
+{
+  nodeTimeseries:: import 'timeseries.libsonnet',
+}

--- a/docs/node-mixin/lib/prom-mixin.libsonnet
+++ b/docs/node-mixin/lib/prom-mixin.libsonnet
@@ -523,10 +523,10 @@ local nodeTimeseries = nodePanels.nodeTimeseries;
     dashboard: if platform == 'Linux' then
       dashboard.new(
         '%sNodes' % config.dashboardNamePrefix,
-        time_from='now-1h',
+        time_from=config.dashboardInterval,
         tags=(config.dashboardTags),
-        timezone='utc',
-        refresh='30s',
+        timezone=config.dashboardTimezone,
+        refresh=config.dashboardRefresh,
         graphTooltip='shared_crosshair'
       )
       .addTemplates(templates)
@@ -534,10 +534,10 @@ local nodeTimeseries = nodePanels.nodeTimeseries;
     else if platform == 'Darwin' then
       dashboard.new(
         '%sMacOS' % config.dashboardNamePrefix,
-        time_from='now-1h',
+        time_from=config.dashboardInterval,
         tags=(config.dashboardTags),
-        timezone='utc',
-        refresh='30s',
+        timezone=config.dashboardTimezone,
+        refresh=config.dashboardRefresh,
         graphTooltip='shared_crosshair'
       )
       .addTemplates(templates)

--- a/docs/node-mixin/lib/timeseries.libsonnet
+++ b/docs/node-mixin/lib/timeseries.libsonnet
@@ -1,0 +1,112 @@
+{
+  new(panel)::
+    panel
+    {
+      type: 'timeseries',
+      options+: {
+        tooltip: {
+          mode: 'multi',
+        },
+      },
+    }
+    + self.withFillOpacity(10)
+    + self.withGradientMode('opacity')
+    + self.withLineInterpolation('smooth')
+    + self.withShowPoints('never')
+    + self.withTooltip(mode='multi', sort='none'),
+  withTooltip(mode=null, sort='none'):: self {
+    options+: {
+      tooltip: {
+        mode: 'multi',
+        sort: 'none',
+      },
+    },
+
+  },
+  withLineInterpolation(value):: self {
+    fieldConfig+: {
+      defaults+: {
+        custom+: {
+          lineInterpolation: value,
+        },
+      },
+    },
+  },
+  withShowPoints(value):: self {
+    fieldConfig+: {
+      defaults+: {
+        custom+: {
+          showPoints: value,
+        },
+      },
+    },
+  },
+  withMin(value):: self {
+    fieldConfig+: {
+      defaults+: {
+        min: value,
+      },
+    },
+  },
+  withMax(value):: self {
+    fieldConfig+: {
+      defaults+: {
+        max: value,
+      },
+    },
+  },
+  withStacking(stack):: self {
+    fieldConfig+: {
+      defaults+: {
+        custom+: {
+          stacking: {
+            mode: stack,
+            group: 'A',
+          },
+        },
+      },
+    },
+  },
+  withGradientMode(mode):: self {
+    fieldConfig+: {
+      defaults+: {
+        custom+: {
+          gradientMode: mode,
+        },
+      },
+    },
+  },
+  addDataLink(title, url):: self {
+
+    fieldConfig+: {
+      defaults+: {
+        links: [
+          {
+            title: title,
+            url: url,
+          },
+        ],
+      },
+    },
+  },
+
+  withUnit(unit):: self {
+
+    fieldConfig+: {
+      defaults+: {
+        unit: unit,
+      },
+    },
+  },
+
+  withFillOpacity(opacity):: self {
+    fieldConfig+: {
+      defaults+: {
+        custom+: {
+          fillOpacity: opacity,
+        },
+      },
+    },
+
+  },
+}


### PR DESCRIPTION
Convert graph panels to timeseries panels with default style (opacity, tooltip etc).
Also:
Change 'logical core' line style to dotted
Update Disk I/O time metric to dots
Move dashboards parameters to _config

![image](https://user-images.githubusercontent.com/14870891/213434773-65cd0032-ca46-43fd-90c8-3ecb2d66ab8d.png)

