### PR TITLE
Fix OpenBSD interrupt device parsing

### DIFF
--- a/collector/interrupts_openbsd_amd64.go
+++ b/collector/interrupts_openbsd_amd64.go
@@ -21,6 +21,8 @@ import (
 	"strconv"
 	"unsafe"
 
+	"github.com/prometheus/node_exporter/collector/utils"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/unix"
 )
@@ -49,7 +51,7 @@ func intr(idx _C_int) (itr interrupt, err error) {
 		return
 	}
 	dev := *(*[128]byte)(unsafe.Pointer(&buf[0]))
-	itr.device = string(dev[:])
+	itr.device = utils.SafeBytesToString(dev[:])
 
 	mib[2] = KERN_INTRCNT_VECTOR
 	buf, err = sysctl(mib[:])

--- a/collector/utils/utils.go
+++ b/collector/utils/utils.go
@@ -13,6 +13,11 @@
 
 package utils
 
+import (
+	"bytes"
+	"strings"
+)
+
 func SafeDereference[T any](s ...*T) []T {
 	var resolved []T
 	for _, v := range s {
@@ -24,4 +29,19 @@ func SafeDereference[T any](s ...*T) []T {
 		}
 	}
 	return resolved
+}
+
+// SafeBytesToString takes a slice of bytes and sanitizes it for Prometheus label
+// values.
+// * Terminate the string at the first null byte.
+// * Convert any invalid UTF-8 to "�".
+func SafeBytesToString(b []byte) string {
+	var s string
+	zeroIndex := bytes.IndexByte(b, 0)
+	if zeroIndex == -1 {
+		s = string(b)
+	} else {
+		s = string(b[:zeroIndex])
+	}
+	return strings.ToValidUTF8(s, "�")
 }

--- a/collector/utils/utils_test.go
+++ b/collector/utils/utils_test.go
@@ -1,0 +1,30 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file ewcept in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+)
+
+func TestSafeBytesToString(t *testing.T) {
+	foo := []byte("foo\x00")
+	if want, got := SafeBytesToString(foo), "foo"; want != got {
+		t.Errorf("Expected: %s, Got: %s", want, got)
+	}
+
+	foo = []byte{115, 97, 110, 101, 253, 190, 214}
+	if want, got := SafeBytesToString(foo), "sane�"; want != got {
+		t.Errorf("Expected: %s, Got: %s", want, got)
+	}
+}


### PR DESCRIPTION
Sanitize zero terminated strings from OpenBSD device name parsing.
* Add byte-to-string util function.

Fixes: https://github.com/prometheus/node_exporter/issues/3287