### PR TITLE
textfile: Allow specifiying multiple directory globs.

### DIFF
--- a/collector/textfile_test.go
+++ b/collector/textfile_test.go
@@ -52,75 +52,82 @@ func (a collectorAdapter) Collect(ch chan<- prometheus.Metric) {
 
 func TestTextfileCollector(t *testing.T) {
 	tests := []struct {
-		path string
-		out  string
+		paths []string
+		out   string
 	}{
 		{
-			path: "fixtures/textfile/no_metric_files",
-			out:  "fixtures/textfile/no_metric_files.out",
+			paths: []string{"fixtures/textfile/no_metric_files"},
+			out:   "fixtures/textfile/no_metric_files.out",
 		},
 		{
-			path: "fixtures/textfile/two_metric_files",
-			out:  "fixtures/textfile/two_metric_files.out",
+			paths: []string{"fixtures/textfile/two_metric_files"},
+			out:   "fixtures/textfile/two_metric_files.out",
 		},
 		{
-			path: "fixtures/textfile/nonexistent_path",
-			out:  "fixtures/textfile/nonexistent_path.out",
+			paths: []string{"fixtures/textfile/nonexistent_path"},
+			out:   "fixtures/textfile/nonexistent_path.out",
 		},
 		{
-			path: "fixtures/textfile/client_side_timestamp",
-			out:  "fixtures/textfile/client_side_timestamp.out",
+			paths: []string{"fixtures/textfile/client_side_timestamp"},
+			out:   "fixtures/textfile/client_side_timestamp.out",
 		},
 		{
-			path: "fixtures/textfile/different_metric_types",
-			out:  "fixtures/textfile/different_metric_types.out",
+			paths: []string{"fixtures/textfile/different_metric_types"},
+			out:   "fixtures/textfile/different_metric_types.out",
 		},
 		{
-			path: "fixtures/textfile/inconsistent_metrics",
-			out:  "fixtures/textfile/inconsistent_metrics.out",
+			paths: []string{"fixtures/textfile/inconsistent_metrics"},
+			out:   "fixtures/textfile/inconsistent_metrics.out",
 		},
 		{
-			path: "fixtures/textfile/histogram",
-			out:  "fixtures/textfile/histogram.out",
+			paths: []string{"fixtures/textfile/histogram"},
+			out:   "fixtures/textfile/histogram.out",
 		},
 		{
-			path: "fixtures/textfile/histogram_extra_dimension",
-			out:  "fixtures/textfile/histogram_extra_dimension.out",
+			paths: []string{"fixtures/textfile/histogram_extra_dimension"},
+			out:   "fixtures/textfile/histogram_extra_dimension.out",
 		},
 		{
-			path: "fixtures/textfile/summary",
-			out:  "fixtures/textfile/summary.out",
+			paths: []string{"fixtures/textfile/summary"},
+			out:   "fixtures/textfile/summary.out",
 		},
 		{
-			path: "fixtures/textfile/summary_extra_dimension",
-			out:  "fixtures/textfile/summary_extra_dimension.out",
+			paths: []string{"fixtures/textfile/summary_extra_dimension"},
+			out:   "fixtures/textfile/summary_extra_dimension.out",
 		},
 		{
-			path: "fixtures/textfile/*_extra_dimension",
-			out:  "fixtures/textfile/glob_extra_dimension.out",
+			paths: []string{
+				"fixtures/textfile/histogram_extra_dimension",
+				"fixtures/textfile/summary_extra_dimension",
+			},
+			out: "fixtures/textfile/glob_extra_dimension.out",
 		},
 		{
-			path: "fixtures/textfile/metrics_merge_empty_help",
-			out:  "fixtures/textfile/metrics_merge_empty_help.out",
+			paths: []string{"fixtures/textfile/*_extra_dimension"},
+			out:   "fixtures/textfile/glob_extra_dimension.out",
 		},
 		{
-			path: "fixtures/textfile/metrics_merge_no_help",
-			out:  "fixtures/textfile/metrics_merge_no_help.out",
+			paths: []string{"fixtures/textfile/metrics_merge_empty_help"},
+			out:   "fixtures/textfile/metrics_merge_empty_help.out",
 		},
 		{
-			path: "fixtures/textfile/metrics_merge_same_help",
-			out:  "fixtures/textfile/metrics_merge_same_help.out",
+			paths: []string{"fixtures/textfile/metrics_merge_no_help"},
+			out:   "fixtures/textfile/metrics_merge_no_help.out",
 		},
 		{
-			path: "fixtures/textfile/metrics_merge_different_help",
-			out:  "fixtures/textfile/metrics_merge_different_help.out",
+			paths: []string{"fixtures/textfile/metrics_merge_same_help"},
+			out:   "fixtures/textfile/metrics_merge_same_help.out",
+		},
+		{
+			paths: []string{"fixtures/textfile/metrics_merge_different_help"},
+			out:   "fixtures/textfile/metrics_merge_different_help.out",
 		},
 	}
 
 	for i, test := range tests {
 		mtime := 1.0
 		c := &textFileCollector{
-			path:   test.path,
+			paths:  test.paths,
 			mtime:  &mtime,
 			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		}
@@ -146,7 +153,7 @@ func TestTextfileCollector(t *testing.T) {
 		}
 
 		if string(want) != got {
-			t.Fatalf("%d.%q want:\n\n%s\n\ngot:\n\n%s", i, test.path, string(want), got)
+			t.Fatalf("%d.%q want:\n\n%s\n\ngot:\n\n%s", i, test.paths, string(want), got)
 		}
 	}
 }


### PR DESCRIPTION
We already support reading from multiple directories though only using globs. Now we can specify them outright.

Example use case is exporting both static info on a RO FS generated during image building and traditional uses of textfiles (e.g. for R/W service metrics files) without scripting a file copy.

* keep flag name for compatibility
* clarify flag help text
* add test case (replicating the glob one)