### PR TITLE
Update golangci-lint config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,13 +28,6 @@ jobs:
       - checkout
       - run: uname -a
       - run: make test-e2e
-  codespell:
-    docker:
-      - image: circleci/python
-    steps:
-      - checkout
-      - run: sudo pip install codespell
-      - run: codespell --skip=".git,./vendor,ttar,go.mod,go.sum,*pem,./collector/fixtures" -I scripts/codespell_ignore.txt
   test_mixins:
     executor: golang
     steps:
@@ -102,10 +95,6 @@ workflows:
             tags:
               only: /.*/
       - build:
-          filters:
-            tags:
-              only: /.*/
-      - codespell:
           filters:
             tags:
               only: /.*/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 linters:
   enable:
+    - misspell
     - revive
   disable:
     # Disable soon to deprecated[1] linters that lead to false
@@ -19,4 +20,8 @@ issues:
 
 linters-settings:
   errcheck:
-    exclude: scripts/errcheck_excludes.txt
+    exclude-functions:
+      # Used in HTTP handlers, any error is handled by the server itself.
+      - (net/http.ResponseWriter).Write
+      # Never check for logger errors.
+      - (github.com/go-kit/log.Logger).Log

--- a/scripts/codespell_ignore.txt
+++ b/scripts/codespell_ignore.txt
@@ -1,6 +1,0 @@
-inflight
-packages\'
-ro
-siz
-uint
-uptodate

--- a/scripts/errcheck_excludes.txt
+++ b/scripts/errcheck_excludes.txt
@@ -1,4 +1,0 @@
-// Used in HTTP handlers, any error is handled by the server itself.
-(net/http.ResponseWriter).Write
-// Never check for logger errors.
-(github.com/go-kit/log.Logger).Log


### PR DESCRIPTION
* Migrate from Python codespell to golangci-lint misspell.
* Inline errcheck exclude list in the golangci-lint config.