### PR TITLE
Add NodeBondingDegraded alert

### DIFF
--- a/docs/node-mixin/alerts/alerts.libsonnet
+++ b/docs/node-mixin/alerts/alerts.libsonnet
@@ -407,6 +407,20 @@
               description: 'Systemd service {{ $labels.name }} has entered failed state at {{ $labels.instance }}',
             },
           },
+          {
+            alert: 'NodeBondingDegraded',
+            expr: |||
+              (node_bonding_slaves - node_bonding_active) != 0
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Bonding interface is degraded',
+              description: 'Bonding interface {{ $labels.master }} on {{ $labels.instance }} is in degraded state due to one or more slave failures.',
+            },
+          },
         ],
       },
     ],


### PR DESCRIPTION
The node_bonding_xxx metrics are activated by default and can be used to define this alert

the commit is DCO signed off.