### PR TITLE
Deprecate supervisord collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,6 @@ perf | Exposes perf based metrics (Warning: Metrics are dependent on kernel conf
 processes | Exposes aggregate process statistics from `/proc`. | Linux
 qdisc | Exposes [queuing discipline](https://en.wikipedia.org/wiki/Network_scheduler#Linux_kernel) statistics | Linux
 slabinfo | Exposes slab statistics from `/proc/slabinfo`. Note that permission of `/proc/slabinfo` is usually 0400, so set it appropriately. | Linux
-supervisord | Exposes service status from [supervisord](http://supervisord.org/). | _any_
 sysctl | Expose sysctl values from `/proc/sys`. Use `--collector.sysctl.include(-info)` to configure. | Linux
 systemd | Exposes service and system status from [systemd](http://www.freedesktop.org/wiki/Software/systemd/). | Linux
 tcpstat | Exposes TCP connection status information from `/proc/net/tcp` and `/proc/net/tcp6`. (Warning: the current version has potential performance issues in high load situations.) | Linux
@@ -212,6 +211,7 @@ Name     | Description | OS
 ---------|-------------|----
 ntp | Exposes local NTP daemon health to check [time](./docs/TIME.md) | _any_
 runit | Exposes service status from [runit](http://smarden.org/runit/). | _any_
+supervisord | Exposes service status from [supervisord](http://supervisord.org/). | _any_
 
 ### Perf Collector
 

--- a/collector/supervisord.go
+++ b/collector/supervisord.go
@@ -69,6 +69,8 @@ func NewSupervisordCollector(logger log.Logger) (Collector, error) {
 		xrpc = xmlrpc.NewClient(*supervisordURL)
 	}
 
+	level.Warn(logger).Log("msg", "This collector is deprecated and will be removed in the next major version release.")
+
 	return &supervisordCollector{
 		upDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "up"),


### PR DESCRIPTION
Mark the `supervisord` as deprecated. This process
supevisor, like `runit`, is of scope for the node_exporter.