### PR TITLE
fix: data race of NetClassCollector metrics initialization when multiple requests happen

### DIFF
--- a/collector/netclass_linux.go
+++ b/collector/netclass_linux.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"os"
 	"regexp"
+	"sync"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/go-kit/log"
@@ -41,6 +42,7 @@ type netClassCollector struct {
 	subsystem             string
 	ignoredDevicesPattern *regexp.Regexp
 	metricDescs           map[string]*prometheus.Desc
+	metricDescsMu         sync.Mutex
 	logger                log.Logger
 }
 
@@ -136,6 +138,9 @@ func (c *netClassCollector) netClassSysfsUpdate(ch chan<- prometheus.Metric) err
 }
 
 func (c *netClassCollector) getFieldDesc(name string) *prometheus.Desc {
+	c.metricDescsMu.Lock()
+	defer c.metricDescsMu.Unlock()
+
 	fieldDesc, exists := c.metricDescs[name]
 
 	if !exists {


### PR DESCRIPTION
fix data race issue:
```
fatal error: concurrent map read and map write

goroutine 420 [running]:
github.com/prometheus/node_exporter/collector.(*netClassCollector).getFieldDesc(0xc0004f6f40, {0x1c87090, 0x8})
        github.com/prometheus/node_exporter@v1.6.1/collector/netclass_linux.go:139 +0x49
github.com/prometheus/node_exporter/collector.(*netClassCollector).netClassSysfsUpdate(0xc0004f6f40, 0x493ad7?)
        github.com/prometheus/node_exporter@v1.6.1/collector/netclass_linux.go:115 +0xc9e
github.com/prometheus/node_exporter/collector.(*netClassCollector).Update(0x223d72656e696174?, 0x6e6567612d676f6c?)
        github.com/prometheus/node_exporter@v1.6.1/collector/netclass_linux.go:71 +0x36
github.com/prometheus/node_exporter/collector.execute({0x1c872e0, 0x8}, {0x1f93920, 0xc0004f6f40}, 0x313734622d366530?, {0x1f925e0, 0x2e3f378})
        github.com/prometheus/node_exporter@v1.6.1/collector/collector.go:161 +0x9c
github.com/prometheus/node_exporter/collector.NodeCollector.Collect.func1({0x1c872e0?, 0x342d746e6567612d?}, {0x1f93920?, 0xc0004f6f40?})
        github.com/prometheus/node_exporter@v1.6.1/collector/collector.go:152 +0x3d
created by github.com/prometheus/node_exporter/collector.NodeCollector.Collect
        github.com/prometheus/node_exporter@v1.6.1/collector/collector.go:151 +0xd0

...

goroutine 461 [runnable]:
github.com/prometheus/node_exporter/collector.pushMetric(0xc001f198f0?, 0x7?, {0x7?, 0x0?}, {0x19637e0?, 0xc000037820?}, 0x0?, {0xc001b36600, 0x1, 0x1})
        github.com/prometheus/node_exporter@v1.6.1/collector/collector.go:245 +0x2e9
github.com/prometheus/node_exporter/collector.(*netClassCollector).netClassSysfsUpdate(0xc0004f6f40, 0x493ad7?)
        github.com/prometheus/node_exporter@v1.6.1/collector/netclass_linux.go:119 +0xfbe
github.com/prometheus/node_exporter/collector.(*netClassCollector).Update(0x0?, 0x0?)
        github.com/prometheus/node_exporter@v1.6.1/collector/netclass_linux.go:71 +0x36
github.com/prometheus/node_exporter/collector.execute({0x1c872e0, 0x8}, {0x1f93920, 0xc0004f6f40}, 0x0?, {0x1f925e0, 0x2e3f378})
        github.com/prometheus/node_exporter@v1.6.1/collector/collector.go:161 +0x9c
github.com/prometheus/node_exporter/collector.NodeCollector.Collect.func1({0x1c872e0?, 0x0?}, {0x1f93920?, 0xc0004f6f40?})
        github.com/prometheus/node_exporter@v1.6.1/collector/collector.go:152 +0x3d
created by github.com/prometheus/node_exporter/collector.NodeCollector.Collect
        github.com/prometheus/node_exporter@v1.6.1/collector/collector.go:151 +0xd0

...

goroutine 542 [runnable]:
syscall.fcntl(0x10?, 0x4?, 0x8000?)
        syscall/zsyscall_linux_amd64.go:406 +0xbe
syscall.SetNonblock(0x0?, 0x0)
        syscall/exec_unix.go:116 +0x69
internal/poll.(*FD).SetBlocking(0xc001c2b290?)
        internal/poll/fd_unix.go:132 +0xf1
os.(*File).Fd(...)
        os/file_unix.go:87
github.com/prometheus/procfs/internal/util.SysReadFile({0xc001c2b290?, 0xc00073b0e0?})
        github.com/prometheus/procfs@v0.12.0/internal/util/sysreadfile.go:44 +0xd4
github.com/prometheus/procfs/sysfs.ParseNetClassAttribute({0xc0009aa140?, 0xc0009aa140?}, {0xc000380480, 0x5}, 0xc00001a360)
        github.com/prometheus/procfs@v0.12.0/sysfs/net_class.go:148 +0x9f
github.com/prometheus/procfs/sysfs.parseNetClassIface({0xc0009aa140, 0x1e})
        github.com/prometheus/procfs@v0.12.0/sysfs/net_class.go:231 +0xdc
github.com/prometheus/procfs/sysfs.FS.NetClassByIface({{0xc0005b77ed?, 0x0?}}, {0xc00038006c, 0x4})
        github.com/prometheus/procfs@v0.12.0/sysfs/net_class.go:91 +0x10c
github.com/prometheus/node_exporter/collector.(*netClassCollector).getNetClassInfo(0xc0004f6f40)
        github.com/prometheus/node_exporter@v1.6.1/collector/netclass_linux.go:165 +0x125
github.com/prometheus/node_exporter/collector.(*netClassCollector).netClassSysfsUpdate(0xc0004f6f40, 0x493ad7?)
        github.com/prometheus/node_exporter@v1.6.1/collector/netclass_linux.go:75 +0x3e
github.com/prometheus/node_exporter/collector.(*netClassCollector).Update(0x0?, 0x0?)
        github.com/prometheus/node_exporter@v1.6.1/collector/netclass_linux.go:71 +0x36
github.com/prometheus/node_exporter/collector.execute({0x1c872e0, 0x8}, {0x1f93920, 0xc0004f6f40}, 0x0?, {0x1f925e0, 0x2e3f378})
        github.com/prometheus/node_exporter@v1.6.1/collector/collector.go:161 +0x9c
github.com/prometheus/node_exporter/collector.NodeCollector.Collect.func1({0x1c872e0?, 0x0?}, {0x1f93920?, 0xc0004f6f40?})
        github.com/prometheus/node_exporter@v1.6.1/collector/collector.go:152 +0x3d
created by github.com/prometheus/node_exporter/collector.NodeCollector.Collect
        github.com/prometheus/node_exporter@v1.6.1/collector/collector.go:151 +0xd0

...
```