### PR TITLE
memory_bsd: Fix a problem fetching the user wire count on FreeBSD

### DIFF
--- a/collector/memory_bsd.go
+++ b/collector/memory_bsd.go
@@ -87,6 +87,7 @@ func NewMemoryCollector(logger log.Logger) (Collector, error) {
 				description: "Locked in memory by user, mlock, etc",
 				mib:         "vm.stats.vm.v_user_wire_count",
 				conversion:  fromPage,
+				dataType:    bsdSysctlTypeCLong,
 			},
 			{
 				name:        "cache_bytes",


### PR DESCRIPTION
This PR fixes a problem with fetching the `vm.stats.vm.v_user_wire_count` sysctl value on FreeBSD.

Without this fix, the following error is encountered:

```
caller=collector.go:169 level=error msg="collector failed" name=meminfo duration_seconds=1.9608e-05 err="couldn't get memory: cannot allocate memory"
```

The issue is resolved by setting the correct `dataType` on the metric.