### PR TITLE
Sign node exporter darwin binary with rcodesign

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       # sign the darwin build so it doesn't get SIGKILLed on start, see: https://github.com/prometheus/node_exporter/issues/2539
       - run:
           command: |
-            if [ -d "$(pwd)/.build/darwin-arm64" ]; then
+            if [[ -f "$(pwd)/.build/darwin-arm64/node_exporter" ]]; then
                 promu codesign "$(pwd)/.build/darwin-arm64/node_exporter"
             fi
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,10 @@ jobs:
             if [[ -f "$(pwd)/.build/darwin-arm64/node_exporter" ]]; then
                 promu codesign "$(pwd)/.build/darwin-arm64/node_exporter"
             fi
+
+            if [[ -f "$(pwd)/.build/darwin-amd64/node_exporter" ]]; then
+                promu codesign "$(pwd)/.build/darwin-amd64/node_exporter"                
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,12 @@ jobs:
       - run: docker run --privileged linuxkit/binfmt:af88a591f9cc896a52ce596b9cf7ca26a061ef97
       - run: promu crossbuild -v --parallelism $CIRCLE_NODE_TOTAL --parallelism-thread $CIRCLE_NODE_INDEX
       - run: promu --config .promu-cgo.yml crossbuild -v --parallelism $CIRCLE_NODE_TOTAL --parallelism-thread $CIRCLE_NODE_INDEX
+      # sign the darwin build so it doesn't get SIGKILLed on start, see: https://github.com/prometheus/node_exporter/issues/2539
+      - run:
+          command: |
+            if [ -d "$(pwd)/.build/darwin-arm64" ]; then
+                promu codesign "$(pwd)/.build/darwin-arm64/node_exporter"
+            fi
       - persist_to_workspace:
           root: .
           paths:

--- a/Makefile.common
+++ b/Makefile.common
@@ -55,7 +55,7 @@ ifneq ($(shell command -v gotestsum 2> /dev/null),)
 endif
 endif
 
-PROMU_VERSION ?= 0.15.0
+PROMU_VERSION ?= 0.17.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
 SKIP_GOLANGCI_LINT :=


### PR DESCRIPTION
Alright, since I seem to have butchered my previous PR (see https://github.com/prometheus/node_exporter/pull/2916) beyond recovery with force pushes, I decided to open a new one that looks more sane.

Prevents SIGKILL issues on macs.

Fixes: https://github.com/prometheus/node_exporter/issues/2539, https://github.com/prometheus/node_exporter/issues/2217

I previously tested the darwin build that came out, and it ran well on my M1 mac, so this should be good to go.