### PR TITLE
Fix flaky Solaris test

### DIFF
--- a/collector/fixtures/e2e-output-solaris.txt
+++ b/collector/fixtures/e2e-output-solaris.txt
@@ -91,12 +91,6 @@ node_buddyinfo_blocks{node="0",size="8",zone="Normal"} 0
 node_buddyinfo_blocks{node="0",size="9",zone="DMA"} 1
 node_buddyinfo_blocks{node="0",size="9",zone="DMA32"} 0
 node_buddyinfo_blocks{node="0",size="9",zone="Normal"} 0
-# HELP node_cpu_frequency_max_hertz Maximum CPU thread frequency in hertz.
-# TYPE node_cpu_frequency_max_hertz gauge
-node_cpu_frequency_max_hertz{cpu="0"} 2.445e+09
-node_cpu_frequency_max_hertz{cpu="1"} 2.445e+09
-node_cpu_frequency_max_hertz{cpu="2"} 2.445e+09
-node_cpu_frequency_max_hertz{cpu="3"} 2.445e+09
 # HELP node_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which node_exporter was built, and the goos and goarch for the build.
 # TYPE node_exporter_build_info gauge
 # HELP node_os_info A metric with a constant '1' value labeled by build_id, id, id_like, image_id, image_version, name, pretty_name, variant, variant_id, version, version_codename, version_id.

--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -325,6 +325,7 @@ get "127.0.0.1:${port}/metrics" | grep --text -E -v "${skip_re}" > "${generated_
 non_deterministic_metrics=$(cat << METRICS
   node_boot_time_seconds
   node_cpu_frequency_hertz
+  node_cpu_frequency_max_hertz
   node_cpu_seconds_total
   node_disk_io_time_seconds_total
   node_disk_read_bytes_total


### PR DESCRIPTION
Ignore `node_cpu_frequency_max_hertz` to fix flaky Solaris end-to-end test.