### PR TITLE
exec_bsd: Fix labels for vm.stats.sys.v_syscall sysctl

### DIFF
--- a/collector/exec_bsd.go
+++ b/collector/exec_bsd.go
@@ -61,8 +61,8 @@ func NewExecCollector(logger log.Logger) (Collector, error) {
 				name:        "exec_system_calls_total",
 				description: "System calls since system boot.  Resets at architecture unsigned integer.",
 				mib:         "vm.stats.sys.v_syscall",
+				labels:      nil,
 			},
-			labels: nil,
 			{
 				name:        "exec_device_interrupts_total",
 				description: "Device interrupts since system boot.  Resets at architecture unsigned integer.",


### PR DESCRIPTION
This PR fixes an incorrectly placed `labels` in `exec_bsd.go`.

This issue currently means that the BSDs (or, at least FreeBSD) cannot compile 1.7.0.