### PR TITLE
filesystem: surface device errors

### DIFF
--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -60,7 +60,7 @@ var (
 		"Regexp of filesystem types to ignore for filesystem collector.",
 	).Hidden().String()
 
-	filesystemLabelNames = []string{"device", "mountpoint", "fstype"}
+	filesystemLabelNames = []string{"device", "mountpoint", "fstype", "device_error"}
 )
 
 type filesystemCollector struct {
@@ -73,7 +73,7 @@ type filesystemCollector struct {
 }
 
 type filesystemLabels struct {
-	device, mountPoint, fsType, options string
+	device, mountPoint, fsType, options, device_error string
 }
 
 type filesystemStats struct {
@@ -184,11 +184,11 @@ func (c *filesystemCollector) Update(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.deviceErrorDesc, prometheus.GaugeValue,
-			s.deviceError, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.deviceError, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.roDesc, prometheus.GaugeValue,
-			s.ro, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.ro, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
 		)
 
 		if s.deviceError > 0 {
@@ -197,23 +197,23 @@ func (c *filesystemCollector) Update(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.sizeDesc, prometheus.GaugeValue,
-			s.size, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.size, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.freeDesc, prometheus.GaugeValue,
-			s.free, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.free, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.availDesc, prometheus.GaugeValue,
-			s.avail, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.avail, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.filesDesc, prometheus.GaugeValue,
-			s.files, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.files, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.filesFreeDesc, prometheus.GaugeValue,
-			s.filesFree, s.labels.device, s.labels.mountPoint, s.labels.fsType,
+			s.filesFree, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
 		)
 	}
 	return nil

--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -73,7 +73,7 @@ type filesystemCollector struct {
 }
 
 type filesystemLabels struct {
-	device, mountPoint, fsType, options, device_error string
+	device, mountPoint, fsType, options, deviceError string
 }
 
 type filesystemStats struct {
@@ -184,11 +184,11 @@ func (c *filesystemCollector) Update(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.deviceErrorDesc, prometheus.GaugeValue,
-			s.deviceError, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
+			s.deviceError, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.deviceError,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.roDesc, prometheus.GaugeValue,
-			s.ro, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
+			s.ro, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.deviceError,
 		)
 
 		if s.deviceError > 0 {
@@ -197,23 +197,23 @@ func (c *filesystemCollector) Update(ch chan<- prometheus.Metric) error {
 
 		ch <- prometheus.MustNewConstMetric(
 			c.sizeDesc, prometheus.GaugeValue,
-			s.size, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
+			s.size, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.deviceError,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.freeDesc, prometheus.GaugeValue,
-			s.free, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
+			s.free, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.deviceError,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.availDesc, prometheus.GaugeValue,
-			s.avail, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
+			s.avail, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.deviceError,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.filesDesc, prometheus.GaugeValue,
-			s.files, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
+			s.files, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.deviceError,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.filesFreeDesc, prometheus.GaugeValue,
-			s.filesFree, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.device_error,
+			s.filesFree, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.deviceError,
 		)
 	}
 	return nil

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -213,10 +213,10 @@ func parseFilesystemLabels(r io.Reader) ([]filesystemLabels, error) {
 		parts[1] = strings.Replace(parts[1], "\\011", "\t", -1)
 
 		filesystems = append(filesystems, filesystemLabels{
-			device:       parts[0],
-			mountPoint:   rootfsStripPrefix(parts[1]),
-			fsType:       parts[2],
-			options:      parts[3],
+			device:      parts[0],
+			mountPoint:  rootfsStripPrefix(parts[1]),
+			fsType:      parts[2],
+			options:     parts[3],
 			deviceError: "",
 		})
 	}

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -85,7 +85,7 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 
 			stuckMountsMtx.Lock()
 			if _, ok := stuckMounts[labels.mountPoint]; ok {
-		                labels.device_error = "mountpoint timeout"
+				labels.device_error = "mountpoint timeout"
 				stats = append(stats, filesystemStats{
 					labels:      labels,
 					deviceError: 1,
@@ -213,11 +213,11 @@ func parseFilesystemLabels(r io.Reader) ([]filesystemLabels, error) {
 		parts[1] = strings.Replace(parts[1], "\\011", "\t", -1)
 
 		filesystems = append(filesystems, filesystemLabels{
-			device:     parts[0],
-			mountPoint: rootfsStripPrefix(parts[1]),
-			fsType:     parts[2],
-			options:    parts[3],
-			device_error:    "",
+			device:       parts[0],
+			mountPoint:   rootfsStripPrefix(parts[1]),
+			fsType:       parts[2],
+			options:      parts[3],
+			device_error: "",
 		})
 	}
 

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -123,15 +123,7 @@ func (c *filesystemCollector) processStat(labels filesystemLabels) filesystemSta
 
 	buf := new(unix.Statfs_t)
 	err := unix.Statfs(rootfsFilePath(labels.mountPoint), buf)
-	stuckMountsMtx.Lock()
 	close(success)
-
-	// If the mount has been marked as stuck, unmark it and log it's recovery.
-	if _, ok := stuckMounts[labels.mountPoint]; ok {
-		level.Debug(c.logger).Log("msg", "Mount point has recovered, monitoring will resume", "mountpoint", labels.mountPoint)
-		delete(stuckMounts, labels.mountPoint)
-	}
-	stuckMountsMtx.Unlock()
 
 	if err != nil {
 		labels.deviceError = err.Error()
@@ -163,17 +155,29 @@ func stuckMountWatcher(mountPoint string, success chan struct{}, logger log.Logg
 	select {
 	case <-success:
 		// Success
+		// If the mount has been marked as stuck, unmark it and log it's recovery.
+		stuckMountsMtx.Lock()
+		defer stuckMountsMtx.Unlock()
+		if _, ok := stuckMounts[mountPoint]; ok {
+			level.Debug(logger).Log("msg", "Mount point has recovered, monitoring will resume", "mountpoint", mountPoint)
+			delete(stuckMounts, mountPoint)
+		}
 	case <-mountCheckTimer.C:
 		// Timed out, mark mount as stuck
 		stuckMountsMtx.Lock()
+		defer stuckMountsMtx.Unlock()
 		select {
 		case <-success:
 			// Success came in just after the timeout was reached, don't label the mount as stuck
+			// If the mount has been marked as stuck, unmark it and log it's recovery.
+			if _, ok := stuckMounts[mountPoint]; ok {
+				level.Debug(logger).Log("msg", "Mount point has recovered, monitoring will resume", "mountpoint", mountPoint)
+				delete(stuckMounts, mountPoint)
+			}
 		default:
 			level.Debug(logger).Log("msg", "Mount point timed out, it is being labeled as stuck and will not be monitored", "mountpoint", mountPoint)
 			stuckMounts[mountPoint] = struct{}{}
 		}
-		stuckMountsMtx.Unlock()
 	}
 }
 

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -209,17 +209,10 @@ func parseFilesystemLabels(r io.Reader) ([]filesystemLabels, error) {
 		parts[1] = strings.Replace(parts[1], "\\011", "\t", -1)
 
 		filesystems = append(filesystems, filesystemLabels{
-<<<<<<< HEAD
 			device:      parts[0],
 			mountPoint:  rootfsStripPrefix(parts[1]),
 			fsType:      parts[2],
 			options:     parts[3],
-=======
-			device:       parts[0],
-			mountPoint:   rootfsStripPrefix(parts[1]),
-			fsType:       parts[2],
-			options:      parts[3],
->>>>>>> 8d495980343a6ad1177b53b6fb709e1ee6e24736
 			deviceError: "",
 		})
 	}

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -85,6 +85,7 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 
 			stuckMountsMtx.Lock()
 			if _, ok := stuckMounts[labels.mountPoint]; ok {
+		                labels.device_error = "mountpoint timeout"
 				stats = append(stats, filesystemStats{
 					labels:      labels,
 					deviceError: 1,
@@ -125,6 +126,7 @@ func (c *filesystemCollector) processStat(labels filesystemLabels) filesystemSta
 	close(success)
 
 	if err != nil {
+		labels.device_error = err.Error()
 		level.Debug(c.logger).Log("msg", "Error on statfs() system call", "rootfs", rootfsFilePath(labels.mountPoint), "err", err)
 		return filesystemStats{
 			labels:      labels,
@@ -215,6 +217,7 @@ func parseFilesystemLabels(r io.Reader) ([]filesystemLabels, error) {
 			mountPoint: rootfsStripPrefix(parts[1]),
 			fsType:     parts[2],
 			options:    parts[3],
+			device_error:    "",
 		})
 	}
 

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -85,7 +85,7 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 
 			stuckMountsMtx.Lock()
 			if _, ok := stuckMounts[labels.mountPoint]; ok {
-				labels.device_error = "mountpoint timeout"
+				labels.deviceError = "mountpoint timeout"
 				stats = append(stats, filesystemStats{
 					labels:      labels,
 					deviceError: 1,
@@ -126,7 +126,7 @@ func (c *filesystemCollector) processStat(labels filesystemLabels) filesystemSta
 	close(success)
 
 	if err != nil {
-		labels.device_error = err.Error()
+		labels.deviceError = err.Error()
 		level.Debug(c.logger).Log("msg", "Error on statfs() system call", "rootfs", rootfsFilePath(labels.mountPoint), "err", err)
 		return filesystemStats{
 			labels:      labels,
@@ -217,7 +217,7 @@ func parseFilesystemLabels(r io.Reader) ([]filesystemLabels, error) {
 			mountPoint:   rootfsStripPrefix(parts[1]),
 			fsType:       parts[2],
 			options:      parts[3],
-			device_error: "",
+			deviceError: "",
 		})
 	}
 


### PR DESCRIPTION
Adding new label of "device_error" to surface error in node_filesystem_device_error.
Tests have been done for below scenarios:

**Scenario-1:** No device error
```
$ curl -s http://localhost:9100/metrics | grep node_filesystem_device_error | grep 100.70.222.247
node_filesystem_device_error{device="100.70.222.247:/share_5618cf05_5d99_44b6_a90d_8c2797929dbb",device_error="",fstype="nfs4",mountpoint="/test_nfs"} 0
```

**Scenario-2:** mountpoint timeout
```
$ curl -s http://localhost:9100/metrics | grep node_filesystem_device_error | grep 100.70.222.247
node_filesystem_device_error{device="100.70.222.247:/share_5618cf05_5d99_44b6_a90d_8c2797929dbb",device_error="mountpoint timeout",fstype="nfs4",mountpoint="/test_nfs"} 1
```

**Scenario-3:** error from statfs() e.g. permission denied
```
$ curl -s http://localhost:9100/metrics | grep node_filesystem_device_error | grep 100.70.222.247
node_filesystem_device_error{device="100.70.222.247:/share_5618cf05_5d99_44b6_a90d_8c2797929dbb",device_error="permission denied",fstype="nfs4",mountpoint="/test_nfs"} 1
```

fixes: https://github.com/prometheus/node_exporter/issues/2918