### PR TITLE
collector/filesystem: Handle `Statfs_t` overflows

### DIFF
--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -70,8 +70,9 @@ type filesystemCollector struct {
 	sizeDesc, freeDesc, availDesc *prometheus.Desc
 	filesDesc, filesFreeDesc      *prometheus.Desc
 	roDesc, deviceErrorDesc       *prometheus.Desc
-	fsStats                       *unix.Statfs_t
 	logger                        log.Logger
+	// Used to mock `unix.Statfs` values for testing.
+	_fsStats *unix.Statfs_t
 }
 
 type filesystemLabels struct {

--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -19,6 +19,7 @@ package collector
 
 import (
 	"errors"
+	"golang.org/x/sys/unix"
 	"regexp"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -69,6 +70,7 @@ type filesystemCollector struct {
 	sizeDesc, freeDesc, availDesc *prometheus.Desc
 	filesDesc, filesFreeDesc      *prometheus.Desc
 	roDesc, deviceErrorDesc       *prometheus.Desc
+	fsStats                       *unix.Statfs_t
 	logger                        log.Logger
 }
 

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -152,9 +152,9 @@ func (c *filesystemCollector) processStat(labels filesystemLabels) filesystemSta
 
 	// Handle for under/over-flow for cases where: "node_filesystem_{free,avail}_bytes reporting values are larger than node_filesystem_size_bytes".
 	if bits.UintSize == 64 && float64(buf.Blocks)*float64(buf.Bsize) > float64(float64Mantissa) {
-		size, _ := new(big.Float).SetUint64(buf.Blocks).Mul(new(big.Float).SetUint64(buf.Blocks), new(big.Float).SetInt64(int64(buf.Bsize))).Float64()
-		free, _ := new(big.Float).SetUint64(buf.Bfree).Mul(new(big.Float).SetUint64(buf.Bfree), new(big.Float).SetInt64(int64(buf.Bsize))).Float64()
-		avail, _ := new(big.Float).SetUint64(buf.Bavail).Mul(new(big.Float).SetUint64(buf.Bavail), new(big.Float).SetInt64(int64(buf.Bsize))).Float64()
+		size, _ := new(big.Int).Mul(new(big.Int).SetUint64(buf.Blocks), new(big.Int).SetInt64(buf.Bsize)).Float64()
+		free, _ := new(big.Int).Mul(new(big.Int).SetUint64(buf.Bfree), new(big.Int).SetInt64(buf.Bsize)).Float64()
+		avail, _ := new(big.Int).Mul(new(big.Int).SetUint64(buf.Bavail), new(big.Int).SetInt64(buf.Bsize)).Float64()
 		return filesystemStats{
 			labels:    labels,
 			size:      size,

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -123,8 +123,8 @@ func (c *filesystemCollector) processStat(labels filesystemLabels) filesystemSta
 	buf := new(unix.Statfs_t)
 
 	// Allow mocking `unix.Statfs` values for testing.
-	if c.fsStats != nil {
-		buf = c.fsStats
+	if c._fsStats != nil {
+		buf = c._fsStats
 	} else {
 		success := make(chan struct{})
 		go stuckMountWatcher(labels.mountPoint, success, c.logger)

--- a/collector/filesystem_linux_overflow64_test.go
+++ b/collector/filesystem_linux_overflow64_test.go
@@ -50,8 +50,8 @@ func TestOverflowHandling(t *testing.T) {
 	}
 	for _, testcase := range testcases {
 		var fsC = filesystemCollector{
-			logger:  log.NewNopLogger(),
-			fsStats: testcase.fsStats,
+			logger:   log.NewNopLogger(),
+			_fsStats: testcase.fsStats,
 		}
 		fsStats := fsC.processStat(filesystemLabels{
 			mountPoint: "/",

--- a/collector/filesystem_linux_overflow64_test.go
+++ b/collector/filesystem_linux_overflow64_test.go
@@ -1,0 +1,76 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !386
+// +build !386
+
+package collector
+
+import (
+	"github.com/go-kit/log"
+	"golang.org/x/sys/unix"
+	"math/big"
+	"runtime"
+	"testing"
+)
+
+func TestOverflowHandling(t *testing.T) {
+	if runtime.GOARCH == "386" {
+		t.Skip("Skipping on 32-bit architecture")
+	}
+	factor := uint64(24)
+	testcases := []struct {
+		fsStats  *unix.Statfs_t
+		overflow bool
+	}{
+		{
+			fsStats: &unix.Statfs_t{
+				Bsize:  int64(float64Mantissa),
+				Blocks: factor,
+			},
+			overflow: true,
+		},
+		{
+			fsStats: &unix.Statfs_t{
+				Bsize:  int64(float64Mantissa / factor),
+				Blocks: factor,
+			},
+			overflow: false,
+		},
+	}
+	for _, testcase := range testcases {
+		var fsC = filesystemCollector{
+			logger:  log.NewNopLogger(),
+			fsStats: testcase.fsStats,
+		}
+		fsStats := fsC.processStat(filesystemLabels{
+			mountPoint: "/",
+		})
+
+		oldsize := float64(testcase.fsStats.Blocks) * float64(testcase.fsStats.Bsize)
+		size := new(big.Float).SetFloat64(fsStats.size)
+		actual := new(big.Float).
+			Mul(new(big.Float).SetFloat64(float64(testcase.fsStats.Blocks)), new(big.Float).SetFloat64(float64(testcase.fsStats.Bsize)))
+		if testcase.overflow {
+			oldsizeActualDiff := new(big.Float).Abs(new(big.Float).Sub(actual, new(big.Float).SetFloat64(oldsize)))
+			sizeActualDiff := new(big.Float).Abs(new(big.Float).Sub(actual, size))
+			if sizeActualDiff.Cmp(oldsizeActualDiff) < 0 {
+				t.Errorf("Expected size to be closer to %f than %f, got %f instead", actual, oldsize, size)
+			}
+		} else {
+			if size.Cmp(actual) != 0 {
+				t.Errorf("Expected size to be %f, got %f instead", actual, size)
+			}
+		}
+	}
+}

--- a/collector/filesystem_linux_overflow64_test.go
+++ b/collector/filesystem_linux_overflow64_test.go
@@ -59,8 +59,8 @@ func TestOverflowHandling(t *testing.T) {
 
 		oldsize := float64(testcase.fsStats.Blocks) * float64(testcase.fsStats.Bsize)
 		size := new(big.Float).SetFloat64(fsStats.size)
-		actual := new(big.Float).
-			Mul(new(big.Float).SetFloat64(float64(testcase.fsStats.Blocks)), new(big.Float).SetFloat64(float64(testcase.fsStats.Bsize)))
+		actualFloat64, _ := new(big.Int).Mul(new(big.Int).SetUint64(testcase.fsStats.Blocks), new(big.Int).SetInt64(testcase.fsStats.Bsize)).Float64()
+		actual := new(big.Float).SetFloat64(actualFloat64)
 		if testcase.overflow {
 			oldsizeActualDiff := new(big.Float).Abs(new(big.Float).Sub(actual, new(big.Float).SetFloat64(oldsize)))
 			sizeActualDiff := new(big.Float).Abs(new(big.Float).Sub(actual, size))


### PR DESCRIPTION
Handle cases where, owing to multiplying two `uint64` integers and typecasting it to `float64`, the overall precision is lost when the values concerned exceed the `floatMantissa64` (1 << 53) before or after the operation (which is well within the acceptable `uint64` range).

Fixes: #1672