### PR TITLE
Fixup hwmon chip include

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ ethtool | device | --collector.ethtool.device-include | --collector.ethtool.devi
 ethtool | metrics | --collector.ethtool.metrics-include | N/A
 filesystem | fs-types | N/A | --collector.filesystem.fs-types-exclude
 filesystem | mount-points | N/A | --collector.filesystem.mount-points-exclude
+hwmon | chip | --collector.hwmon.chip-include | --collector.hwmon.chip-exclude
 netdev | device | --collector.netdev.device-include | --collector.netdev.device-exclude
 qdisk | device | --collector.qdisk.device-include | --collector.qdisk.device-exclude
 sysctl | all | --collector.sysctl.include | N/A

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -356,6 +356,9 @@ Lines: 1
 100000
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/hwmon/hwmon5
+SymlinkTo: ../../devices/platform/bogus.0/hwmon/hwmon5/
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/class/infiniband
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2671,6 +2674,45 @@ Path: sys/devices/platform/applesmc.768/name
 Lines: 1
 applesmc
 Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/platform/bogus.0
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/platform/bogus.0/hwmon
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/platform/bogus.0/hwmon/hwmon5
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/bogus.0/hwmon/hwmon5/bogus1_crit
+Lines: 1
+100000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/bogus.0/hwmon/hwmon5/bogus1_crit_alarm
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/bogus.0/hwmon/hwmon5/bogus1_input
+Lines: 1
+55000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/bogus.0/hwmon/hwmon5/bogus1_label
+Lines: 1
+Physical id 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/bogus.0/hwmon/hwmon5/bogus1_max
+Lines: 1
+84000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/bogus.0/hwmon/hwmon5/name
+Lines: 1
+bogus
+Mode: 664
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/devices/platform/coretemp.0
 Mode: 755

--- a/collector/hwmon_linux.go
+++ b/collector/hwmon_linux.go
@@ -61,7 +61,7 @@ func NewHwMonCollector(logger log.Logger) (Collector, error) {
 
 	return &hwMonCollector{
 		logger:       logger,
-		deviceFilter: newDeviceFilter(*collectorHWmonChipExclude, *collectorHWmonChipExclude),
+		deviceFilter: newDeviceFilter(*collectorHWmonChipExclude, *collectorHWmonChipInclude),
 	}, nil
 }
 
@@ -164,6 +164,7 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) er
 	}
 
 	if c.deviceFilter.ignored(hwmonName) {
+		level.Debug(c.logger).Log("msg", "ignoring hwmon chip", "chip", hwmonName)
 		return nil
 	}
 

--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -132,6 +132,7 @@ fi
   --collector.qdisc.fixtures="collector/fixtures/qdisc/" \
   --collector.qdisk.device-include="(wlan0|eth0)" \
   --collector.arp.device-exclude="nope" \
+  --collector.hwmon.chip-include="(applesmc|coretemp|hwmon4|nct6779)" \
   --collector.netclass.ignored-devices="(dmz|int)" \
   --collector.netclass.ignore-invalid-speed \
   --collector.netdev.device-include="lo" \


### PR DESCRIPTION
Use the correct include value to the device filter function.
* Add new bogus hwmon fixture.
* Update end-to-end test to use hwmon chip include flag.