### PR TITLE
Update README.md: update the 'more details' url in the section 'TLS endpoint'

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ The exporter supports TLS via a new web configuration file.
 ./node_exporter --web.config.file=web-config.yml
 ```
 
-See the [exporter-toolkit web-configuration](https://github.com/prometheus/exporter-toolkit/blob/v0.10.0/docs/web-configuration.md) for more details.
+See the [exporter-toolkit web-configuration](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md) for more details.
 
 [travis]: https://travis-ci.org/prometheus/node_exporter
 [hub]: https://hub.docker.com/r/prom/node-exporter/

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ The exporter supports TLS via a new web configuration file.
 ./node_exporter --web.config.file=web-config.yml
 ```
 
-See the [exporter-toolkit https package](https://github.com/prometheus/exporter-toolkit/blob/v0.1.0/https/README.md) for more details.
+See the [exporter-toolkit web-configuration](https://github.com/prometheus/exporter-toolkit/blob/v0.10.0/docs/web-configuration.md) for more details.
 
 [travis]: https://travis-ci.org/prometheus/node_exporter
 [hub]: https://hub.docker.com/r/prom/node-exporter/


### PR DESCRIPTION
The present url https://github.com/prometheus/exporter-toolkit/blob/v0.1.0/https/README.md is out of date(v0.1.0) and gives misleading information like `To run a server with TLS, use the flag --web.config`.