### PR TITLE
Fix linter warning

### DIFF
--- a/collector/ethtool_linux.go
+++ b/collector/ethtool_linux.go
@@ -446,7 +446,7 @@ func (c *ethtoolCollector) Update(ch chan<- prometheus.Metric) error {
 			}
 		}
 
-		if stats == nil || len(stats) < 1 {
+		if len(stats) == 0 {
 			// No stats returned; device does not support ethtool stats.
 			continue
 		}


### PR DESCRIPTION
Fix S1009: should omit nil check; len() for nil maps is defined as zero (gosimple)