### PR TITLE
Adressing potential memory leak introduced with the purgeable space reporting feature

### DIFF
--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -89,7 +89,7 @@ type filesystemStats struct {
 	labels            filesystemLabels
 	size, free, avail float64
 	files, filesFree  float64
-	purgeable         *float64
+	purgeable         float64
 	ro, deviceError   float64
 }
 
@@ -232,11 +232,10 @@ func (c *filesystemCollector) Update(ch chan<- prometheus.Metric) error {
 			c.mountInfoDesc, prometheus.GaugeValue,
 			1.0, s.labels.device, s.labels.major, s.labels.minor, s.labels.mountPoint,
 		)
-		if s.purgeable != nil {
+		if s.purgeable >= 0 {
 			ch <- prometheus.MustNewConstMetric(
 				c.purgeableDesc, prometheus.GaugeValue,
-				*s.purgeable, s.labels.device, s.labels.mountPoint,
-				s.labels.fsType, s.labels.deviceError,
+				s.purgeable, s.labels.device, s.labels.mountPoint, s.labels.fsType, s.labels.deviceError,
 			)
 		}
 	}

--- a/collector/filesystem_macos.go
+++ b/collector/filesystem_macos.go
@@ -20,23 +20,22 @@ package collector
 #cgo CFLAGS: -x objective-c
 #cgo LDFLAGS: -framework Foundation
 #import <Foundation/Foundation.h>
-Float64 *purgeable(char *path) {
+Float64 purgeable(char *path) {
   CFNumberRef tmp;
-  Float64 *value;
   NSError *error = nil;
   NSString *str = [NSString stringWithUTF8String:path];
   NSURL *fileURL = [[NSURL alloc] initFileURLWithPath:str];
   NSDictionary *results = [fileURL resourceValuesForKeys:@[NSURLVolumeAvailableCapacityForImportantUsageKey] error:&error];
   if (results) {
-    if ((tmp = CFDictionaryGetValue((CFDictionaryRef)results, NSURLVolumeAvailableCapacityForImportantUsageKey)) == NULL)
-      return NULL;
-    value = (Float64 *)malloc(sizeof(Float64));
-    if (CFNumberGetValue(tmp, kCFNumberFloat64Type, value)) {
+    if ((tmp = CFDictionaryGetValue((CFDictionaryRef)results, NSURLVolumeAvailableCapacityForImportantUsageKey)) == NULL) {
+      return -1.0f;
+    }
+    Float64 value;
+    if (CFNumberGetValue(tmp, kCFNumberFloat64Type, &value)) {
       return value;
     }
   }
-  free(value);
-  return NULL;
+  return -1.0f;
 }
 */
 import "C"
@@ -100,7 +99,7 @@ func (c *filesystemCollector) GetStats() (stats []filesystemStats, err error) {
 			avail:     float64(mnt[i].f_bavail) * float64(mnt[i].f_bsize),
 			files:     float64(mnt[i].f_files),
 			filesFree: float64(mnt[i].f_ffree),
-			purgeable: (*float64)(C.purgeable(C.CString(mountpoint))),
+			purgeable: float64(C.purgeable(C.CString(mountpoint))),
 			ro:        ro,
 		})
 	}


### PR DESCRIPTION
This should fix issues reported with #3269 by using values rather than references while keeping the semantics of the original implementation.

@SuperQ , @discordianfish 