### PR TITLE
Deprecate ntp collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ logind | Exposes session counts from [logind](http://www.freedesktop.org/wiki/So
 meminfo\_numa | Exposes memory statistics from `/proc/meminfo_numa`. | Linux
 mountstats | Exposes filesystem statistics from `/proc/self/mountstats`. Exposes detailed NFS client statistics. | Linux
 network_route | Exposes the routing table as metrics | Linux
-ntp | Exposes local NTP daemon health to check [time](./docs/TIME.md) | _any_
 perf | Exposes perf based metrics (Warning: Metrics are dependent on kernel configuration and settings). | Linux
 processes | Exposes aggregate process statistics from `/proc`. | Linux
 qdisc | Exposes [queuing discipline](https://en.wikipedia.org/wiki/Network_scheduler#Linux_kernel) statistics | Linux
@@ -177,6 +176,14 @@ systemd | Exposes service and system status from [systemd](http://www.freedeskto
 tcpstat | Exposes TCP connection status information from `/proc/net/tcp` and `/proc/net/tcp6`. (Warning: the current version has potential performance issues in high load situations.) | Linux
 wifi | Exposes WiFi device and station statistics. | Linux
 zoneinfo | Exposes NUMA memory zone metrics. | Linux
+
+### Deprecated
+
+These colectors are deprecated and will be removed in the next major release.
+
+Name     | Description | OS
+---------|-------------|----
+ntp | Exposes local NTP daemon health to check [time](./docs/TIME.md) | _any_
 
 ### Perf Collector
 

--- a/collector/ntp.go
+++ b/collector/ntp.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/beevik/ntp"
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -79,6 +80,7 @@ func NewNtpCollector(logger log.Logger) (Collector, error) {
 		return nil, fmt.Errorf("invalid NTP port number %d; must be between 1 and 65535 inclusive", *ntpServerPort)
 	}
 
+	level.Warn(logger).Log("msg", "This collector is deprecated and will be removed in the next major version release.")
 	return &ntpCollector{
 		stratum: typedDesc{prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, ntpSubsystem, "stratum"),

--- a/docs/TIME.md
+++ b/docs/TIME.md
@@ -2,6 +2,8 @@
 
 ## `ntp` collector
 
+NOTE: This collector is deprecated and will be removed in the next major version release.
+
 This collector is intended for usage with local NTP daemons including [ntp.org](http://ntp.org/), [chrony](https://chrony.tuxfamily.org/comparison.html), and [OpenNTPD](http://www.openntpd.org/).
 
 Note, some chrony packages have `local stratum 10` configuration value making chrony a valid server when it is unsynchronised. This configuration makes one of the heuristics that derive `node_ntp_sanity` unreliable.


### PR DESCRIPTION
The ntp collector has always been a source of confusion and problems. The data it produces is more of a blackbox probe against an NTP server. The time sync / offset data produced is not what users expect.

Mark this collector as deprecated to be removed in v2.0.0