### PR TITLE
Do not panic as much in Linux collector tests

### DIFF
--- a/collector/btrfs_linux_test.go
+++ b/collector/btrfs_linux_test.go
@@ -92,7 +92,10 @@ func checkMetric(exp, got *btrfsMetric) bool {
 }
 
 func TestBtrfs(t *testing.T) {
-	fs, _ := btrfs.NewFS("fixtures/sys")
+	fs, err := btrfs.NewFS("fixtures/sys")
+	if err != nil {
+		t.Fatal(err)
+	}
 	collector := &btrfsCollector{fs: fs}
 
 	stats, err := collector.fs.Stats()

--- a/collector/diskstats_linux_test.go
+++ b/collector/diskstats_linux_test.go
@@ -320,7 +320,7 @@ node_disk_written_bytes_total{device="vda"} 1.0938236928e+11
 	logger := log.NewLogfmtLogger(os.Stderr)
 	collector, err := NewDiskstatsCollector(logger)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	c, err := NewTestDiskStatsCollector(logger)
 	if err != nil {

--- a/collector/ethtool_linux_test.go
+++ b/collector/ethtool_linux_test.go
@@ -257,11 +257,11 @@ func (e *EthtoolFixture) LinkInfo(intf string) (ethtool.EthtoolCmd, error) {
 
 func NewEthtoolTestCollector(logger log.Logger) (Collector, error) {
 	collector, err := makeEthtoolCollector(logger)
-	collector.ethtool = &EthtoolFixture{
-		fixturePath: "fixtures/ethtool/",
-	}
 	if err != nil {
 		return nil, err
+	}
+	collector.ethtool = &EthtoolFixture{
+		fixturePath: "fixtures/ethtool/",
 	}
 	return collector, nil
 }
@@ -373,7 +373,7 @@ node_network_supported_speed_bytes{device="eth0",duplex="half",mode="10baseT"} 1
 	logger := log.NewLogfmtLogger(os.Stderr)
 	collector, err := NewEthtoolTestCollector(logger)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	c, err := NewTestEthtoolCollector(logger)
 	if err != nil {


### PR DESCRIPTION
Running `go test` in the collector directory, without the fixtures available, results in multiple panics, including `SIGSEGV`. Most of these are due to incorrect error handling. This cleans them up.