### PR TITLE
chore: Lint with golangci-lint v2

### DIFF
--- a/collector/btrfs_linux.go
+++ b/collector/btrfs_linux.go
@@ -69,7 +69,7 @@ func (c *btrfsCollector) Update(ch chan<- prometheus.Metric) error {
 
 	for _, s := range stats {
 		// match up procfs and ioctl info by filesystem UUID (without dashes)
-		var fsUUID = strings.Replace(s.UUID, "-", "", -1)
+		var fsUUID = strings.ReplaceAll(s.UUID, "-", "")
 		ioctlStats := ioctlStatsMap[fsUUID]
 		c.updateBtrfsStats(ch, s, ioctlStats)
 	}

--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -87,7 +87,7 @@ func NewCPUCollector(logger *slog.Logger) (Collector, error) {
 	isolcpus, err := sfs.IsolatedCPUs()
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("Unable to get isolated cpus: %w", err)
+			return nil, fmt.Errorf("unable to get isolated cpus: %w", err)
 		}
 		logger.Debug("Could not open isolated file", "error", err)
 	}

--- a/collector/cpu_netbsd.go
+++ b/collector/cpu_netbsd.go
@@ -155,7 +155,7 @@ func getCPUTemperatures() (map[int]float64, error) {
 	}
 
 	keys := sortFilterSysmonProperties(props, "coretemp")
-	for idx, _ := range keys {
+	for idx := range keys {
 		convertTemperatures(props[keys[idx]], res)
 	}
 

--- a/collector/ethtool_linux_test.go
+++ b/collector/ethtool_linux_test.go
@@ -212,16 +212,18 @@ func (e *EthtoolFixture) LinkInfo(intf string) (ethtool.EthtoolCmd, error) {
 
 		items := strings.Split(line, ": ")
 		if items[0] == "Supported pause frame use" {
-			if items[1] == "Symmetric" {
+			switch items[1] {
+			case "Symmetric":
 				res.Supported |= (1 << unix.ETHTOOL_LINK_MODE_Pause_BIT)
-			} else if items[1] == "Receive-only" {
+			case "Receive-only":
 				res.Supported |= (1 << unix.ETHTOOL_LINK_MODE_Asym_Pause_BIT)
 			}
 		}
 		if items[0] == "Advertised pause frame use" {
-			if items[1] == "Symmetric" {
+			switch items[1] {
+			case "Symmetric":
 				res.Advertising |= (1 << unix.ETHTOOL_LINK_MODE_Pause_BIT)
-			} else if items[1] == "Receive-only" {
+			case "Receive-only":
 				res.Advertising |= (1 << unix.ETHTOOL_LINK_MODE_Asym_Pause_BIT)
 			}
 		}

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -215,8 +215,8 @@ func parseFilesystemLabels(r io.Reader) ([]filesystemLabels, error) {
 
 		// Ensure we handle the translation of \040 and \011
 		// as per fstab(5).
-		parts[4] = strings.Replace(parts[4], "\\040", " ", -1)
-		parts[4] = strings.Replace(parts[4], "\\011", "\t", -1)
+		parts[4] = strings.ReplaceAll(parts[4], "\\040", " ")
+		parts[4] = strings.ReplaceAll(parts[4], "\\011", "\t")
 
 		filesystems = append(filesystems, filesystemLabels{
 			device:      parts[m+3],

--- a/collector/meminfo_linux.go
+++ b/collector/meminfo_linux.go
@@ -44,7 +44,7 @@ func NewMeminfoCollector(logger *slog.Logger) (Collector, error) {
 func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 	meminfo, err := c.fs.Meminfo()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get memory info: %s", err)
+		return nil, fmt.Errorf("failed to get memory info: %s", err)
 	}
 
 	metrics := make(map[string]float64)

--- a/collector/perf_linux_test.go
+++ b/collector/perf_linux_test.go
@@ -33,7 +33,7 @@ func canTestPerf(t *testing.T) {
 	if err != nil {
 		t.Skip("Procfs not mounted, skipping perf tests")
 	}
-	paranoidStr := strings.Replace(string(paranoidBytes), "\n", "", -1)
+	paranoidStr := strings.ReplaceAll(string(paranoidBytes), "\n", "")
 	paranoid, err := strconv.Atoi(paranoidStr)
 	if err != nil {
 		t.Fatalf("Expected perf_event_paranoid to be an int, got: %s", paranoidStr)

--- a/collector/systemd_linux_test.go
+++ b/collector/systemd_linux_test.go
@@ -122,11 +122,12 @@ func TestSystemdSummary(t *testing.T) {
 	summary := summarizeUnits(fixtures[0])
 
 	for _, state := range unitStatesName {
-		if state == "inactive" {
+		switch state {
+		case "inactive":
 			testSummaryHelper(t, state, summary[state], 3.0)
-		} else if state == "active" {
+		case "active":
 			testSummaryHelper(t, state, summary[state], 1.0)
-		} else {
+		default:
 			testSummaryHelper(t, state, summary[state], 0.0)
 		}
 	}

--- a/collector/zfs_linux.go
+++ b/collector/zfs_linux.go
@@ -435,5 +435,5 @@ type zfsSysctl string
 
 func (s zfsSysctl) metricName() string {
 	parts := strings.Split(string(s), ".")
-	return strings.Replace(parts[len(parts)-1], "-", "_", -1)
+	return strings.ReplaceAll(parts[len(parts)-1], "-", "_")
 }

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -112,7 +112,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		h.logger.Warn("Couldn't create filtered metrics handler:", "err", err)
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(fmt.Sprintf("Couldn't create filtered metrics handler: %s", err)))
+		fmt.Fprintf(w, "Couldn't create filtered metrics handler: %s", err)
 		return
 	}
 	filteredHandler.ServeHTTP(w, r)


### PR DESCRIPTION
This should help prepare the repository for an upgrade of the commonly shared CI files to golangci-lint v2.