### PR TITLE
Optimize cpufreq collector

### DIFF
--- a/collector/cpufreq_common.go
+++ b/collector/cpufreq_common.go
@@ -1,0 +1,54 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nocpu
+// +build !nocpu
+
+package collector
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	cpuFreqHertzDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "frequency_hertz"),
+		"Current cpu thread frequency in hertz.",
+		[]string{"cpu"}, nil,
+	)
+	cpuFreqMinDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "frequency_min_hertz"),
+		"Minimum cpu thread frequency in hertz.",
+		[]string{"cpu"}, nil,
+	)
+	cpuFreqMaxDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "frequency_max_hertz"),
+		"Maximum cpu thread frequency in hertz.",
+		[]string{"cpu"}, nil,
+	)
+	cpuFreqScalingFreqDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "scaling_frequency_hertz"),
+		"Current scaled CPU thread frequency in hertz.",
+		[]string{"cpu"}, nil,
+	)
+	cpuFreqScalingFreqMinDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "scaling_frequency_min_hertz"),
+		"Minimum scaled CPU thread frequency in hertz.",
+		[]string{"cpu"}, nil,
+	)
+	cpuFreqScalingFreqMaxDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "scaling_frequency_max_hertz"),
+		"Maximum scaled CPU thread frequency in hertz.",
+		[]string{"cpu"}, nil,
+	)
+)

--- a/collector/cpufreq_linux.go
+++ b/collector/cpufreq_linux.go
@@ -25,14 +25,8 @@ import (
 )
 
 type cpuFreqCollector struct {
-	fs             sysfs.FS
-	cpuFreq        *prometheus.Desc
-	cpuFreqMin     *prometheus.Desc
-	cpuFreqMax     *prometheus.Desc
-	scalingFreq    *prometheus.Desc
-	scalingFreqMin *prometheus.Desc
-	scalingFreqMax *prometheus.Desc
-	logger         log.Logger
+	fs     sysfs.FS
+	logger log.Logger
 }
 
 func init() {
@@ -47,37 +41,7 @@ func NewCPUFreqCollector(logger log.Logger) (Collector, error) {
 	}
 
 	return &cpuFreqCollector{
-		fs: fs,
-		cpuFreq: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "frequency_hertz"),
-			"Current cpu thread frequency in hertz.",
-			[]string{"cpu"}, nil,
-		),
-		cpuFreqMin: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "frequency_min_hertz"),
-			"Minimum cpu thread frequency in hertz.",
-			[]string{"cpu"}, nil,
-		),
-		cpuFreqMax: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "frequency_max_hertz"),
-			"Maximum cpu thread frequency in hertz.",
-			[]string{"cpu"}, nil,
-		),
-		scalingFreq: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "scaling_frequency_hertz"),
-			"Current scaled CPU thread frequency in hertz.",
-			[]string{"cpu"}, nil,
-		),
-		scalingFreqMin: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "scaling_frequency_min_hertz"),
-			"Minimum scaled CPU thread frequency in hertz.",
-			[]string{"cpu"}, nil,
-		),
-		scalingFreqMax: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "scaling_frequency_max_hertz"),
-			"Maximum scaled CPU thread frequency in hertz.",
-			[]string{"cpu"}, nil,
-		),
+		fs:     fs,
 		logger: logger,
 	}, nil
 }
@@ -94,7 +58,7 @@ func (c *cpuFreqCollector) Update(ch chan<- prometheus.Metric) error {
 	for _, stats := range cpuFreqs {
 		if stats.CpuinfoCurrentFrequency != nil {
 			ch <- prometheus.MustNewConstMetric(
-				c.cpuFreq,
+				cpuFreqHertzDesc,
 				prometheus.GaugeValue,
 				float64(*stats.CpuinfoCurrentFrequency)*1000.0,
 				stats.Name,
@@ -102,7 +66,7 @@ func (c *cpuFreqCollector) Update(ch chan<- prometheus.Metric) error {
 		}
 		if stats.CpuinfoMinimumFrequency != nil {
 			ch <- prometheus.MustNewConstMetric(
-				c.cpuFreqMin,
+				cpuFreqMinDesc,
 				prometheus.GaugeValue,
 				float64(*stats.CpuinfoMinimumFrequency)*1000.0,
 				stats.Name,
@@ -110,7 +74,7 @@ func (c *cpuFreqCollector) Update(ch chan<- prometheus.Metric) error {
 		}
 		if stats.CpuinfoMaximumFrequency != nil {
 			ch <- prometheus.MustNewConstMetric(
-				c.cpuFreqMax,
+				cpuFreqMaxDesc,
 				prometheus.GaugeValue,
 				float64(*stats.CpuinfoMaximumFrequency)*1000.0,
 				stats.Name,
@@ -118,7 +82,7 @@ func (c *cpuFreqCollector) Update(ch chan<- prometheus.Metric) error {
 		}
 		if stats.ScalingCurrentFrequency != nil {
 			ch <- prometheus.MustNewConstMetric(
-				c.scalingFreq,
+				cpuFreqScalingFreqDesc,
 				prometheus.GaugeValue,
 				float64(*stats.ScalingCurrentFrequency)*1000.0,
 				stats.Name,
@@ -126,7 +90,7 @@ func (c *cpuFreqCollector) Update(ch chan<- prometheus.Metric) error {
 		}
 		if stats.ScalingMinimumFrequency != nil {
 			ch <- prometheus.MustNewConstMetric(
-				c.scalingFreqMin,
+				cpuFreqScalingFreqMinDesc,
 				prometheus.GaugeValue,
 				float64(*stats.ScalingMinimumFrequency)*1000.0,
 				stats.Name,
@@ -134,7 +98,7 @@ func (c *cpuFreqCollector) Update(ch chan<- prometheus.Metric) error {
 		}
 		if stats.ScalingMaximumFrequency != nil {
 			ch <- prometheus.MustNewConstMetric(
-				c.scalingFreqMax,
+				cpuFreqScalingFreqMaxDesc,
 				prometheus.GaugeValue,
 				float64(*stats.ScalingMaximumFrequency)*1000.0,
 				stats.Name,

--- a/collector/cpufreq_solaris.go
+++ b/collector/cpufreq_solaris.go
@@ -29,9 +29,7 @@ import (
 import "C"
 
 type cpuFreqCollector struct {
-	cpuFreq    *prometheus.Desc
-	cpuFreqMax *prometheus.Desc
-	logger     log.Logger
+	logger log.Logger
 }
 
 func init() {
@@ -40,16 +38,6 @@ func init() {
 
 func NewCpuFreqCollector(logger log.Logger) (Collector, error) {
 	return &cpuFreqCollector{
-		cpuFreq: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "frequency_hertz"),
-			"Current CPU thread frequency in hertz.",
-			[]string{"cpu"}, nil,
-		),
-		cpuFreqMax: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, cpuCollectorSubsystem, "frequency_max_hertz"),
-			"Maximum CPU thread frequency in hertz.",
-			[]string{"cpu"}, nil,
-		),
 		logger: logger,
 	}, nil
 }
@@ -81,14 +69,14 @@ func (c *cpuFreqCollector) Update(ch chan<- prometheus.Metric) error {
 
 		lcpu := strconv.Itoa(cpu)
 		ch <- prometheus.MustNewConstMetric(
-			c.cpuFreq,
+			cpuFreqHertzDesc,
 			prometheus.GaugeValue,
 			float64(cpuFreqV.UintVal),
 			lcpu,
 		)
 		// Multiply by 1e+6 to convert MHz to Hz.
 		ch <- prometheus.MustNewConstMetric(
-			c.cpuFreqMax,
+			cpuFreqMaxDesc,
 			prometheus.GaugeValue,
 			float64(cpuFreqMaxV.IntVal)*1e+6,
 			lcpu,


### PR DESCRIPTION
Move metric descriptiions to package vars to avoid allocating them every time `NewCPUFreqCollector()` is called.

Signed-off-by: Ben Kochie <superq@gmail.com>