### PR TITLE
collector/diskstats: Use SCSI_IDENT_SERIAL as serial

### DIFF
--- a/collector/diskstats_linux.go
+++ b/collector/diskstats_linux.go
@@ -63,6 +63,7 @@ const (
 	udevIDRevision              = "ID_REVISION"
 	udevIDSerialShort           = "ID_SERIAL_SHORT"
 	udevIDWWN                   = "ID_WWN"
+	udevSCSIIdentSerial         = "SCSI_IDENT_SERIAL"
 )
 
 type typedFactorDesc struct {
@@ -286,13 +287,21 @@ func (c *diskstatsCollector) Update(ch chan<- prometheus.Metric) error {
 			level.Debug(c.logger).Log("msg", "Failed to parse udev info", "err", err)
 		}
 
+		// This is usually the serial printed on the disk label.
+		serial := info[udevSCSIIdentSerial]
+
+		// If it's undefined, fallback to ID_SERIAL_SHORT instead.
+		if serial == "" {
+			serial = info[udevIDSerialShort]
+		}
+
 		ch <- c.infoDesc.mustNewConstMetric(1.0, dev,
 			fmt.Sprint(stats.MajorNumber),
 			fmt.Sprint(stats.MinorNumber),
 			info[udevIDPath],
 			info[udevIDWWN],
 			info[udevIDModel],
-			info[udevIDSerialShort],
+			serial,
 			info[udevIDRevision],
 		)
 


### PR DESCRIPTION
On most hard drives, `ID_SERIAL_SHORT` and `SCSI_IDENT_SERIAL` are identical, but on some SAS drives they do differ. In that case, `SCSI_IDENT_SERIAL` corresponds to the serial number printed on the drive label, and to the value returned by `smartctl -i`.

So use that value by default for the `serial` label on the `node_disk_info` metric, and fallback to `ID_SERIAL_SHORT` only if it's undefined.