### PR TITLE
Extend DRM labels

### DIFF
--- a/collector/drm_linux.go
+++ b/collector/drm_linux.go
@@ -58,7 +58,7 @@ func NewDrmCollector(logger *slog.Logger) (Collector, error) {
 		CardInfo: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, drmCollectorSubsystem, "card_info"),
 			"Card information",
-			[]string{"card", "memory_vendor", "power_performance_level", "unique_id", "vendor"}, nil,
+			[]string{"card", "memory_vendor", "power_performance_level", "unique_id", "chip", "vendor"}, nil,
 		),
 		GPUBusyPercent: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, drmCollectorSubsystem, "gpu_busy_percent"),
@@ -112,7 +112,7 @@ func (c *drmCollector) updateAMDCards(ch chan<- prometheus.Metric) error {
 	for _, s := range stats {
 		ch <- prometheus.MustNewConstMetric(
 			c.CardInfo, prometheus.GaugeValue, 1,
-			s.Name, s.MemoryVRAMVendor, s.PowerDPMForcePerformanceLevel, s.UniqueID, vendor)
+			s.Name, s.MemoryVRAMVendor, s.PowerDPMForcePerformanceLevel, s.UniqueID, s.HWmonChip, vendor)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.GPUBusyPercent, prometheus.GaugeValue, float64(s.GPUBusyPercent), s.Name)


### PR DESCRIPTION
## Issue
Add chip label to the `node_drm_card_info` metric.

## Solution
Extend the DRM collector to have the `chip` label from the `ClassDRMCardAMDGPUStats`.
The change was also proposed in the [procfs repo](https://github.com/prometheus/procfs), and the [PR](https://github.com/prometheus/procfs/pull/672) is awaiting review.

## Context
The DRM metrics are impossible to relate to the `hwmon` metrics, which export other helpful information about AMD GPUs. The extension will allow us to relate metrics from both 'hwmon` and 'drm` and, in turn, create a better GPU Dashboard for AMD with proper filtering and labelling. 

Demo example metrics:

```
node_drm_card_info{card="card0",chip="0000:9d:00_0_0000:9e:00_0",memory_vendor="samsung",power_performance_level="auto",unique_id="",vendor="amd"} 1
node_drm_gpu_busy_percent{card="card0"} 0
node_drm_memory_gtt_size_bytes{card="card0"} 4.294967296e+09
node_drm_memory_gtt_used_bytes{card="card0"} 8.081408e+06
node_drm_memory_vis_vram_size_bytes{card="card0"} 2.68435456e+08
node_drm_memory_vis_vram_used_bytes{card="card0"} 5.439488e+06
node_drm_memory_vram_size_bytes{card="card0"} 4.294967296e+09
node_drm_memory_vram_used_bytes{card="card0"} 5.57056e+06
node_scrape_collector_duration_seconds{collector="drm"} 0.000537504
node_scrape_collector_success{collector="drm"} 1
```

and:

```
...
node_hwmon_chip_names{chip="0000:9d:00_0_0000:9e:00_0",chip_name="amdgpu"} 1
...
```
