### PR TITLE
Add mitigation information label to the linux CPU vulnerabilities metric

### DIFF
--- a/collector/cpu_vulnerabilities_linux.go
+++ b/collector/cpu_vulnerabilities_linux.go
@@ -29,7 +29,7 @@ var (
 	vulnerabilityDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, cpuVulerabilitiesCollector, "info"),
 		"Details of each CPU vulnerability reported by sysfs. The value of the series is an int encoded state of the vulnerability. The same state is stored as a string in the label",
-		[]string{"codename", "state"},
+		[]string{"codename", "state", "mitigation"},
 		nil,
 	)
 )
@@ -62,6 +62,7 @@ func (v *cpuVulnerabilitiesCollector) Update(ch chan<- prometheus.Metric) error 
 			1.0,
 			vulnerability.CodeName,
 			sysfs.VulnerabilityHumanEncoding[vulnerability.State],
+			vulnerability.Mitigation,
 		)
 	}
 	return nil

--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -404,11 +404,11 @@ node_cpu_seconds_total{cpu="7",mode="system"} 101.64
 node_cpu_seconds_total{cpu="7",mode="user"} 290.98
 # HELP node_cpu_vulnerabilities_info Details of each CPU vulnerability reported by sysfs. The value of the series is an int encoded state of the vulnerability. The same state is stored as a string in the label
 # TYPE node_cpu_vulnerabilities_info gauge
-node_cpu_vulnerabilities_info{codename="itlb_multihit",state="not affected"} 1
-node_cpu_vulnerabilities_info{codename="mds",state="vulnerable"} 1
-node_cpu_vulnerabilities_info{codename="retbleed",state="mitigation"} 1
-node_cpu_vulnerabilities_info{codename="spectre_v1",state="mitigation"} 1
-node_cpu_vulnerabilities_info{codename="spectre_v2",state="mitigation"} 1
+node_cpu_vulnerabilities_info{codename="itlb_multihit",mitigation="",state="not affected"} 1
+node_cpu_vulnerabilities_info{codename="mds",mitigation="",state="vulnerable"} 1
+node_cpu_vulnerabilities_info{codename="retbleed",mitigation="untrained return thunk; SMT enabled with STIBP protection",state="mitigation"} 1
+node_cpu_vulnerabilities_info{codename="spectre_v1",mitigation="usercopy/swapgs barriers and __user pointer sanitization",state="mitigation"} 1
+node_cpu_vulnerabilities_info{codename="spectre_v2",mitigation="Retpolines, IBPB: conditional, STIBP: always-on, RSB filling, PBRSB-eIBRS: Not affected",state="mitigation"} 1
 # HELP node_disk_ata_rotation_rate_rpm ATA disk rotation rate in RPMs (0 for SSDs).
 # TYPE node_disk_ata_rotation_rate_rpm gauge
 node_disk_ata_rotation_rate_rpm{device="sda"} 7200

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -426,11 +426,11 @@ node_cpu_seconds_total{cpu="7",mode="system"} 101.64
 node_cpu_seconds_total{cpu="7",mode="user"} 290.98
 # HELP node_cpu_vulnerabilities_info Details of each CPU vulnerability reported by sysfs. The value of the series is an int encoded state of the vulnerability. The same state is stored as a string in the label
 # TYPE node_cpu_vulnerabilities_info gauge
-node_cpu_vulnerabilities_info{codename="itlb_multihit",state="not affected"} 1
-node_cpu_vulnerabilities_info{codename="mds",state="vulnerable"} 1
-node_cpu_vulnerabilities_info{codename="retbleed",state="mitigation"} 1
-node_cpu_vulnerabilities_info{codename="spectre_v1",state="mitigation"} 1
-node_cpu_vulnerabilities_info{codename="spectre_v2",state="mitigation"} 1
+node_cpu_vulnerabilities_info{codename="itlb_multihit",mitigation="",state="not affected"} 1
+node_cpu_vulnerabilities_info{codename="mds",mitigation="",state="vulnerable"} 1
+node_cpu_vulnerabilities_info{codename="retbleed",mitigation="untrained return thunk; SMT enabled with STIBP protection",state="mitigation"} 1
+node_cpu_vulnerabilities_info{codename="spectre_v1",mitigation="usercopy/swapgs barriers and __user pointer sanitization",state="mitigation"} 1
+node_cpu_vulnerabilities_info{codename="spectre_v2",mitigation="Retpolines, IBPB: conditional, STIBP: always-on, RSB filling, PBRSB-eIBRS: Not affected",state="mitigation"} 1
 # HELP node_disk_ata_rotation_rate_rpm ATA disk rotation rate in RPMs (0 for SSDs).
 # TYPE node_disk_ata_rotation_rate_rpm gauge
 node_disk_ata_rotation_rate_rpm{device="sda"} 7200


### PR DESCRIPTION
While the CPU vulnerabilities metric has been added in #2721, it's currently not including information regarding the mitigation strategy used for a given vulnerability.

This information can be quite valuable, as oftentimes different mitigation strategies come with a different performance impact.

This commit adds a third label to the cpu_vulnerabilities_info metric, to include the "mitigation" used for a given vulnerability - if a given vulnerability is not affecting a node or the node is still vulnerable, the mitigation is expected to be empty.