### PR TITLE
zfs: Only attempt to pull mibs from supported Releases

### DIFF
--- a/collector/uname_bsd.go
+++ b/collector/uname_bsd.go
@@ -18,6 +18,7 @@
 package collector
 
 import (
+	"strconv"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -60,4 +61,16 @@ func parseHostNameAndDomainName(utsname unix.Utsname) (hostname string, domainna
 		domainname = split[1]
 	}
 	return hostname, domainname
+}
+
+// getOSReleaseMajorMinor returns the Major.Minor version of the Operating System based on the uname's Release as a floating point number
+// this is intended to assist in detecting OS compatibilty/support
+func getOSReleaseMajorMinor() (float64, error) {
+	u, err := getUname()
+	if err != nil {
+		return 0, err
+	}
+	majorMinor := versionRegex.FindString(u.Release)
+	f, err := strconv.ParseFloat(majorMinor, 64)
+	return f, err
 }

--- a/collector/zfs_freebsd.go
+++ b/collector/zfs_freebsd.go
@@ -17,8 +17,9 @@
 package collector
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type zfsCollector struct {
@@ -31,7 +32,8 @@ const (
 )
 
 func NewZFSCollector(logger *slog.Logger) (Collector, error) {
-	return &zfsCollector{
+	c := &zfsCollector{
+		// Common ZFS sysctl metrics
 		sysctls: []bsdSysctl{
 			{
 				name:        "abdstats_linear_count_total",
@@ -208,35 +210,6 @@ func NewZFSCollector(logger *slog.Logger) (Collector, error) {
 				dataType:    bsdSysctlTypeUint64,
 				valueType:   prometheus.GaugeValue,
 			},
-			// when FreeBSD 14.0+, `meta/pm/pd` install of `p`.
-			{
-				name:        "arcstats_p_bytes",
-				description: "ZFS ARC MRU target size",
-				mib:         "kstat.zfs.misc.arcstats.p",
-				dataType:    bsdSysctlTypeUint64,
-				valueType:   prometheus.GaugeValue,
-			},
-			{
-				name:        "arcstats_meta_bytes",
-				description: "ZFS ARC metadata target frac ",
-				mib:         "kstat.zfs.misc.arcstats.meta",
-				dataType:    bsdSysctlTypeUint64,
-				valueType:   prometheus.GaugeValue,
-			},
-			{
-				name:        "arcstats_pd_bytes",
-				description: "ZFS ARC data MRU target frac",
-				mib:         "kstat.zfs.misc.arcstats.pd",
-				dataType:    bsdSysctlTypeUint64,
-				valueType:   prometheus.GaugeValue,
-			},
-			{
-				name:        "arcstats_pm_bytes",
-				description: "ZFS ARC meta MRU target frac",
-				mib:         "kstat.zfs.misc.arcstats.pm",
-				dataType:    bsdSysctlTypeUint64,
-				valueType:   prometheus.GaugeValue,
-			},
 			{
 				name:        "arcstats_size_bytes",
 				description: "ZFS ARC size",
@@ -260,7 +233,50 @@ func NewZFSCollector(logger *slog.Logger) (Collector, error) {
 			},
 		},
 		logger: logger,
-	}, nil
+	}
+
+	v, err := getOSReleaseMajorMinor()
+	if err != nil {
+		c.logger.Warn("unable to determine OS release, zfs arcstats metrics may be missing or unsupported", "error", err)
+		return c, nil
+	}
+	// when FreeBSD 14.0+, use `meta/pm/pd` instead of `p`.
+	if v >= 14.0 {
+		c.sysctls = append(c.sysctls,
+			bsdSysctl{
+				name:        "arcstats_meta_bytes",
+				description: "ZFS ARC metadata target frac ",
+				mib:         "kstat.zfs.misc.arcstats.meta",
+				dataType:    bsdSysctlTypeUint64,
+				valueType:   prometheus.GaugeValue,
+			},
+			bsdSysctl{
+				name:        "arcstats_pd_bytes",
+				description: "ZFS ARC data MRU target frac",
+				mib:         "kstat.zfs.misc.arcstats.pd",
+				dataType:    bsdSysctlTypeUint64,
+				valueType:   prometheus.GaugeValue,
+			},
+			bsdSysctl{
+				name:        "arcstats_pm_bytes",
+				description: "ZFS ARC meta MRU target frac",
+				mib:         "kstat.zfs.misc.arcstats.pm",
+				dataType:    bsdSysctlTypeUint64,
+				valueType:   prometheus.GaugeValue,
+			},
+		)
+	} else {
+		c.sysctls = append(c.sysctls,
+			bsdSysctl{
+				name:        "arcstats_p_bytes",
+				description: "ZFS ARC MRU target size",
+				mib:         "kstat.zfs.misc.arcstats.p",
+				dataType:    bsdSysctlTypeUint64,
+				valueType:   prometheus.GaugeValue,
+			},
+		)
+	}
+	return c, nil
 }
 
 func (c *zfsCollector) Update(ch chan<- prometheus.Metric) error {


### PR DESCRIPTION
In particular 14.0 changed the way arcstats were listed, but we previously attempted to grab them all. By adding a bit of a major release detection we reduce the error noise.

The collector was still functioning, but FreeBSD users were seeing a large spam of error logs like such:
```
msg="collector failed" name=zfs err="couldn't get sysctl: no such file or directory"
```

Instead, the zfs collector will now select the appropriate arcstat metrics for the release. A warning is generated once during start-up if it was unable to determine the OS release.

Resolves #2847