### PR TITLE
fix pressure metric collection fails on systems that do not expose a full CPU stat

### DIFF
--- a/collector/pressure_linux.go
+++ b/collector/pressure_linux.go
@@ -106,7 +106,7 @@ func (c *pressureStatsCollector) Update(ch chan<- prometheus.Metric) error {
 			level.Debug(c.logger).Log("msg", "pressure information returned no 'some' data")
 			return ErrNoData
 		}
-		if vals.Full == nil {
+		if vals.Full == nil && res != "cpu" {
 			level.Debug(c.logger).Log("msg", "pressure information returned no 'full' data")
 			return ErrNoData
 		}


### PR DESCRIPTION
fix #3051
allow only some for CPU.