### PR TITLE
feat!: new meminfo_procfs collector, deprecate meminfo collector

### DIFF
--- a/collector/meminfo.go
+++ b/collector/meminfo.go
@@ -40,6 +40,8 @@ func init() {
 
 // NewMeminfoCollector returns a new Collector exposing memory stats.
 func NewMeminfoCollector(logger log.Logger) (Collector, error) {
+	level.Warn(logger).Log("msg", "This collector is deprecated and will be removed in the next major version release.")
+
 	return &meminfoCollector{logger}, nil
 }
 

--- a/collector/meminfo_procfs.go
+++ b/collector/meminfo_procfs.go
@@ -1,0 +1,77 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux && !nomeminfo_procfs
+// +build linux,!nomeminfo_procfs
+
+package collector
+
+import (
+	"fmt"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/procfs"
+)
+
+const (
+	memInfoProcfsSubsystem = "memory"
+)
+
+var (
+	memoryBytesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, memInfoProcfsSubsystem, "bytes"),
+		"Value in bytes for the labeled field in /proc/meminfo.",
+		[]string{"field"}, nil,
+	)
+)
+
+type meminfoProcfsCollector struct {
+	memoryBytesDesc *prometheus.Desc
+	fs              procfs.FS
+	logger          log.Logger
+}
+
+func init() {
+	registerCollector("meminfo_procfs", defaultDisabled, NewMeminfoProcfsCollector)
+}
+
+// NewMeminfoProcfsCollector returns a new Collector exposing memory stats.
+func NewMeminfoProcfsCollector(logger log.Logger) (Collector, error) {
+	fs, err := procfs.NewFS(*procPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open procfs: %w", err)
+	}
+
+	return &meminfoProcfsCollector{
+		fs:              fs,
+		logger:          logger,
+		memoryBytesDesc: memoryBytesDesc,
+	}, nil
+}
+
+// Update calls (*meminfoProcfsCollector).getMemInfo to get the platform specific
+// memory metrics.
+func (c *meminfoProcfsCollector) Update(ch chan<- prometheus.Metric) error {
+	memInfo, err := c.getMemInfo()
+	if err != nil {
+		return fmt.Errorf("couldn't get meminfo: %w", err)
+	}
+
+	level.Debug(c.logger).Log("msg", "Set node_mem", "memInfoProcfs", fmt.Sprintf("%v", memInfo))
+	for k, v := range memInfo {
+		ch <- prometheus.MustNewConstMetric(c.memoryBytesDesc, prometheus.GaugeValue, v, k)
+	}
+	return nil
+}

--- a/collector/meminfo_procfs_linux.go
+++ b/collector/meminfo_procfs_linux.go
@@ -1,0 +1,76 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nomeminfo_procfs
+// +build !nomeminfo_procfs
+
+package collector
+
+import (
+	"fmt"
+)
+
+func (c *meminfoProcfsCollector) getMemInfo() (map[string]float64, error) {
+	meminfo, err := c.fs.Meminfo()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get memory info: %s", err)
+	}
+
+	return map[string]float64{
+		"MemTotal":          uint64PtrToFloat(meminfo.MemTotalBytes),
+		"MemFree":           uint64PtrToFloat(meminfo.MemFreeBytes),
+		"MemAvailable":      uint64PtrToFloat(meminfo.MemAvailableBytes),
+		"Buffers":           uint64PtrToFloat(meminfo.BuffersBytes),
+		"Cached":            uint64PtrToFloat(meminfo.CachedBytes),
+		"SwapCached":        uint64PtrToFloat(meminfo.SwapCachedBytes),
+		"Active":            uint64PtrToFloat(meminfo.ActiveBytes),
+		"Inactive":          uint64PtrToFloat(meminfo.InactiveBytes),
+		"ActiveAnon":        uint64PtrToFloat(meminfo.ActiveAnonBytes),
+		"InactiveAnon":      uint64PtrToFloat(meminfo.InactiveAnonBytes),
+		"ActiveFile":        uint64PtrToFloat(meminfo.ActiveFileBytes),
+		"InactiveFile":      uint64PtrToFloat(meminfo.InactiveFileBytes),
+		"Unevictable":       uint64PtrToFloat(meminfo.UnevictableBytes),
+		"Mlocked":           uint64PtrToFloat(meminfo.MlockedBytes),
+		"SwapTotal":         uint64PtrToFloat(meminfo.SwapTotalBytes),
+		"SwapFree":          uint64PtrToFloat(meminfo.SwapFreeBytes),
+		"Dirty":             uint64PtrToFloat(meminfo.DirtyBytes),
+		"Writeback":         uint64PtrToFloat(meminfo.WritebackBytes),
+		"AnonPages":         uint64PtrToFloat(meminfo.AnonPagesBytes),
+		"Mapped":            uint64PtrToFloat(meminfo.MappedBytes),
+		"Shmem":             uint64PtrToFloat(meminfo.ShmemBytes),
+		"Slab":              uint64PtrToFloat(meminfo.SlabBytes),
+		"SReclaimable":      uint64PtrToFloat(meminfo.SReclaimableBytes),
+		"SUnreclaim":        uint64PtrToFloat(meminfo.SUnreclaimBytes),
+		"KernelStack":       uint64PtrToFloat(meminfo.KernelStackBytes),
+		"PageTables":        uint64PtrToFloat(meminfo.PageTablesBytes),
+		"NFSUnstable":       uint64PtrToFloat(meminfo.NFSUnstableBytes),
+		"Bounce":            uint64PtrToFloat(meminfo.BounceBytes),
+		"WritebackTmp":      uint64PtrToFloat(meminfo.WritebackTmpBytes),
+		"CommitLimit":       uint64PtrToFloat(meminfo.CommitLimitBytes),
+		"CommittedAS":       uint64PtrToFloat(meminfo.CommittedASBytes),
+		"VmallocTotal":      uint64PtrToFloat(meminfo.VmallocTotalBytes),
+		"VmallocUsed":       uint64PtrToFloat(meminfo.VmallocUsedBytes),
+		"VmallocChunk":      uint64PtrToFloat(meminfo.VmallocChunkBytes),
+		"Percpu":            uint64PtrToFloat(meminfo.PercpuBytes),
+		"HardwareCorrupted": uint64PtrToFloat(meminfo.HardwareCorruptedBytes),
+		"AnonHugePages":     uint64PtrToFloat(meminfo.AnonHugePagesBytes),
+		"ShmemHugePages":    uint64PtrToFloat(meminfo.ShmemHugePagesBytes),
+		"ShmemPmdMapped":    uint64PtrToFloat(meminfo.ShmemPmdMappedBytes),
+		"CmaTotal":          uint64PtrToFloat(meminfo.CmaTotalBytes),
+		"CmaFree":           uint64PtrToFloat(meminfo.CmaFreeBytes),
+		"Hugepagesize":      uint64PtrToFloat(meminfo.HugepagesizeBytes),
+		"DirectMap4k":       uint64PtrToFloat(meminfo.DirectMap4kBytes),
+		"DirectMap2M":       uint64PtrToFloat(meminfo.DirectMap2MBytes),
+		"DirectMap1G":       uint64PtrToFloat(meminfo.DirectMap1GBytes),
+	}, nil
+}

--- a/collector/meminfo_procfs_linux_test.go
+++ b/collector/meminfo_procfs_linux_test.go
@@ -1,0 +1,131 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nomeminfo_procfs
+// +build !nomeminfo_procfs
+
+package collector
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+const (
+	testMetrics = `# HELP node_memory_bytes Value in bytes for the labeled field in /proc/meminfo.
+# TYPE node_memory_bytes gauge
+node_memory_bytes{field="ActiveAnon"} 2.068484096e+09
+node_memory_bytes{field="Active"} 2.287017984e+09
+node_memory_bytes{field="ActiveFile"} 2.18533888e+08
+node_memory_bytes{field="AnonHugePages"} 0
+node_memory_bytes{field="AnonPages"} 2.298032128e+09
+node_memory_bytes{field="Bounce"} 0
+node_memory_bytes{field="Buffers"} 2.256896e+07
+node_memory_bytes{field="Cached"} 9.53229312e+08
+node_memory_bytes{field="CmaFree"} 0
+node_memory_bytes{field="CmaTotal"} 0
+node_memory_bytes{field="CommitLimit"} 6.210940928e+09
+node_memory_bytes{field="CommittedAS"} 8.023486464e+09
+node_memory_bytes{field="DirectMap1G"} 0
+node_memory_bytes{field="DirectMap2M"} 3.787456512e+09
+node_memory_bytes{field="DirectMap4k"} 1.9011584e+08
+node_memory_bytes{field="Dirty"} 1.077248e+06
+node_memory_bytes{field="HardwareCorrupted"} 0
+node_memory_bytes{field="Hugepagesize"} 2.097152e+06
+node_memory_bytes{field="InactiveAnon"} 9.04245248e+08
+node_memory_bytes{field="Inactive"} 1.053417472e+09
+node_memory_bytes{field="InactiveFile"} 1.49172224e+08
+node_memory_bytes{field="KernelStack"} 5.9392e+06
+node_memory_bytes{field="Mapped"} 2.4496128e+08
+node_memory_bytes{field="MemAvailable"} 0
+node_memory_bytes{field="MemFree"} 2.30883328e+08
+node_memory_bytes{field="MemTotal"} 3.831959552e+09
+node_memory_bytes{field="Mlocked"} 32768
+node_memory_bytes{field="NFSUnstable"} 0
+node_memory_bytes{field="PageTables"} 7.7017088e+07
+node_memory_bytes{field="Percpu"} 0
+node_memory_bytes{field="SReclaimable"} 4.5846528e+07
+node_memory_bytes{field="SUnreclaim"} 5.545984e+07
+node_memory_bytes{field="Shmem"} 6.0809216e+08
+node_memory_bytes{field="ShmemHugePages"} 0
+node_memory_bytes{field="ShmemPmdMapped"} 0
+node_memory_bytes{field="Slab"} 1.01306368e+08
+node_memory_bytes{field="SwapCached"} 1.97124096e+08
+node_memory_bytes{field="SwapFree"} 3.23108864e+09
+node_memory_bytes{field="SwapTotal"} 4.2949632e+09
+node_memory_bytes{field="Unevictable"} 32768
+node_memory_bytes{field="VmallocChunk"} 3.5183963009024e+13
+node_memory_bytes{field="VmallocTotal"} 3.5184372087808e+13
+node_memory_bytes{field="VmallocUsed"} 3.6130816e+08
+node_memory_bytes{field="Writeback"} 0
+node_memory_bytes{field="WritebackTmp"} 0
+`
+)
+
+type testMeminfoProcfsCollector struct {
+	mc Collector
+}
+
+func (c testMeminfoProcfsCollector) Collect(ch chan<- prometheus.Metric) {
+	c.mc.Update(ch)
+}
+
+func (c testMeminfoProcfsCollector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(c, ch)
+}
+
+func NewTestMeminfoProcfsCollector(logger log.Logger) (prometheus.Collector, error) {
+	mc, err := NewMeminfoProcfsCollector(logger)
+	if err != nil {
+		return testMeminfoProcfsCollector{}, err
+	}
+	return testMeminfoProcfsCollector{
+		mc: mc,
+	}, err
+}
+
+func TestMemInfoProcfs(t *testing.T) {
+	*procPath = "fixtures/proc"
+	logger := log.NewLogfmtLogger(os.Stderr)
+
+	collector, err := NewMeminfoProcfsCollector(logger)
+	if err != nil {
+		panic(err)
+	}
+	c, err := NewTestMeminfoProcfsCollector(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(c)
+
+	sink := make(chan prometheus.Metric)
+	go func() {
+		err = collector.Update(sink)
+		if err != nil {
+			panic(fmt.Errorf("failed to update collector: %s", err))
+		}
+		close(sink)
+	}()
+
+	err = testutil.GatherAndCompare(reg, strings.NewReader(testMetrics))
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Part of #2957

Adds a new collector named `meminfo_procfs` that exposes memory metrics in a format that attemps to be more inline with upstream conventions -- memory metrics are now exposed under a single metric named `node_memory_bytes` that has a single label called `field`, corresponding to the name of the field in `/proc/meminfo` that value represents. Label values for the `field` label are named according to the struct field in the procfs.Meminfo struct, and the values always use the byte-normalized counterpart fields in the procfs.Meminfo struct, resulting in a transition such as the following:
`node_memory_Active_anon_bytes -> node_memory_bytes{field="ActiveAnon"}`

Notes:
currently linux only, as that is the focus of the procfs lib. once consensus has been reached here on new metric name/labels/format, I can expand coverage for darwin/openbsd/netbsd and forward-port the existing meminfo collector for those platforms to use the updated format.