### PR TITLE
bugfix: [mixin] remove invalid variable from cluster use dashboards

### DIFF
--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -200,9 +200,6 @@ local diskSpaceUtilisation =
                            + dashboard.withVariables([
                              datasource,
                              $._clusterVariable,
-                             variable.query.withDatasourceFromVariable(datasource)
-                             + variable.query.refresh.onTime()
-                             + variable.query.withSort(asc=true),
                            ])
                            + dashboard.withPanels(
                              grafana.util.grid.makeGrid([
@@ -331,9 +328,6 @@ local diskSpaceUtilisation =
                            + dashboard.withUid(std.md5('node-multicluster-rsrc-use.json'))
                            + dashboard.withVariables([
                              datasource,
-                             variable.query.withDatasourceFromVariable(datasource)
-                             + variable.query.refresh.onTime()
-                             + variable.query.withSort(asc=true),
                            ])
                            + dashboard.withPanels(
                              grafana.util.grid.makeGrid([


### PR DESCRIPTION
It looks like the changes made in #3147 introduced an invalid variable to the 2 cluster use dashboards, this PR removes them.
The invalid variable was most likely not caught since Grafana just removes it without complaining.

Culprit:
```
{
   "datasource": {
      "type": "prometheus",
      "uid": "${datasource}"
   },
   "refresh": 2,
   "sort": 1
}

```

Before:
```
"templating": {
   "list": [
      {
         "name": "datasource",
         "query": "prometheus",
         "type": "datasource"
      },
      {
         "datasource": {
            "type": "prometheus",
            "uid": "${datasource}"
         },
         "hide": 2,
         "includeAll": false,
         "name": "cluster",
         "query": "label_values(node_time_seconds, cluster)",
         "refresh": 2,
         "sort": 1,
         "type": "query"
      },
      {
         "datasource": {
            "type": "prometheus",
            "uid": "${datasource}"
         },
         "refresh": 2,
         "sort": 1
      }
   ]
```

After:

```
"templating": {
   "list": [
      {
         "name": "datasource",
         "query": "prometheus",
         "type": "datasource"
      },
      {
         "datasource": {
            "type": "prometheus",
            "uid": "${datasource}"
         },
         "hide": 0,
         "includeAll": false,
         "name": "cluster",
         "query": "label_values(node_time_seconds, cluster)",
         "refresh": 2,
         "sort": 1,
         "type": "query"
      }
   ]
```

