### PR TITLE
Automatically set GOMAXPROCS according to available CPU quota

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/prometheus/exporter-toolkit v0.10.0
 	github.com/prometheus/procfs v0.12.0
 	github.com/safchain/ethtool v0.3.0
+	go.uber.org/automaxprocs v1.5.3
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/sys v0.13.0
 	howett.net/plist v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,7 @@ github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaL
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prometheus-community/go-runit v0.1.0 h1:uTWEj/Fn2RoLdfg/etSqwzgYNOYPrARx1BHUN052tGA=
 github.com/prometheus-community/go-runit v0.1.0/go.mod h1:AvJ9Jo3gAFu2lbM4+qfjdpq30FfiLDJZKbQ015u08IQ=
 github.com/prometheus/client_golang v1.17.0 h1:rl2sfwZMtSthVU752MqfjQozy7blglC+1SOtjMAMh+Q=
@@ -105,6 +106,8 @@ github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtX
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/automaxprocs v1.5.3 h1:kWazyxZUrS3Gs4qUpbwo5kEIMGe/DAvi5Z4tl2NW4j8=
+go.uber.org/automaxprocs v1.5.3/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
This PR allows node_exporter to automatically set GOMAXPROCS according to available CPU quota if `--runtime.gomaxprocs` < 1, using the `go.uber.org/automaxprocs` package.
This is useful for running node_exporter on containerized environments with CPU resource limits.
This makes the node_exporter take advantage of its allocated CPU quota while avoiding being throttled due to over consumption of CPU burst budgets.

Here are the logs showing how it behavior under various configurations:
- When `--runtime.gomaxprocs` is set > 1,  `GOMAXPROCS`  takes its value regardless of the situation. 
```shell
$docker run --cpu-period=10000 --cpu-quota=36000   node_exporter --collector.disable-defaults --log.level=debug --runtime.gomaxprocs=5
ts=2023-10-23T15:22:04.327Z caller=node_exporter.go:193 level=info msg="Starting node_exporter" version="(version=1.6.1, branch=auto_maxprocs, revision=86ed8cdc6b1ba328e7ac4a9b1680129e9ab3d309)"
ts=2023-10-23T15:22:04.327Z caller=node_exporter.go:194 level=info msg="Build context" build_context="(go=go1.20.3, platform=linux/amd64, user=hsun@WORKPC-RH1, date=20231023-13:16:46, tags=netgo osusergo static_build)"
ts=2023-10-23T15:22:04.327Z caller=node_exporter.go:211 level=debug msg="Go MAXPROCS" procs=5
ts=2023-10-23T15:22:04.327Z caller=node_exporter.go:111 level=info msg="Enabled collectors"
ts=2023-10-23T15:22:04.328Z caller=tls_config.go:274 level=info msg="Listening on" address=[::]:9100
ts=2023-10-23T15:22:04.328Z caller=tls_config.go:277 level=info msg="TLS is disabled." http2=false address=[::]:9100
```
- When `--runtime.gomaxprocs` is set < 1,  `GOMAXPROCS`  is automatically set to optimal value.
```shell
$docker run --cpu-period=10000 --cpu-quota=36000   node_exporter --collector.disable-defaults -
-log.level=debug --runtime.gomaxprocs=0
ts=2023-10-23T15:21:03.075Z caller=node_exporter.go:193 level=info msg="Starting node_exporter" version="(version=1.6.1, branch=auto_maxprocs, revision=86ed8cdc6b1ba328e7ac4a9b1680129e9ab3d309)"
ts=2023-10-23T15:21:03.075Z caller=node_exporter.go:194 level=info msg="Build context" build_context="(go=go1.20.3, platform=linux/amd64, user=hsun@WORKPC-RH1, date=20231023-13:16:46, tags=netgo osusergo static_build)"
ts=2023-10-23T15:21:03.076Z caller=node_exporter.go:202 level=debug msg="maxprocs: Updating GOMAXPROCS=3: determined from CPU quota"
ts=2023-10-23T15:21:03.076Z caller=node_exporter.go:211 level=debug msg="Go MAXPROCS" procs=3
ts=2023-10-23T15:21:03.076Z caller=node_exporter.go:111 level=info msg="Enabled collectors"
ts=2023-10-23T15:21:03.077Z caller=tls_config.go:274 level=info msg="Listening on" address=[::]:9100
ts=2023-10-23T15:21:03.077Z caller=tls_config.go:277 level=info msg="TLS is disabled." http2=false address=[::]:9100
```
- - When `--runtime.gomaxprocs` is not set , `GOMAXPROCS`  is set to its default value 1.
```shell
$docker run --cpu-period=10000 --cpu-quota=36000   node_exporter --collector.disable-defaults --log.level=debug
ts=2023-10-23T15:21:35.110Z caller=node_exporter.go:193 level=info msg="Starting node_exporter" version="(version=1.6.1, branch=auto_maxprocs, revision=86ed8cdc6b1ba328e7ac4a9b1680129e9ab3d309)"
ts=2023-10-23T15:21:35.111Z caller=node_exporter.go:194 level=info msg="Build context" build_context="(go=go1.20.3, platform=linux/amd64, user=hsun@WORKPC-RH1, date=20231023-13:16:46, tags=netgo osusergo static_build)"
ts=2023-10-23T15:21:35.111Z caller=node_exporter.go:211 level=debug msg="Go MAXPROCS" procs=1
ts=2023-10-23T15:21:35.111Z caller=node_exporter.go:111 level=info msg="Enabled collectors"
ts=2023-10-23T15:21:35.111Z caller=tls_config.go:274 level=info msg="Listening on" address=[::]:9100
ts=2023-10-23T15:21:35.111Z caller=tls_config.go:277 level=info msg="TLS is disabled." http2=false address=[::]:9100
```


