### PR TITLE
Bump golang-builder version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
     environment:
-      DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.18-base
+      DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.21-base
       REPO_PATH: github.com/prometheus/node_exporter
     steps:
       - prometheus/setup_environment


### PR DESCRIPTION
We had recently pushed a new golang-builder version with this MR: https://github.com/prometheus/golang-builder/pull/239

Bumping this version to that latest one.