### PR TITLE
collector/cpu: `s/cpu_ticks*/cpu_nsec*` for solaris

### DIFF
--- a/collector/cpu_solaris.go
+++ b/collector/cpu_solaris.go
@@ -60,17 +60,17 @@ func (c *cpuCollector) Update(ch chan<- prometheus.Metric) error {
 		}
 
 		for k, v := range map[string]string{
-			"idle":   "cpu_ticks_idle",
-			"kernel": "cpu_ticks_kernel",
-			"user":   "cpu_ticks_user",
-			"wait":   "cpu_ticks_wait",
+			"idle":   "cpu_nsec_idle",
+			"kernel": "cpu_nsec_kernel",
+			"user":   "cpu_nsec_user",
+			"wait":   "cpu_nsec_wait",
 		} {
 			kstatValue, err := ksCPU.GetNamed(v)
 			if err != nil {
 				return err
 			}
 
-			ch <- c.cpu.mustNewConstMetric(float64(kstatValue.UintVal), strconv.Itoa(cpu), k)
+			ch <- c.cpu.mustNewConstMetric(float64(kstatValue.UintVal)/1e9, strconv.Itoa(cpu), k)
 		}
 	}
 	return nil


### PR DESCRIPTION
Replace all `cpu_ticks_*` with `cpu_nsec_*`, since the former was off my a magnitude of `10e6`, and showed incorrect values for `node_cpu_seconds_total`.

Fixes: #1837

