### PR TITLE
Sync build tags in *_test.go

### DIFF
--- a/collector/bonding_linux_test.go
+++ b/collector/bonding_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nobonding
+// +build !nobonding
+
 package collector
 
 import (

--- a/collector/diskstats_linux_test.go
+++ b/collector/diskstats_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nodiskstats
+// +build !nodiskstats
+
 package collector
 
 import (

--- a/collector/ethtool_linux_test.go
+++ b/collector/ethtool_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !noethtool
+// +build !noethtool
+
 package collector
 
 import (

--- a/collector/filefd_linux_test.go
+++ b/collector/filefd_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nofilefd
+// +build !nofilefd
+
 package collector
 
 import "testing"

--- a/collector/filesystem_linux_test.go
+++ b/collector/filesystem_linux_test.go
@@ -11,14 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nofilesystem
+// +build !nofilesystem
+
 package collector
 
 import (
-	"github.com/go-kit/log"
 	"strings"
 	"testing"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/go-kit/log"
 )
 
 func Test_parseFilesystemLabelsError(t *testing.T) {

--- a/collector/interrupts_linux_test.go
+++ b/collector/interrupts_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nointerrupts
+// +build !nointerrupts
+
 package collector
 
 import (

--- a/collector/ipvs_linux_test.go
+++ b/collector/ipvs_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !noipvs
+// +build !noipvs
+
 package collector
 
 import (

--- a/collector/loadavg_linux_test.go
+++ b/collector/loadavg_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !noloadavg
+// +build !noloadavg
+
 package collector
 
 import "testing"

--- a/collector/logind_linux_test.go
+++ b/collector/logind_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nologind
+// +build !nologind
+
 package collector
 
 import (

--- a/collector/meminfo_linux_test.go
+++ b/collector/meminfo_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nomeminfo
+// +build !nomeminfo
+
 package collector
 
 import (

--- a/collector/meminfo_numa_linux_test.go
+++ b/collector/meminfo_numa_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nomeminfo_numa
+// +build !nomeminfo_numa
+
 package collector
 
 import (

--- a/collector/netdev_linux_test.go
+++ b/collector/netdev_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nonetdev
+// +build !nonetdev
+
 package collector
 
 import (

--- a/collector/netstat_linux_test.go
+++ b/collector/netstat_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nonetstat
+// +build !nonetstat
+
 package collector
 
 import (

--- a/collector/perf_linux_test.go
+++ b/collector/perf_linux_test.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !noprocesses
-// +build !noprocesses
+//go:build !noperf
+// +build !noperf
 
 package collector
 
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/systemd_linux_test.go
+++ b/collector/systemd_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nosystemd
+// +build !nosystemd
+
 package collector
 
 import (

--- a/collector/tcpstat_linux_test.go
+++ b/collector/tcpstat_linux_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !notcpstat
+// +build !notcpstat
+
 package collector
 
 import (

--- a/collector/textfile_test.go
+++ b/collector/textfile_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !notextfile
+// +build !notextfile
+
 package collector
 
 import (


### PR DESCRIPTION
Ensure that unwanted tests are correctly excluded when various build tags are specified, i.e. when the code that they test would be excluded from compilation.