### PR TITLE
Update to go version 1.23.1 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ executors:
   # should also be updated.
   golang:
     docker:
-      - image: cimg/go:1.23
+      - image: cimg/go:1.23.1
   arm:
     docker:
-      - image: cimg/go:1.23
+      - image: cimg/go:1.23.1
     resource_class: arm.medium
 
 jobs:
@@ -57,7 +57,7 @@ jobs:
             fi
 
             if [[ -f "$(pwd)/.build/darwin-amd64/node_exporter" ]]; then
-                promu codesign "$(pwd)/.build/darwin-amd64/node_exporter"                
+                promu codesign "$(pwd)/.build/darwin-amd64/node_exporter"
             fi
       - persist_to_workspace:
           root: .
@@ -70,7 +70,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
     environment:
-      DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.23-base
+      DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.23.1-base
       REPO_PATH: github.com/prometheus/node_exporter
     steps:
       - prometheus/setup_environment

--- a/.promu-cgo.yml
+++ b/.promu-cgo.yml
@@ -1,7 +1,7 @@
 go:
     # Whenever the Go version is updated here, .circle/config.yml and
     # .promu.yml should also be updated.
-    version: 1.23
+    version: 1.23.1
     cgo: true
 repository:
     path: github.com/prometheus/node_exporter

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,7 +1,7 @@
 go:
     # Whenever the Go version is updated here, .circle/config.yml and
     # .promu-cgo.yml should also be updated.
-    version: 1.23
+    version: 1.23.1
 repository:
     path: github.com/prometheus/node_exporter
 build:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/node_exporter
 
-go 1.23.1
+go 1.22.0
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/node_exporter
 
-go 1.22.0
+go 1.23.1
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
An update of the go version to 1.23.1 is carried out here, in order to fix 3 CVEs, as raised in https://github.com/prometheus/node_exporter/issues/3146.