### PR TITLE
Update ansible role in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The `node_exporter` listens on HTTP port 9100 by default. See the `--help` outpu
 
 ### Ansible
 
-For automated installs with [Ansible](https://www.ansible.com/), there is the [Cloud Alchemy role](https://github.com/cloudalchemy/ansible-node-exporter).
+For automated installs with [Ansible](https://www.ansible.com/), there is the [Prometheus Community role](https://github.com/prometheus-community/ansible).
 
 ### Docker
 


### PR DESCRIPTION
@SuperQ, @discordianfish: This is just a small change in the readme, because https://github.com/cloudalchemy/ansible-node-exporter has been deprecated on Mar 2, 2023.