### PR TITLE
Add UIDs to dashboards

### DIFF
--- a/docs/node-mixin/dashboards/node.libsonnet
+++ b/docs/node-mixin/dashboards/node.libsonnet
@@ -1,7 +1,7 @@
 {
   local nodemixin = import '../lib/prom-mixin.libsonnet',
   grafanaDashboards+:: {
-    'nodes.json': nodemixin.new(config=$._config, platform='Linux').dashboard,
-    'nodes-darwin.json': nodemixin.new(config=$._config, platform='Darwin').dashboard,
+    'nodes.json': nodemixin.new(config=$._config, platform='Linux', uid=std.md5('nodes.json')).dashboard,
+    'nodes-darwin.json': nodemixin.new(config=$._config, platform='Darwin', uid=std.md5('nodes-darwin.json')).dashboard,
   },
 }

--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -150,7 +150,8 @@ local diskSpaceUtilisation =
                              tags=($._config.dashboardTags),
                              timezone='utc',
                              refresh='30s',
-                             graphTooltip='shared_crosshair'
+                             graphTooltip='shared_crosshair',
+                             uid=std.md5('node-rsrc-use.json')
                            )
                            .addTemplate(datasourceTemplate)
                            .addTemplate($._clusterTemplate)
@@ -215,7 +216,8 @@ local diskSpaceUtilisation =
                              tags=($._config.dashboardTags),
                              timezone='utc',
                              refresh='30s',
-                             graphTooltip='shared_crosshair'
+                             graphTooltip='shared_crosshair',
+                             uid=std.md5('node-cluster-rsrc-use.json')
                            )
                            .addTemplate(datasourceTemplate)
                            .addTemplate($._clusterTemplate)
@@ -326,7 +328,8 @@ local diskSpaceUtilisation =
                              tags=($._config.dashboardTags),
                              timezone='utc',
                              refresh='30s',
-                             graphTooltip='shared_crosshair'
+                             graphTooltip='shared_crosshair',
+                             uid=std.md5('node-multicluster-rsrc-use.json')
                            )
                            .addTemplate(datasourceTemplate)
                            .addRow(

--- a/docs/node-mixin/lib/prom-mixin.libsonnet
+++ b/docs/node-mixin/lib/prom-mixin.libsonnet
@@ -10,7 +10,7 @@ local table = grafana70.panel.table;
 
 {
 
-  new(config=null, platform=null):: {
+  new(config=null, platform=null, uid=null):: {
 
     local prometheusDatasourceTemplate = {
       current: {
@@ -501,7 +501,8 @@ local table = grafana70.panel.table;
         tags=(config.dashboardTags),
         timezone='utc',
         refresh='30s',
-        graphTooltip='shared_crosshair'
+        graphTooltip='shared_crosshair',
+        uid=std.md5(uid)
       )
       .addTemplates(templates)
       .addRows(rows)
@@ -512,7 +513,8 @@ local table = grafana70.panel.table;
         tags=(config.dashboardTags),
         timezone='utc',
         refresh='30s',
-        graphTooltip='shared_crosshair'
+        graphTooltip='shared_crosshair',
+        uid=std.md5(uid)
       )
       .addTemplates(templates)
       .addRows(rows),


### PR DESCRIPTION
Automatically add a uid to each dashboard. This prevents changing URLs when restarting a grafana pod and re-importing the dashboards via ConfigMaps.