### PR TITLE
Exclude iowait from NodeCPUHighUsage alert

### DIFF
--- a/docs/node-mixin/alerts/alerts.libsonnet
+++ b/docs/node-mixin/alerts/alerts.libsonnet
@@ -312,7 +312,7 @@
           {
             alert: 'NodeCPUHighUsage',
             expr: |||
-              sum without(mode) (avg without (cpu) (rate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode!="idle"}[2m]))) * 100 > %(cpuHighUsageThreshold)d
+              sum without(mode) (avg without (cpu) (rate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode!~"idle|iowait"}[2m]))) * 100 > %(cpuHighUsageThreshold)d
             ||| % $._config,
             'for': '15m',
             labels: {


### PR DESCRIPTION
Hello, 

This PR removes iowait from the NodeCPUHighUsage alert. Similar change was done in #2194. In my opinion there's no reason why it shouldn't be changed here as well. I'm not sure if it makes sense to keep steal in here but I'm open to someone else to chime in. 