### PR TITLE
Move RO status before error return

### DIFF
--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -186,6 +186,11 @@ func (c *filesystemCollector) Update(ch chan<- prometheus.Metric) error {
 			c.deviceErrorDesc, prometheus.GaugeValue,
 			s.deviceError, s.labels.device, s.labels.mountPoint, s.labels.fsType,
 		)
+		ch <- prometheus.MustNewConstMetric(
+			c.roDesc, prometheus.GaugeValue,
+			s.ro, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+		)
+
 		if s.deviceError > 0 {
 			continue
 		}
@@ -209,10 +214,6 @@ func (c *filesystemCollector) Update(ch chan<- prometheus.Metric) error {
 		ch <- prometheus.MustNewConstMetric(
 			c.filesFreeDesc, prometheus.GaugeValue,
 			s.filesFree, s.labels.device, s.labels.mountPoint, s.labels.fsType,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.roDesc, prometheus.GaugeValue,
-			s.ro, s.labels.device, s.labels.mountPoint, s.labels.fsType,
 		)
 	}
 	return nil

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -109,6 +109,14 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 }
 
 func (c *filesystemCollector) processStat(labels filesystemLabels) filesystemStats {
+	var ro float64
+	for _, option := range strings.Split(labels.options, ",") {
+		if option == "ro" {
+			ro = 1
+			break
+		}
+	}
+
 	success := make(chan struct{})
 	go stuckMountWatcher(labels.mountPoint, success, c.logger)
 
@@ -129,16 +137,10 @@ func (c *filesystemCollector) processStat(labels filesystemLabels) filesystemSta
 		return filesystemStats{
 			labels:      labels,
 			deviceError: 1,
+			ro:          ro,
 		}
 	}
 
-	var ro float64
-	for _, option := range strings.Split(labels.options, ",") {
-		if option == "ro" {
-			ro = 1
-			break
-		}
-	}
 	return filesystemStats{
 		labels:    labels,
 		size:      float64(buf.Blocks) * float64(buf.Bsize),


### PR DESCRIPTION
It should resolve the following situation:
https://discuss.prometheus.io/t/running-node-exporter-on-kubernetes-without-root-privileges/1896/2