### PR TITLE
Fix pressure collector nil reference

### DIFF
--- a/collector/fixtures/proc/pressure/cpu
+++ b/collector/fixtures/proc/pressure/cpu
@@ -1,1 +1,2 @@
 some avg10=0.00 avg60=0.00 avg300=0.00 total=14036781
+full avg10=0.00 avg60=0.00 avg300=0.00 total=0

--- a/collector/pressure_linux.go
+++ b/collector/pressure_linux.go
@@ -102,6 +102,14 @@ func (c *pressureStatsCollector) Update(ch chan<- prometheus.Metric) error {
 			}
 			return fmt.Errorf("failed to retrieve pressure stats: %w", err)
 		}
+		if vals.Some == nil {
+			level.Debug(c.logger).Log("msg", "pressure information returned no 'some' data")
+			return ErrNoData
+		}
+		if vals.Full == nil {
+			level.Debug(c.logger).Log("msg", "pressure information returned no 'full' data")
+			return ErrNoData
+		}
 		switch res {
 		case "cpu":
 			ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, float64(vals.Some.Total)/1000.0/1000.0)


### PR DESCRIPTION
Check that the PSI metrics are returned in order to avoid nil pointer dereference.

Fixes: https://github.com/prometheus/node_exporter/issues/3015