### PR TITLE
Fix unused value

### DIFF
--- a/collector/diskstats_linux.go
+++ b/collector/diskstats_linux.go
@@ -85,7 +85,6 @@ type diskstatsCollector struct {
 	deviceMapperInfoDesc    typedFactorDesc
 	ataDescs                map[string]typedFactorDesc
 	logger                  *slog.Logger
-	queueDescs              []typedFactorDesc
 	getUdevDeviceProperties func(uint32, uint32) (udevInfo, error)
 }
 


### PR DESCRIPTION
Remove unused `queueDescs` value from diskstats collector.