### PR TITLE
btrfs: close btrfs.FS handle after use

### DIFF
--- a/collector/btrfs_linux.go
+++ b/collector/btrfs_linux.go
@@ -135,6 +135,7 @@ func (c *btrfsCollector) getIoctlStats() (map[string]*btrfsIoctlFsStats, error) 
 				"err", err)
 			continue
 		}
+		defer fs.Close()
 
 		fsInfo, err := fs.Info()
 		if err != nil {


### PR DESCRIPTION
Despite being quite hard to provoke (< 10% in my testing), the btrfs collector would occasionally leave stale FDs relating to btrfs mountpoints, making the filesystems unable to be unmounted.

Fixes: #2772.