### PR TITLE
Gracefully handle absence of environment configuration file

### DIFF
--- a/examples/systemd/node_exporter.service
+++ b/examples/systemd/node_exporter.service
@@ -4,7 +4,9 @@ Requires=node_exporter.socket
 
 [Service]
 User=node_exporter
-EnvironmentFile=/etc/sysconfig/node_exporter
+# Fallback when environment file does not exist
+Environment=OPTIONS=
+EnvironmentFile=-/etc/sysconfig/node_exporter
 ExecStart=/usr/sbin/node_exporter --web.systemd-socket $OPTIONS
 
 [Install]


### PR DESCRIPTION
node_exporter has reasonable defaults so it is able to start without explicit config. Such a setup is common in /usr/-only images where /etc/ is an empty tmpfs upon boot.