### PR TITLE
zfs: Log mib when sysctl read fails on FreeBSD

### DIFF
--- a/collector/zfs_freebsd.go
+++ b/collector/zfs_freebsd.go
@@ -273,7 +273,7 @@ func (c *zfsCollector) Update(ch chan<- prometheus.Metric) error {
 		v, err := m.Value()
 		if err != nil {
 			// debug logging
-			level.Debug(c.logger).Log("name", m.name, "couldn't get sysctl:", err)
+			level.Debug(c.logger).Log("name", m.name, "mib", m.mib, "couldn't get sysctl:", err)
 			continue
 		}
 


### PR DESCRIPTION
When the zfs collector fails on FreeBSD it doesn't log which `mib` triggered the issue. This makes diagnostics harder.

Incompatibilities in the list of supported mibs is not uncommon with major os updates. By adding this change, it'll be easier for users to report the specific mib that is triggering the failure.

Related to #2847