### PR TITLE
Add interrupts collector filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ filesystem | fs-types | N/A | --collector.filesystem.fs-types-exclude
 filesystem | mount-points | N/A | --collector.filesystem.mount-points-exclude
 hwmon | chip | --collector.hwmon.chip-include | --collector.hwmon.chip-exclude
 hwmon | sensor | --collector.hwmon.sensor-include | --collector.hwmon.sensor-exclude
+interrupts | name | --collector.interrupts.name-include | --collector.interrupts.name-exclude
 netdev | device | --collector.netdev.device-include | --collector.netdev.device-exclude
 qdisk | device | --collector.qdisk.device-include | --collector.qdisk.device-exclude
 slabinfo | slab-names | --collector.slabinfo.slabs-include | --collector.slabinfo.slabs-exclude

--- a/collector/interrupts_linux.go
+++ b/collector/interrupts_linux.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -39,9 +40,18 @@ func (c *interruptsCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	}
 	for name, interrupt := range interrupts {
 		for cpuNo, value := range interrupt.values {
+			filterName := name + ";" + interrupt.info + ";" + interrupt.devices
+			if c.nameFilter.ignored(filterName) {
+				level.Debug(c.logger).Log("msg", "ignoring interrupt name", "filter_name", filterName)
+				continue
+			}
 			fv, err := strconv.ParseFloat(value, 64)
 			if err != nil {
 				return fmt.Errorf("invalid value %s in interrupts: %w", value, err)
+			}
+			if !c.includeZeros && fv == 0.0 {
+				level.Debug(c.logger).Log("msg", "ignoring interrupt with zero value", "filter_name", filterName, "cpu", cpuNo)
+				continue
 			}
 			ch <- c.desc.mustNewConstMetric(fv, strconv.Itoa(cpuNo), name, interrupt.info, interrupt.devices)
 		}


### PR DESCRIPTION
In order to reduce cardinality of the interrupts collector add filtering options
* Add include/exclude regexp filter flags.
* Add boolean flag to include zero values, enabled by default.