### PR TITLE
chore: add the instance label to `NodeHighNumberConntrackEntriesUsed` alert description

### DIFF
--- a/docs/node-mixin/alerts/alerts.libsonnet
+++ b/docs/node-mixin/alerts/alerts.libsonnet
@@ -191,7 +191,7 @@
             ||| % $._config,
             annotations: {
               summary: 'Number of conntrack are getting close to the limit.',
-              description: '{{ $value | humanizePercentage }} of conntrack entries are used.',
+              description: '{{ $labels.instance }} {{ $value | humanizePercentage }} of conntrack entries are used.',
             },
             labels: {
               severity: 'warning',


### PR DESCRIPTION
The description of other alerts has the instance label, but the `NodeHighNumberConntrackEntriesUsed` alert does not have it.