### PR TITLE
docs (node/mixin): fix annotation for Skew alert

### DIFF
--- a/docs/node-mixin/alerts/alerts.libsonnet
+++ b/docs/node-mixin/alerts/alerts.libsonnet
@@ -231,7 +231,7 @@
             },
             annotations: {
               summary: 'Clock skew detected.',
-              description: 'Clock on {{ $labels.instance }} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.',
+              description: 'Clock on {{ $labels.instance }} is out of sync by more than 0.05s. Ensure NTP is configured correctly on this host.',
             },
           },
           {


### PR DESCRIPTION
This updates the annotation for the NodeClockSkewDetected mixin alert to match the new threshold set.

Original discussion was in this PR: https://github.com/prometheus/node_exporter/pull/1480

I spent an embarrassingly large amount of time trying to figure out how the heck that alert would mean 300s of clock skew. Turns out the annotation was just left the same after the threshold change.

@SuperQ 
@discordianfish 