### PR TITLE
Drop redundant GOOS build tags if already in filename

### DIFF
--- a/collector/boot_time_solaris.go
+++ b/collector/boot_time_solaris.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build solaris && !noboottime
-// +build solaris,!noboottime
+//go:build !noboottime
+// +build !noboottime
 
 package collector
 

--- a/collector/cpu_solaris.go
+++ b/collector/cpu_solaris.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build solaris && !nocpu
-// +build solaris,!nocpu
+//go:build !nocpu
+// +build !nocpu
 
 package collector
 

--- a/collector/cpufreq_solaris.go
+++ b/collector/cpufreq_solaris.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build solaris && !nocpu
-// +build solaris,!nocpu
+//go:build !nocpu
+// +build !nocpu
 
 package collector
 

--- a/collector/diskstats_openbsd.go
+++ b/collector/diskstats_openbsd.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build openbsd && !amd64 && !nodiskstats
-// +build openbsd,!amd64,!nodiskstats
+//go:build !nodiskstats && !amd64
+// +build !nodiskstats,!amd64
 
 package collector
 

--- a/collector/fibrechannel_linux.go
+++ b/collector/fibrechannel_linux.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux && !nofibrechannel
-// +build linux,!nofibrechannel
+//go:build !nofibrechannel
+// +build !nofibrechannel
 
 package collector
 

--- a/collector/filesystem_openbsd.go
+++ b/collector/filesystem_openbsd.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build openbsd && !nofilesystem
-// +build openbsd,!nofilesystem
+//go:build !nofilesystem
+// +build !nofilesystem
 
 package collector
 

--- a/collector/infiniband_linux.go
+++ b/collector/infiniband_linux.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux && !noinfiniband
-// +build linux,!noinfiniband
+//go:build !noinfiniband
+// +build !noinfiniband
 
 package collector
 

--- a/collector/interrupts_openbsd.go
+++ b/collector/interrupts_openbsd.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build openbsd && !amd64 && !nointerrupts
-// +build openbsd,!amd64,!nointerrupts
+//go:build !nointerrupts && !amd64
+// +build !nointerrupts,!amd64
 
 package collector
 

--- a/collector/meminfo_netbsd.go
+++ b/collector/meminfo_netbsd.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build netbsd && !nomeminfo
-// +build netbsd,!nomeminfo
+//go:build !nomeminfo
+// +build !nomeminfo
 
 package collector
 

--- a/collector/meminfo_openbsd.go
+++ b/collector/meminfo_openbsd.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build openbsd && !amd64 && !nomeminfo
-// +build openbsd,!amd64,!nomeminfo
+//go:build !nomeminfo && !amd64
+// +build !nomeminfo,!amd64
 
 package collector
 

--- a/collector/netdev_openbsd.go
+++ b/collector/netdev_openbsd.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build openbsd && !amd64 && !nonetdev
-// +build openbsd,!amd64,!nonetdev
+//go:build !nonetdev && !amd64
+// +build !nonetdev,!amd64
 
 package collector
 

--- a/collector/netisr_freebsd.go
+++ b/collector/netisr_freebsd.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build freebsd && !nonetisr
-// +build freebsd,!nonetisr
+//go:build !nonetisr
+// +build !nonetisr
 
 package collector
 

--- a/collector/nvme_linux.go
+++ b/collector/nvme_linux.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux && !nonvme
-// +build linux,!nonvme
+//go:build !nonvme
+// +build !nonvme
 
 package collector
 

--- a/collector/selinux_linux.go
+++ b/collector/selinux_linux.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux && !noselinux
-// +build linux,!noselinux
+//go:build !noselinux
+// +build !noselinux
 
 package collector
 

--- a/collector/slabinfo_linux.go
+++ b/collector/slabinfo_linux.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux && !noslabinfo
-// +build linux,!noslabinfo
+//go:build !noslabinfo
+// +build !noslabinfo
 
 package collector
 

--- a/collector/time_linux.go
+++ b/collector/time_linux.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux && !notime
-// +build linux,!notime
+//go:build !notime
+// +build !notime
 
 package collector
 

--- a/collector/zfs_solaris.go
+++ b/collector/zfs_solaris.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build solaris && !nozfs
-// +build solaris,!nozfs
+//go:build !nozfs
+// +build !nozfs
 
 package collector
 


### PR DESCRIPTION
Drop redundant GOOS build tags at start of file if the constraint is already specified by the filename, e.g. foo_GOOS.go or foo_GOOS_GOARCH.go, avoiding potential confusion in future.

cf. https://pkg.go.dev/cmd/go#hdr-Build_constraints