### PR TITLE
Add include and exclude filter for sensors in hwmon collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ ethtool | metrics | --collector.ethtool.metrics-include | N/A
 filesystem | fs-types | N/A | --collector.filesystem.fs-types-exclude
 filesystem | mount-points | N/A | --collector.filesystem.mount-points-exclude
 hwmon | chip | --collector.hwmon.chip-include | --collector.hwmon.chip-exclude
+hwmon | sensor | --collector.hwmon.sensor-include | --collector.hwmon.sensor-exclude
 netdev | device | --collector.netdev.device-include | --collector.netdev.device-exclude
 qdisk | device | --collector.qdisk.device-include | --collector.qdisk.device-exclude
 slabinfo | slab-names | --collector.slabinfo.slabs-include | --collector.slabinfo.slabs-exclude

--- a/collector/hwmon_linux.go
+++ b/collector/hwmon_linux.go
@@ -32,8 +32,10 @@ import (
 )
 
 var (
-	collectorHWmonChipInclude = kingpin.Flag("collector.hwmon.chip-include", "Regexp of hwmon chip to include (mutually exclusive to device-exclude).").String()
-	collectorHWmonChipExclude = kingpin.Flag("collector.hwmon.chip-exclude", "Regexp of hwmon chip to exclude (mutually exclusive to device-include).").String()
+	collectorHWmonChipInclude   = kingpin.Flag("collector.hwmon.chip-include", "Regexp of hwmon chip to include (mutually exclusive to device-exclude).").String()
+	collectorHWmonChipExclude   = kingpin.Flag("collector.hwmon.chip-exclude", "Regexp of hwmon chip to exclude (mutually exclusive to device-include).").String()
+	collectorHWmonSensorInclude = kingpin.Flag("collector.hwmon.sensor-include", "Regexp of hwmon sensor to include (mutually exclusive to sensor-exclude).").String()
+	collectorHWmonSensorExclude = kingpin.Flag("collector.hwmon.sensor-exclude", "Regexp of hwmon sensor to exclude (mutually exclusive to sensor-include).").String()
 
 	hwmonInvalidMetricChars = regexp.MustCompile("[^a-z0-9:_]")
 	hwmonFilenameFormat     = regexp.MustCompile(`^(?P<type>[^0-9]+)(?P<id>[0-9]*)?(_(?P<property>.+))?$`)
@@ -52,6 +54,7 @@ func init() {
 
 type hwMonCollector struct {
 	deviceFilter deviceFilter
+	sensorFilter deviceFilter
 	logger       log.Logger
 }
 
@@ -62,6 +65,7 @@ func NewHwMonCollector(logger log.Logger) (Collector, error) {
 	return &hwMonCollector{
 		logger:       logger,
 		deviceFilter: newDeviceFilter(*collectorHWmonChipExclude, *collectorHWmonChipInclude),
+		sensorFilter: newDeviceFilter(*collectorHWmonSensorExclude, *collectorHWmonSensorInclude),
 	}, nil
 }
 
@@ -201,6 +205,15 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) er
 
 	// Format all sensors.
 	for sensor, sensorData := range data {
+
+		// Filtering for sensors is done on concatenated device name and sensor name
+		// separated by an underscore. This allows for excluding or including of specific
+		// sensors on specific devices. For example, to exclude the sensor "temp3" on
+		// the device "platform_coretemp_0", use "platform_coretemp_0_temp3"
+		if c.sensorFilter.ignored(hwmonName + "_" + sensor) {
+			level.Debug(c.logger).Log("msg", "ignoring sensor", "sensor", sensor)
+			continue
+		}
 
 		_, sensorType, _, _ := explodeSensorFilename(sensor)
 

--- a/collector/hwmon_linux.go
+++ b/collector/hwmon_linux.go
@@ -207,10 +207,10 @@ func (c *hwMonCollector) updateHwmon(ch chan<- prometheus.Metric, dir string) er
 	for sensor, sensorData := range data {
 
 		// Filtering for sensors is done on concatenated device name and sensor name
-		// separated by an underscore. This allows for excluding or including of specific
+		// separated by a semicolon. This allows for excluding or including of specific
 		// sensors on specific devices. For example, to exclude the sensor "temp3" on
-		// the device "platform_coretemp_0", use "platform_coretemp_0_temp3"
-		if c.sensorFilter.ignored(hwmonName + "_" + sensor) {
+		// the device "platform_coretemp_0", use "platform_coretemp_0;temp3"
+		if c.sensorFilter.ignored(hwmonName + ";" + sensor) {
 			level.Debug(c.logger).Log("msg", "ignoring sensor", "sensor", sensor)
 			continue
 		}


### PR DESCRIPTION
Fixes #2242

This commit adds two new flags (`collector.hwmon.sensor-include` and `collector.hwmon.sensor-exclude`) to the `hwmon` collector to allow inclusion or exclusion of specific sensors.

Some devices export nonsensical values for certain sensors. Here is an example:

```
node_hwmon_temp_celsius{chip="platform_nct6775_656",sensor="temp13"} 49.75
node_hwmon_temp_celsius{chip="platform_nct6775_656",sensor="temp15"} 3.892313987e+06
node_hwmon_temp_celsius{chip="platform_nct6775_656",sensor="temp16"} 3.892313987e+06
```

As a user I would like to only exclude these sensors, not necessarily the complete device (as is currently possible with the `--collector.hwmon.chip-exclude` flag) as other sensor values might be sensical or desired.

The new option filters based both on device name and sensor name, separated by a semicolon. For example, to exclude the two sensors above, the following regex can be used:

~~~
--collector.hwmon.sensor-exclude="platform_nct6775_656;temp1[5,6]"
~~~

@SuperQ @discordianfish PTAL

Signed-off-by: Simon Krenger <skrenger@redhat.com>