### PR TITLE
Fix filesystem mountTimeout not working issue

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -122,15 +122,7 @@ func (c *filesystemCollector) processStat(labels filesystemLabels) filesystemSta
 
 	buf := new(unix.Statfs_t)
 	err := unix.Statfs(rootfsFilePath(labels.mountPoint), buf)
-	stuckMountsMtx.Lock()
 	close(success)
-
-	// If the mount has been marked as stuck, unmark it and log it's recovery.
-	if _, ok := stuckMounts[labels.mountPoint]; ok {
-		level.Debug(c.logger).Log("msg", "Mount point has recovered, monitoring will resume", "mountpoint", labels.mountPoint)
-		delete(stuckMounts, labels.mountPoint)
-	}
-	stuckMountsMtx.Unlock()
 
 	if err != nil {
 		level.Debug(c.logger).Log("msg", "Error on statfs() system call", "rootfs", rootfsFilePath(labels.mountPoint), "err", err)
@@ -161,17 +153,29 @@ func stuckMountWatcher(mountPoint string, success chan struct{}, logger log.Logg
 	select {
 	case <-success:
 		// Success
+		// If the mount has been marked as stuck, unmark it and log it's recovery.
+		stuckMountsMtx.Lock()
+		defer stuckMountsMtx.Unlock()
+		if _, ok := stuckMounts[mountPoint]; ok {
+			level.Debug(logger).Log("msg", "Mount point has recovered, monitoring will resume", "mountpoint", mountPoint)
+			delete(stuckMounts, mountPoint)
+		}
 	case <-mountCheckTimer.C:
 		// Timed out, mark mount as stuck
 		stuckMountsMtx.Lock()
+		defer stuckMountsMtx.Unlock()
 		select {
 		case <-success:
 			// Success came in just after the timeout was reached, don't label the mount as stuck
+			// If the mount has been marked as stuck, unmark it and log it's recovery.
+			if _, ok := stuckMounts[mountPoint]; ok {
+				level.Debug(logger).Log("msg", "Mount point has recovered, monitoring will resume", "mountpoint", mountPoint)
+				delete(stuckMounts, mountPoint)
+			}
 		default:
 			level.Debug(logger).Log("msg", "Mount point timed out, it is being labeled as stuck and will not be monitored", "mountpoint", mountPoint)
 			stuckMounts[mountPoint] = struct{}{}
 		}
-		stuckMountsMtx.Unlock()
 	}
 }
 


### PR DESCRIPTION
After the unix.Statfs(rootfsFilePath(labels.mountPoint), buf) function ran, the original code always removed the mountpoint from stuckMounts, assuming it had recovered, regardless of the time taken. This made the mountTimeout parameter not working.
`
        go stuckMountWatcher(labels.mountPoint, success, c.logger)

	buf := new(unix.Statfs_t)
	err := unix.Statfs(rootfsFilePath(labels.mountPoint), buf)
	stuckMountsMtx.Lock()
	close(success)

	// If the mount has been marked as stuck, unmark it and log it's recovery.
	if _, ok := stuckMounts[labels.mountPoint]; ok {
		level.Debug(c.logger).Log("msg", "Mount point has recovered, monitoring will resume", "mountpoint", labels.mountPoint)
		delete(stuckMounts, labels.mountPoint)
	}
	stuckMountsMtx.Unlock()
`
 I moved the "Mount point has recovered" part to the stuckMountWatcher function. Now, only if the success signal is received before the mountCheckTimer expires, will the mountpoint be considered as having recovered.