### PR TITLE
Fix filesystem collector for OpenBSD to not print loads of zero bytes

### DIFF
--- a/collector/filesystem_bsd.go
+++ b/collector/filesystem_bsd.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build ((openbsd && !amd64) || darwin || dragonfly) && !nofilesystem
-// +build openbsd,!amd64 darwin dragonfly
+//go:build (darwin || dragonfly) && !nofilesystem
+// +build darwin dragonfly
 // +build !nofilesystem
 
 package collector

--- a/collector/filesystem_openbsd.go
+++ b/collector/filesystem_openbsd.go
@@ -41,14 +41,14 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 
 	stats = []filesystemStats{}
 	for _, v := range mnt {
-		mountpoint := string(v.F_mntonname[:])
+		mountpoint := unix.ByteSliceToString(v.F_mntonname[:])
 		if c.excludedMountPointsPattern.MatchString(mountpoint) {
 			level.Debug(c.logger).Log("msg", "Ignoring mount point", "mountpoint", mountpoint)
 			continue
 		}
 
-		device := string(v.F_mntfromname[:])
-		fstype := string(v.F_fstypename[:])
+		device := unix.ByteSliceToString(v.F_mntfromname[:])
+		fstype := unix.ByteSliceToString(v.F_fstypename[:])
 		if c.excludedFSTypesPattern.MatchString(fstype) {
 			level.Debug(c.logger).Log("msg", "Ignoring fs type", "type", fstype)
 			continue


### PR DESCRIPTION
Also use the filesystem collector for all OpenBSD archs, there is no reason to only use it on amd64 systems.

Before:
```
node_filesystem_avail_bytes{device="/dev/sd0a���������������������������������������������������������������������������������",fstype="ffs�������������",mountpoint="/�����������������������������������������������������������������������������������������"} 7.860736e+08
```

After:
```
node_filesystem_avail_bytes{device="/dev/sd0a",fstype="ffs",mountpoint="/"} 7.860736e+08
```

Fix from `filesystem_freebsd.go`