### PR TITLE
NFSd: fix nfsd v4 index miss

### DIFF
--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -2738,6 +2738,8 @@ node_nfsd_requests_total{method="SecInfo",proto="4"} 0
 node_nfsd_requests_total{method="SetAttr",proto="2"} 0
 node_nfsd_requests_total{method="SetAttr",proto="3"} 0
 node_nfsd_requests_total{method="SetAttr",proto="4"} 0
+node_nfsd_requests_total{method="SetClientID",proto="4"} 3
+node_nfsd_requests_total{method="SetClientIDConfirm",proto="4"} 3
 node_nfsd_requests_total{method="SymLink",proto="2"} 0
 node_nfsd_requests_total{method="SymLink",proto="3"} 0
 node_nfsd_requests_total{method="Verify",proto="4"} 0

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2760,6 +2760,8 @@ node_nfsd_requests_total{method="SecInfo",proto="4"} 0
 node_nfsd_requests_total{method="SetAttr",proto="2"} 0
 node_nfsd_requests_total{method="SetAttr",proto="3"} 0
 node_nfsd_requests_total{method="SetAttr",proto="4"} 0
+node_nfsd_requests_total{method="SetClientID",proto="4"} 3
+node_nfsd_requests_total{method="SetClientIDConfirm",proto="4"} 3
 node_nfsd_requests_total{method="SymLink",proto="2"} 0
 node_nfsd_requests_total{method="SymLink",proto="3"} 0
 node_nfsd_requests_total{method="Verify",proto="4"} 0

--- a/collector/nfsd_linux.go
+++ b/collector/nfsd_linux.go
@@ -398,6 +398,10 @@ func (c *nfsdCollector) updateNFSdRequestsv4Stats(ch chan<- prometheus.Metric, s
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
 		float64(s.Verify), proto, "Verify")
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
+		float64(s.SetClientId), proto, "SetClientId")
+	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
+		float64(s.SetClientIdConfirm), proto, "SetClientIdConfirm")
+	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
 		float64(s.Write), proto, "Write")
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
 		float64(s.RelLockOwner), proto, "RelLockOwner")

--- a/collector/nfsd_linux.go
+++ b/collector/nfsd_linux.go
@@ -396,9 +396,9 @@ func (c *nfsdCollector) updateNFSdRequestsv4Stats(ch chan<- prometheus.Metric, s
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
 		float64(s.SetAttr), proto, "SetAttr")
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
-		float64(s.SetClientId), proto, "SetClientId")
+		float64(s.SetClientID), proto, "SetClientId")
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
-		float64(s.SetClientIdConfirm), proto, "Verify")
+		float64(s.SetClientIDConfirm), proto, "Verify")
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
 		float64(s.Verify), proto, "Verify")
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,

--- a/collector/nfsd_linux.go
+++ b/collector/nfsd_linux.go
@@ -396,9 +396,9 @@ func (c *nfsdCollector) updateNFSdRequestsv4Stats(ch chan<- prometheus.Metric, s
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
 		float64(s.SetAttr), proto, "SetAttr")
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
-		float64(s.SetClientID), proto, "SetClientId")
+		float64(s.SetClientID), proto, "SetClientID")
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
-		float64(s.SetClientIDConfirm), proto, "Verify")
+		float64(s.SetClientIDConfirm), proto, "SetClientIDConfirm")
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
 		float64(s.Verify), proto, "Verify")
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,

--- a/collector/nfsd_linux.go
+++ b/collector/nfsd_linux.go
@@ -396,11 +396,11 @@ func (c *nfsdCollector) updateNFSdRequestsv4Stats(ch chan<- prometheus.Metric, s
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
 		float64(s.SetAttr), proto, "SetAttr")
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
-		float64(s.Verify), proto, "Verify")
-	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
 		float64(s.SetClientId), proto, "SetClientId")
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
-		float64(s.SetClientIdConfirm), proto, "SetClientIdConfirm")
+		float64(s.SetClientIdConfirm), proto, "Verify")
+	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
+		float64(s.Verify), proto, "Verify")
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,
 		float64(s.Write), proto, "Write")
 	ch <- prometheus.MustNewConstMetric(c.requestsDesc, prometheus.CounterValue,


### PR DESCRIPTION
fix: https://github.com/prometheus/procfs/pull/543 

 It’s just that the lack of `OP_SETCLIENTID` and `OP_SETCLIENTID_CONFIRM` caused the index miss match.
ref: https://www.rfc-editor.org/rfc/rfc7530.html#page-299

