### PR TITLE
MOD: surface filesystem device error #2918

### DIFF
--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -60,7 +60,7 @@ var (
 		"Regexp of filesystem types to ignore for filesystem collector.",
 	).Hidden().String()
 
-	filesystemLabelNames = []string{"device", "mountpoint", "fstype"}
+	filesystemLabelNames = []string{"device", "mountpoint", "fstype", "device_error"}
 )
 
 type filesystemCollector struct {
@@ -73,7 +73,7 @@ type filesystemCollector struct {
 }
 
 type filesystemLabels struct {
-	device, mountPoint, fsType, options string
+	device, mountPoint, fsType, options, device_error string
 }
 
 type filesystemStats struct {
@@ -184,11 +184,11 @@ func (c *filesystemCollector) Update(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.deviceErrorDesc, prometheus.GaugeValue,
-			s.deviceError, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.deviceError, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.roDesc, prometheus.GaugeValue,
-			s.ro, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.ro, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
 		)
 
 		if s.deviceError > 0 {
@@ -197,23 +197,23 @@ func (c *filesystemCollector) Update(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.sizeDesc, prometheus.GaugeValue,
-			s.size, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.size, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.freeDesc, prometheus.GaugeValue,
-			s.free, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.free, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.availDesc, prometheus.GaugeValue,
-			s.avail, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.avail, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.filesDesc, prometheus.GaugeValue,
-			s.files, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.files, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.filesFreeDesc, prometheus.GaugeValue,
-			s.filesFree, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.filesFree, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
 		)
 	}
 	return nil

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -85,6 +85,7 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 
 			stuckMountsMtx.Lock()
 			if _, ok := stuckMounts[labels.mountPoint]; ok {
+		                labels.device_error = "mountpoint timeout"
 				stats = append(stats, filesystemStats{
 					labels:      labels,
 					deviceError: 1,
@@ -133,6 +134,7 @@ func (c *filesystemCollector) processStat(labels filesystemLabels) filesystemSta
 	stuckMountsMtx.Unlock()
 
 	if err != nil {
+		labels.device_error = err.Error()
 		level.Debug(c.logger).Log("msg", "Error on statfs() system call", "rootfs", rootfsFilePath(labels.mountPoint), "err", err)
 		return filesystemStats{
 			labels:      labels,
@@ -211,6 +213,7 @@ func parseFilesystemLabels(r io.Reader) ([]filesystemLabels, error) {
 			mountPoint: rootfsStripPrefix(parts[1]),
 			fsType:     parts[2],
 			options:    parts[3],
+			device_error:    "",
 		})
 	}
 


### PR DESCRIPTION
To provide contribution on issue: https://github.com/prometheus/node_exporter/issues/2918

Adding new label of "device_error" to surface error in node_filesystem_device_error.
Tests have been done for below scenarios, could you please help review and share your suggestion? Thanks.

Scenario-1: No device error
curl http://localhost:9100/metrics | grep node_filesystem_device_error | grep 100.70.222.247 % Total % Received % Xferd Average Speed Time Time Time Current Dload Upload Total Spent Left Speed 100 83276 0 83276 0 0 1786k 0 --:--:-- --:--:-- --:--:-- 1807k node_filesystem_device_error{device="100.70.222.247:/share_5618cf05_5d99_44b6_a90d_8c2797929dbb",device_error="",fstype="nfs4",mountpoint="/test_nfs"} 0

Scenario-2: mountpoint timeout
curl http://localhost:9100/metrics | grep node_filesystem_device_error | grep 100.70.222.247 % Total % Received % Xferd Average Speed Time Time Time Current Dload Upload Total Spent Left Speed 100 83312 0 83312 0 0 3053k 0 --:--:-- --:--:-- --:--:-- 3129k node_filesystem_device_error{device="100.70.222.247:/share_5618cf05_5d99_44b6_a90d_8c2797929dbb",device_error="mountpoint timeout",fstype="nfs4",mountpoint="/test_nfs"} 1

Scenario-3: error from statfs() e.g. permission denied
curl http://localhost:9100/metrics | grep node_filesystem_device_error | grep 100.70.222.247 % Total % Received % Xferd Average Speed Time Time Time Current Dload Upload Total Spent Left Speed 100 83208 0 83208 0 0 2943k 0 --:--:-- --:--:-- --:--:-- 3009k node_filesystem_device_error{device="100.70.222.247:/share_5618cf05_5d99_44b6_a90d_8c2797929dbb",device_error="permission denied",fstype="nfs4",mountpoint="/test_nfs"} 1