### PR TITLE
Add AIX support

### DIFF
--- a/collector/cpu_aix.go
+++ b/collector/cpu_aix.go
@@ -1,0 +1,76 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nocpu
+// +build !nocpu
+
+package collector
+
+/*
+#include <unistd.h>  // Include the standard Unix header
+#include <errno.h>   // For errno
+*/
+import "C"
+import (
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/power-devops/perfstat"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type cpuCollector struct {
+	cpu           typedDesc
+	logger        *slog.Logger
+	tickPerSecond int64
+}
+
+func init() {
+	registerCollector("cpu", defaultEnabled, NewCpuCollector)
+}
+
+func tickPerSecond() (int64, error) {
+	ticks, err := C.sysconf(C._SC_CLK_TCK)
+	if ticks == -1 || err != nil {
+		return 0, fmt.Errorf("failed to get clock ticks per second: %v", err)
+	}
+	return int64(ticks), nil
+}
+
+func NewCpuCollector(logger *slog.Logger) (Collector, error) {
+	ticks, err := tickPerSecond()
+	if err != nil {
+		return nil, err
+	}
+	return &cpuCollector{
+		cpu:           typedDesc{nodeCPUSecondsDesc, prometheus.CounterValue},
+		logger:        logger,
+		tickPerSecond: ticks,
+	}, nil
+}
+
+func (c *cpuCollector) Update(ch chan<- prometheus.Metric) error {
+	stats, err := perfstat.CpuStat()
+	if err != nil {
+		return err
+	}
+
+	for n, stat := range stats {
+		ch <- c.cpu.mustNewConstMetric(float64(stat.User/c.tickPerSecond), strconv.Itoa(n), "user")
+		ch <- c.cpu.mustNewConstMetric(float64(stat.Sys/c.tickPerSecond), strconv.Itoa(n), "system")
+		ch <- c.cpu.mustNewConstMetric(float64(stat.Idle/c.tickPerSecond), strconv.Itoa(n), "idle")
+		ch <- c.cpu.mustNewConstMetric(float64(stat.Wait/c.tickPerSecond), strconv.Itoa(n), "wait")
+	}
+	return nil
+}

--- a/collector/diskstats_aix.go
+++ b/collector/diskstats_aix.go
@@ -1,0 +1,82 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nodiskstats
+// +build !nodiskstats
+
+package collector
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/power-devops/perfstat"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const diskstatsDefaultIgnoredDevices = ""
+
+type diskstatsCollector struct {
+	rbytes typedDesc
+	wbytes typedDesc
+	time   typedDesc
+
+	deviceFilter deviceFilter
+	logger       *slog.Logger
+
+	tickPerSecond int64
+}
+
+func init() {
+	registerCollector("diskstats", defaultEnabled, NewDiskstatsCollector)
+}
+
+// NewDiskstatsCollector returns a new Collector exposing disk device stats.
+func NewDiskstatsCollector(logger *slog.Logger) (Collector, error) {
+	ticks, err := tickPerSecond()
+	if err != nil {
+		return nil, err
+	}
+	deviceFilter, err := newDiskstatsDeviceFilter(logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse device filter flags: %w", err)
+	}
+
+	return &diskstatsCollector{
+		rbytes: typedDesc{readBytesDesc, prometheus.CounterValue},
+		wbytes: typedDesc{writtenBytesDesc, prometheus.CounterValue},
+		time:   typedDesc{ioTimeSecondsDesc, prometheus.CounterValue},
+
+		deviceFilter: deviceFilter,
+		logger:       logger,
+
+		tickPerSecond: ticks,
+	}, nil
+}
+
+func (c *diskstatsCollector) Update(ch chan<- prometheus.Metric) error {
+	stats, err := perfstat.DiskStat()
+	if err != nil {
+		return err
+	}
+
+	for _, stat := range stats {
+		if c.deviceFilter.ignored(stat.Name) {
+			continue
+		}
+		ch <- c.rbytes.mustNewConstMetric(float64(stat.Rblks*512), stat.Name)
+		ch <- c.wbytes.mustNewConstMetric(float64(stat.Wblks*512), stat.Name)
+		ch <- c.time.mustNewConstMetric(float64(stat.Time/c.tickPerSecond), stat.Name)
+	}
+	return nil
+}

--- a/collector/diskstats_common.go
+++ b/collector/diskstats_common.go
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !nodiskstats && (openbsd || linux || darwin)
+//go:build !nodiskstats && (openbsd || linux || darwin || aix)
 // +build !nodiskstats
-// +build openbsd linux darwin
+// +build openbsd linux darwin aix
 
 package collector
 

--- a/collector/filesystem_aix.go
+++ b/collector/filesystem_aix.go
@@ -1,0 +1,65 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nofilesystem
+// +build !nofilesystem
+
+package collector
+
+import (
+	"github.com/power-devops/perfstat"
+)
+
+const (
+	defMountPointsExcluded = "^/(dev|aha)($|/)"
+	defFSTypesExcluded     = "^procfs$"
+)
+
+// Expose filesystem fullness.
+func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
+	fsStat, err := perfstat.FileSystemStat()
+	if err != nil {
+		return nil, err
+	}
+	for _, stat := range fsStat {
+		if c.excludedMountPointsPattern.MatchString(stat.MountPoint) {
+			c.logger.Debug("Ignoring mount point", "mountpoint", stat.MountPoint)
+			continue
+		}
+		fstype := stat.TypeString()
+		if c.excludedFSTypesPattern.MatchString(fstype) {
+			c.logger.Debug("Ignoring fs type", "type", fstype)
+			continue
+		}
+
+		ro := 0.0
+		if stat.Flags&perfstat.VFS_READONLY != 0 {
+			ro = 1.0
+		}
+
+		stats = append(stats, filesystemStats{
+			labels: filesystemLabels{
+				device:     stat.Device,
+				mountPoint: stat.MountPoint,
+				fsType:     fstype,
+			},
+			size:      float64(stat.TotalBlocks / 512.0),
+			free:      float64(stat.FreeBlocks / 512.0),
+			avail:     float64(stat.FreeBlocks / 512.0), // AIX doesn't distinguish between free and available blocks.
+			files:     float64(stat.TotalInodes),
+			filesFree: float64(stat.FreeInodes),
+			ro:        ro,
+		})
+	}
+	return stats, nil
+}

--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !nofilesystem && (linux || freebsd || netbsd || openbsd || darwin || dragonfly)
+//go:build !nofilesystem && (linux || freebsd || netbsd || openbsd || darwin || dragonfly || aix)
 // +build !nofilesystem
-// +build linux freebsd netbsd openbsd darwin dragonfly
+// +build linux freebsd netbsd openbsd darwin dragonfly aix
 
 package collector
 

--- a/collector/loadavg.go
+++ b/collector/loadavg.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build (darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris) && !noloadavg
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+//go:build (darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || aix) && !noloadavg
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris aix
 // +build !noloadavg
 
 package collector

--- a/collector/loadavg_aix.go
+++ b/collector/loadavg_aix.go
@@ -1,0 +1,30 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !noloadavg
+// +build !noloadavg
+
+package collector
+
+import (
+	"github.com/power-devops/perfstat"
+)
+
+func getLoad() ([]float64, error) {
+	stat, err := perfstat.CpuTotalStat()
+	if err != nil {
+		return nil, err
+	}
+
+	return []float64{float64(stat.LoadAvg1), float64(stat.LoadAvg5), float64(stat.LoadAvg15)}, nil
+}

--- a/collector/meminfo.go
+++ b/collector/meminfo.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build (darwin || linux || openbsd || netbsd) && !nomeminfo
-// +build darwin linux openbsd netbsd
+//go:build (darwin || linux || openbsd || netbsd || aix) && !nomeminfo
+// +build darwin linux openbsd netbsd aix
 // +build !nomeminfo
 
 package collector

--- a/collector/meminfo_aix.go
+++ b/collector/meminfo_aix.go
@@ -1,0 +1,47 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nomeminfo
+// +build !nomeminfo
+
+package collector
+
+import (
+	"log/slog"
+
+	"github.com/power-devops/perfstat"
+)
+
+type meminfoCollector struct {
+	logger *slog.Logger
+}
+
+// NewMeminfoCollector returns a new Collector exposing memory stats.
+func NewMeminfoCollector(logger *slog.Logger) (Collector, error) {
+	return &meminfoCollector{
+		logger: logger,
+	}, nil
+}
+
+func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
+	stats, err := perfstat.MemoryTotalStat()
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]float64{
+		"total_bytes":     float64(stats.RealTotal * 4096),
+		"free_bytes":      float64(stats.RealFree * 4096),
+		"available_bytes": float64(stats.RealAvailable * 4096),
+	}, nil
+}

--- a/collector/netdev_aix.go
+++ b/collector/netdev_aix.go
@@ -1,0 +1,54 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nonetdev
+// +build !nonetdev
+
+package collector
+
+import (
+	"log/slog"
+
+	"github.com/power-devops/perfstat"
+)
+
+func getNetDevStats(filter *deviceFilter, logger *slog.Logger) (netDevStats, error) {
+	netDev := netDevStats{}
+
+	stats, err := perfstat.NetAdapterStat()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, stat := range stats {
+		netDev[stat.Name] = map[string]uint64{
+			"receive_packets":    uint64(stat.RxPackets),
+			"transmit_packets":   uint64(stat.TxPackets),
+			"receive_bytes":      uint64(stat.RxBytes),
+			"transmit_bytes":     uint64(stat.TxBytes),
+			"receive_errors":     uint64(stat.RxErrors),
+			"transmit_errors":    uint64(stat.TxErrors),
+			"receive_dropped":    uint64(stat.RxPacketsDropped),
+			"transmit_dropped":   uint64(stat.TxPacketsDropped),
+			"receive_multicast":  uint64(stat.RxMulticastPackets),
+			"transmit_multicast": uint64(stat.TxMulticastPackets),
+		}
+	}
+
+	return netDev, nil
+}
+
+func getNetDevLabels() (map[string]map[string]string, error) {
+	// to be implemented if needed
+	return nil, nil
+}

--- a/collector/netdev_common.go
+++ b/collector/netdev_common.go
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !nonetdev && (linux || freebsd || openbsd || dragonfly || darwin)
+//go:build !nonetdev && (linux || freebsd || openbsd || dragonfly || darwin || aix)
 // +build !nonetdev
-// +build linux freebsd openbsd dragonfly darwin
+// +build linux freebsd openbsd dragonfly darwin aix
 
 package collector
 

--- a/collector/os_release.go
+++ b/collector/os_release.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !noosrelease && !aix
+// +build !noosrelease,!aix
+
 package collector
 
 import (

--- a/collector/uname.go
+++ b/collector/uname.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build (darwin || freebsd || openbsd || netbsd || linux) && !nouname
-// +build darwin freebsd openbsd netbsd linux
+//go:build (darwin || freebsd || openbsd || netbsd || linux || aix) && !nouname
+// +build darwin freebsd openbsd netbsd linux aix
 // +build !nouname
 
 package collector

--- a/collector/uname_bsd.go
+++ b/collector/uname_bsd.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build (darwin || freebsd || openbsd || netbsd) && !nouname
-// +build darwin freebsd openbsd netbsd
+//go:build (darwin || freebsd || openbsd || netbsd || aix) && !nouname
+// +build darwin freebsd openbsd netbsd aix
 // +build !nouname
 
 package collector

--- a/docs/node-mixin/dashboards/node.libsonnet
+++ b/docs/node-mixin/dashboards/node.libsonnet
@@ -3,5 +3,6 @@
   grafanaDashboards+:: {
     'nodes.json': nodemixin.new(config=$._config, platform='Linux', uid=std.md5('nodes.json')).dashboard,
     'nodes-darwin.json': nodemixin.new(config=$._config, platform='Darwin', uid=std.md5('nodes-darwin.json')).dashboard,
+    'nodes-aix.json': nodemixin.new(config=$._config, platform='AIX', uid=std.md5('nodes-aix.json')).dashboard,
   },
 }

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/mdlayher/netlink v1.7.2
 	github.com/mdlayher/wifi v0.2.0
 	github.com/opencontainers/selinux v1.11.0
+	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55
 	github.com/prometheus-community/go-runit v0.1.0
 	github.com/prometheus/client_golang v1.20.3
 	github.com/prometheus/client_model v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaL
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
+github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/prometheus-community/go-runit v0.1.0 h1:uTWEj/Fn2RoLdfg/etSqwzgYNOYPrARx1BHUN052tGA=
 github.com/prometheus-community/go-runit v0.1.0/go.mod h1:AvJ9Jo3gAFu2lbM4+qfjdpq30FfiLDJZKbQ015u08IQ=
 github.com/prometheus/client_golang v1.20.3 h1:oPksm4K8B+Vt35tUhw6GbSNSgVlVSBH0qELP/7u83l4=
@@ -110,6 +112,7 @@ golang.org/x/oauth2 v0.22.0 h1:BzDx2FehcG7jJwgWLELCdmLuxk2i+x9UDpSiss2u0ZA=
 golang.org/x/oauth2 v0.22.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20211031064116-611d5d643895/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=


### PR DESCRIPTION
This PR adds a basic set of AIX metrics, including a dashboard for the mixins:
![image](https://github.com/user-attachments/assets/f2d6146e-ba60-4ef3-88e8-673c7e151f2a)

Since adding tests is hard due to the unavailability of AIX test runners, I carefully manually verified the metrics: https://docs.google.com/document/d/1_9cPbLTNqrxIeTZ57ZbyVsgOurvzvEKy67GvSNSrOhk/edit?usp=sharing

Thanks to Grafana for sponsoring this work!
