### PR TITLE
Uplift go version as a fix to 3 CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/node_exporter
 
-go 1.22.0
+go 1.23.1
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
An update of the go version to 1.23.1 is carried out here, in order to fix 3 CVEs, as raised in https://github.com/prometheus/node_exporter/issues/3146.