### PR TITLE
path.udev.data is not currently using the --path.rootfs prefix

### DIFF
--- a/collector/diskstats_linux.go
+++ b/collector/diskstats_linux.go
@@ -260,7 +260,7 @@ func NewDiskstatsCollector(logger *slog.Logger) (Collector, error) {
 	}
 
 	// Only enable getting device properties from udev if the directory is readable.
-	if stat, err := os.Stat(*udevDataPath); err != nil || !stat.IsDir() {
+	if stat, err := os.Stat(udevDataFilePath("")); err != nil || !stat.IsDir() {
 		logger.Error("Failed to open directory, disabling udev device properties", "path", *udevDataPath)
 	} else {
 		collector.getUdevDeviceProperties = getUdevDeviceProperties

--- a/collector/paths.go
+++ b/collector/paths.go
@@ -42,6 +42,10 @@ func rootfsFilePath(name string) string {
 }
 
 func udevDataFilePath(name string) string {
+	// If rootfsPath flag is set, prepend to the udev data path
+	if *rootfsPath != "/" {
+		return filepath.Join(*rootfsPath, *udevDataPath, name)
+	}
 	return filepath.Join(*udevDataPath, name)
 }
 


### PR DESCRIPTION
Currently when running the docker img you need to explicitly set the path.udev.data flag or it will run in:
```
level=error collector=diskstats msg="Failed to open directory, disabling udev device properties" path=/run/udev/data
``` 
the non-mounted location `/run/udev/data` is searched by default, when instead it should look in `${path.rootfs}/run/udev/data` if `--path.rootfs` is set.

This is confusing because this flag is not well documented and doesn't align with the plug and play behavior of the other parameters like `/proc` and `/sys`. 

This PR suggests to prepend the `path.rootfs` to the udev data path.
The drawback is that it might make setting `--path.udev.data` confusing if the user tries to already pass the prepended path like `/host/run/udev/data` but the error log in this case becomes helpful.

### Testing
When running the current latest tag 

`docker run -d   --net="host"   --pid="host"   -v "/:/host:ro,rslave"  quay.io/prometheus/node-exporter:latest   --path.rootfs=/host` 
```
ts=2024-12-23T22:00:48.494Z caller=node_exporter.go:193 level=info msg="Starting node_exporter" version="(version=1.8.2, branch=HEAD, revision=f1e0e8360aa60b6cb5e5cc1560bed348fc2c1895)"
ts=2024-12-23T22:00:48.494Z caller=node_exporter.go:194 level=info msg="Build context" build_context="(go=go1.22.5, platform=linux/amd64, user=root@03d440803209, date=20240714-11:53:45, tags=unknown)"
ts=2024-12-23T22:00:48.494Z caller=filesystem_common.go:111 level=info collector=filesystem msg="Parsed flag --collector.filesystem.mount-points-exclude" flag=^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($|/)
ts=2024-12-23T22:00:48.494Z caller=filesystem_common.go:113 level=info collector=filesystem msg="Parsed flag --collector.filesystem.fs-types-exclude" flag=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
ts=2024-12-23T22:00:48.494Z caller=diskstats_common.go:111 level=info collector=diskstats msg="Parsed flag --collector.diskstats.device-exclude" flag=^(z?ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\d+n\d+p)\d+$
ts=2024-12-23T22:00:48.494Z caller=diskstats_linux.go:265 level=error collector=diskstats msg="Failed to open directory, disabling udev device properties" path=/run/udev/data
ts=2024-12-23T22:00:48.494Z caller=node_exporter.go:111 level=info msg="Enabled collectors"
ts=2024-12-23T22:00:48.494Z caller=node_exporter.go:118 level=info collector=arp
...
ts=2024-12-23T22:00:48.494Z caller=node_exporter.go:118 level=info collector=zfs
ts=2024-12-23T22:00:48.495Z caller=tls_config.go:313 level=info msg="Listening on" address=[::]:9100
ts=2024-12-23T22:00:48.495Z caller=tls_config.go:316 level=info msg="TLS is disabled." http2=false address=[::]:9100
```

When running the local image built from branch
`docker run -d   --net="host"   --pid="host"   -v "/:/host:ro,rslave"  node_exporter_local   --path.rootfs=/host`
```
time=2024-12-23T21:57:58.938Z level=INFO source=node_exporter.go:216 msg="Starting node_exporter" version="(version=1.8.1, branch=udev_path_flag, revision=e22301c0dd1779dbee2e70c33982354a427e348e)"
time=2024-12-23T21:57:58.938Z level=INFO source=node_exporter.go:217 msg="Build context" build_context="(go=go1.23.3, platform=linux/amd64, user=alfredo@alfredo-x1, date=20241223-21:49:52, tags=unknown)"
time=2024-12-23T21:57:58.938Z level=INFO source=filesystem_common.go:250 msg="Parsed flag --collector.filesystem.mount-points-exclude" collector=filesystem flag=^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($|/)
time=2024-12-23T21:57:58.938Z level=INFO source=filesystem_common.go:279 msg="Parsed flag --collector.filesystem.fs-types-exclude" collector=filesystem flag=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
time=2024-12-23T21:57:58.939Z level=INFO source=diskstats_common.go:110 msg="Parsed flag --collector.diskstats.device-exclude" collector=diskstats flag=^(z?ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\d+n\d+p)\d+$
time=2024-12-23T21:57:58.939Z level=INFO source=node_exporter.go:135 msg="Enabled collectors"
time=2024-12-23T21:57:58.939Z level=INFO source=node_exporter.go:141 msg=arp
...
time=2024-12-23T21:57:58.939Z level=INFO source=node_exporter.go:141 msg=zfs
time=2024-12-23T21:57:58.939Z level=INFO source=tls_config.go:347 msg="Listening on" address=[::]:9100
time=2024-12-23T21:57:58.939Z level=INFO source=tls_config.go:350 msg="TLS is disabled." http2=false address=[::]:9100
```