### PR TITLE
feat(diskstats): add metric for bare disk capacity

### DIFF
--- a/collector/diskstats_common.go
+++ b/collector/diskstats_common.go
@@ -91,6 +91,12 @@ var (
 		diskLabelNames,
 		nil,
 	)
+
+	diskCapacityDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, diskSubsystem, "capacity_bytes"),
+		"Capacity of the disk in bytes.",
+		diskLabelNames, nil,
+	)
 )
 
 func newDiskstatsDeviceFilter(logger log.Logger) (deviceFilter, error) {


### PR DESCRIPTION
work in progress PR to add a metric for bare disk capacity that gets the values of `/sys/block/<device_name>/size`

related issue: https://github.com/prometheus/node_exporter/issues/2595