### PR TITLE
Fix: Correct spacing in EXPERIMENTAL label in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ To see all available configuration flags:
 
 ## TLS endpoint
 
-** EXPERIMENTAL **
+**EXPERIMENTAL**
 
 The exporter supports TLS via a new web configuration file.
 


### PR DESCRIPTION
### Description
This pull request updates the `README.md` file to correct the spacing in the **EXPERIMENTAL** label within the "TLS endpoint" section. The previous version had extra spaces around the word, which have been removed for consistency.

### Motivation
The term **EXPERIMENTAL** was previously formatted with extra spaces (** EXPERIMENTAL **), which was inconsistent with the rest of the document's formatting. Removing the extra spaces improves the readability and consistency of the documentation.

### Changes Made
- Updated the `README.md` file to change ** EXPERIMENTAL ** to **EXPERIMENTAL**.

### Related Issues
- None

### Checklist
- [x] Documentation updated
- [x] No additional dependencies introduced

Please review the changes and let me know if any modifications are needed.
