### PR TITLE
ci(docker): build and publish `linux/riscv64` images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 !.build/linux-arm64
 !.build/linux-ppc64le
 !.build/linux-s390x
+!.build/linux-riscv64

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 all::
 
 # Needs to be defined before including Makefile.common to auto-generate targets
-DOCKER_ARCHS ?= amd64 armv7 arm64 ppc64le s390x
+DOCKER_ARCHS ?= amd64 armv7 arm64 ppc64le s390x riscv64
 
 include Makefile.common
 


### PR DESCRIPTION
Fixes #3311