### PR TITLE
MOD: surface filesystem device error #2918

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -133,6 +133,7 @@ func (c *filesystemCollector) processStat(labels filesystemLabels) filesystemSta
 	stuckMountsMtx.Unlock()
 
 	if err != nil {
+                labels.device_error = err.Error()
 		level.Debug(c.logger).Log("msg", "Error on statfs() system call", "rootfs", rootfsFilePath(labels.mountPoint), "err", err)
 		return filesystemStats{
 			labels:      labels,


### PR DESCRIPTION
To provide contribution on issue: https://github.com/prometheus/node_exporter/issues/2918

Adding new label of "device_error" to surface error in node_filesystem_device_error. 
Tests have been done for below scenarios, could you please help review and share your suggestion? Thanks.

**Scenario-1:** No device error
`curl http://localhost:9100/metrics | grep node_filesystem_device_error | grep 100.70.222.247
% Total % Received % Xferd Average Speed Time Time Time Current
Dload Upload Total Spent Left Speed
100 83276 0 83276 0 0 1786k 0 --:--:-- --:--:-- --:--:-- 1807k
node_filesystem_device_error{device="100.70.222.247:/share_5618cf05_5d99_44b6_a90d_8c2797929dbb",device_error="",fstype="nfs4",mountpoint="/test_nfs"} 0`


**Scenario-2:** mountpoint timeout
`curl http://localhost:9100/metrics | grep node_filesystem_device_error | grep 100.70.222.247
% Total % Received % Xferd Average Speed Time Time Time Current
Dload Upload Total Spent Left Speed
100 83312 0 83312 0 0 3053k 0 --:--:-- --:--:-- --:--:-- 3129k
node_filesystem_device_error{device="100.70.222.247:/share_5618cf05_5d99_44b6_a90d_8c2797929dbb",device_error="mountpoint timeout",fstype="nfs4",mountpoint="/test_nfs"} 1`


**Scenario-3:** error from statfs() e.g. permission denied
`curl http://localhost:9100/metrics | grep node_filesystem_device_error | grep 100.70.222.247
% Total % Received % Xferd Average Speed Time Time Time Current
Dload Upload Total Spent Left Speed
100 83208 0 83208 0 0 2943k 0 --:--:-- --:--:-- --:--:-- 3009k
node_filesystem_device_error{device="100.70.222.247:/share_5618cf05_5d99_44b6_a90d_8c2797929dbb",device_error="permission denied",fstype="nfs4",mountpoint="/test_nfs"} 1`

