### PR TITLE
Fix watchdog_test lint and test failures on macos.

### DIFF
--- a/collector/watchdog_test.go
+++ b/collector/watchdog_test.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !nowatchdog
-// +build !nowatchdog
+//go:build linux && !nowatchdog
+// +build linux,!nowatchdog
 
 package collector
 


### PR DESCRIPTION
Ensure identical build flags embedded in both files.

golangci-lint and tests both failed when run on macos with the following error:
```
collector/watchdog_test.go:72:12: undefined: NewWatchdogCollector
```

@SuperQ @discordianfish 