### PR TITLE
netstat: Add new FreeBSD metrics

### DIFF
--- a/collector/netstat_freebsd.go
+++ b/collector/netstat_freebsd.go
@@ -32,21 +32,53 @@ import (
 #include <netinet/tcp.h>
 #include <netinet/tcp_var.h>
 #include <netinet/udp.h>
+#include <netinet/ip_var.h>
 */
 import "C"
 
 var (
-	sysctlRaw    = unix.SysctlRaw
-	tcpSendTotal = "bsdNetstatTcpSendPacketsTotal"
-	tcpRecvTotal = "bsdNetstatTcpRecvPacketsTotal"
+	sysctlRaw              = unix.SysctlRaw
+	tcpSendTotal           = "bsdNetstatTcpSendPacketsTotal"
+	tcpRecvTotal           = "bsdNetstatTcpRecvPacketsTotal"
+	ipv4SendTotal          = "bsdNetstatIPv4SendPacketsTotal"
+	ipv4RawSendTotal       = "bsdNetstatIPv4RawSendPacketsTotal"
+	ipv4RecvTotal          = "bsdNetstatIPv4RecvPacketsTotal"
+	ipv4RecvFragmentsTotal = "bsdNetstatIPv4RecvFragmentsTotal"
+	ipv4ForwardTotal       = "bsdNetstatIPv4ForwardTotal"
+	ipv4FastForwardTotal   = "bsdNetstatIPv4FastForwardTotal"
+	ipv4DeliveredTotal     = "bsdNetstatIPv4DeliveredTotal"
 
 	counterMetrics = map[string]*prometheus.Desc{
+		// TCP stats
 		tcpSendTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "netstat", "tcp_transmit_packets_total"),
 			"TCP packets sent", nil, nil),
 		tcpRecvTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "netstat", "tcp_receive_packets_total"),
 			"TCP packets received", nil, nil),
+
+		// IPv4 stats
+		ipv4SendTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "ip4_transmit_packets_total"),
+			"IPv4 packets sent from this host", nil, nil),
+		ipv4RawSendTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "ip4_transmit_raw_packets_total"),
+			"IPv4 raw packets generated", nil, nil),
+		ipv4RecvTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "ip4_receive_packets_total"),
+			"IPv4 packets received", nil, nil),
+		ipv4RecvFragmentsTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "ip4_receive_fragments_total"),
+			"IPv4 fragments received", nil, nil),
+		ipv4ForwardTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "ip4_forward_total"),
+			"IPv4 packets forwarded", nil, nil),
+		ipv4FastForwardTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "ip4_fast_forward_total"),
+			"IPv4 packets fast forwarded", nil, nil),
+		ipv4DeliveredTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "ip4_delivered_total"),
+			"IPv4 packets delivered to the upper layer (packets for this host)", nil, nil),
 	}
 )
 
@@ -77,6 +109,34 @@ func (netstatMetric *NetstatTCPData) GetData() (NetstatMetrics, error) {
 	return NetstatMetrics{
 		tcpSendTotal: float64(tcpStats.tcps_sndtotal),
 		tcpRecvTotal: float64(tcpStats.tcps_rcvtotal),
+	}, nil
+}
+
+type NetstatIPv4Data NetstatData
+
+func NewIPv4Stat() *NetstatIPv4Data {
+	return &NetstatIPv4Data{
+		structSize: int(unsafe.Sizeof(C.struct_ipstat{})),
+		sysctl:     "net.inet.ip.stats",
+	}
+}
+
+func (netstatMetric *NetstatIPv4Data) GetData() (NetstatMetrics, error) {
+	data, err := getData(netstatMetric.sysctl, netstatMetric.structSize)
+	if err != nil {
+		return nil, err
+	}
+
+	ipStats := *(*C.struct_ipstat)(unsafe.Pointer(&data[0]))
+
+	return NetstatMetrics{
+		ipv4SendTotal:          float64(ipStats.ips_localout),
+		ipv4RawSendTotal:       float64(ipStats.ips_rawout),
+		ipv4RecvTotal:          float64(ipStats.ips_total),
+		ipv4RecvFragmentsTotal: float64(ipStats.ips_fragments),
+		ipv4ForwardTotal:       float64(ipStats.ips_forward),
+		ipv4FastForwardTotal:   float64(ipStats.ips_fastforward),
+		ipv4DeliveredTotal:     float64(ipStats.ips_delivered),
 	}, nil
 }
 
@@ -119,9 +179,18 @@ func (c *netStatCollector) Update(ch chan<- prometheus.Metric) error {
 		return err
 	}
 
+	ipv4Stats, err := NewIPv4Stat().GetData()
+	if err != nil {
+		return err
+	}
+
 	allStats := make(map[string]float64)
 
 	for k, v := range tcpStats {
+		allStats[k] = v
+	}
+
+	for k, v := range ipv4Stats {
 		allStats[k] = v
 	}
 
@@ -147,6 +216,19 @@ func getFreeBSDDataMock(sysctl string) []byte {
 		size := int(unsafe.Sizeof(C.struct_tcpstat{}))
 
 		return unsafe.Slice((*byte)(unsafe.Pointer(&tcpStats)), size)
+	} else if sysctl == "net.inet.ip.stats" {
+		ipStats := C.struct_ipstat{
+			ips_localout:    1234,
+			ips_rawout:      1235,
+			ips_total:       1236,
+			ips_fragments:   1237,
+			ips_forward:     1238,
+			ips_fastforward: 1239,
+			ips_delivered:   1240,
+		}
+		size := int(unsafe.Sizeof(C.struct_ipstat{}))
+
+		return unsafe.Slice((*byte)(unsafe.Pointer(&ipStats)), size)
 	}
 
 	return make([]byte, 0, 0)

--- a/collector/netstat_freebsd.go
+++ b/collector/netstat_freebsd.go
@@ -33,6 +33,7 @@ import (
 #include <netinet/tcp_var.h>
 #include <netinet/udp.h>
 #include <netinet/ip_var.h>
+#include <netinet6/ip6_var.h>
 */
 import "C"
 
@@ -47,6 +48,12 @@ var (
 	ipv4ForwardTotal       = "bsdNetstatIPv4ForwardTotal"
 	ipv4FastForwardTotal   = "bsdNetstatIPv4FastForwardTotal"
 	ipv4DeliveredTotal     = "bsdNetstatIPv4DeliveredTotal"
+	ipv6SendTotal          = "bsdNetstatIPv6SendPacketsTotal"
+	ipv6RawSendTotal       = "bsdNetstatIPv6RawSendPacketsTotal"
+	ipv6RecvTotal          = "bsdNetstatIPv6RecvPacketsTotal"
+	ipv6RecvFragmentsTotal = "bsdNetstatIPv6RecvFragmentsTotal"
+	ipv6ForwardTotal       = "bsdNetstatIPv6ForwardTotal"
+	ipv6DeliveredTotal     = "bsdNetstatIPv6DeliveredTotal"
 
 	counterMetrics = map[string]*prometheus.Desc{
 		// TCP stats
@@ -79,6 +86,26 @@ var (
 		ipv4DeliveredTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "netstat", "ip4_delivered_total"),
 			"IPv4 packets delivered to the upper layer (packets for this host)", nil, nil),
+
+		// IPv6 stats
+		ipv6SendTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "ip6_transmit_packets_total"),
+			"IPv6 packets sent from this host", nil, nil),
+		ipv6RawSendTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "ip6_transmit_raw_packets_total"),
+			"IPv6 raw packets generated", nil, nil),
+		ipv6RecvTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "ip6_receive_packets_total"),
+			"IPv6 packets received", nil, nil),
+		ipv6RecvFragmentsTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "ip6_receive_fragments_total"),
+			"IPv6 fragments received", nil, nil),
+		ipv6ForwardTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "ip6_forward_total"),
+			"IPv6 packets forwarded", nil, nil),
+		ipv6DeliveredTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "ip6_delivered_total"),
+			"IPv6 packets delivered to the upper layer (packets for this host)", nil, nil),
 	}
 )
 
@@ -140,6 +167,33 @@ func (netstatMetric *NetstatIPv4Data) GetData() (NetstatMetrics, error) {
 	}, nil
 }
 
+type NetstatIPv6Data NetstatData
+
+func NewIPv6Stat() *NetstatIPv6Data {
+	return &NetstatIPv6Data{
+		structSize: int(unsafe.Sizeof(C.struct_ipstat{})),
+		sysctl:     "net.inet6.ip6.stats",
+	}
+}
+
+func (netstatMetric *NetstatIPv6Data) GetData() (NetstatMetrics, error) {
+	data, err := getData(netstatMetric.sysctl, netstatMetric.structSize)
+	if err != nil {
+		return nil, err
+	}
+
+	ipStats := *(*C.struct_ip6stat)(unsafe.Pointer(&data[0]))
+
+	return NetstatMetrics{
+		ipv6SendTotal:          float64(ipStats.ip6s_localout),
+		ipv6RawSendTotal:       float64(ipStats.ip6s_rawout),
+		ipv6RecvTotal:          float64(ipStats.ip6s_total),
+		ipv6RecvFragmentsTotal: float64(ipStats.ip6s_fragments),
+		ipv6ForwardTotal:       float64(ipStats.ip6s_forward),
+		ipv6DeliveredTotal:     float64(ipStats.ip6s_delivered),
+	}, nil
+}
+
 func getData(queryString string, expectedSize int) ([]byte, error) {
 	data, err := sysctlRaw(queryString)
 	if err != nil {
@@ -184,6 +238,11 @@ func (c *netStatCollector) Update(ch chan<- prometheus.Metric) error {
 		return err
 	}
 
+	ipv6Stats, err := NewIPv6Stat().GetData()
+	if err != nil {
+		return err
+	}
+
 	allStats := make(map[string]float64)
 
 	for k, v := range tcpStats {
@@ -191,6 +250,10 @@ func (c *netStatCollector) Update(ch chan<- prometheus.Metric) error {
 	}
 
 	for k, v := range ipv4Stats {
+		allStats[k] = v
+	}
+
+	for k, v := range ipv6Stats {
 		allStats[k] = v
 	}
 
@@ -227,6 +290,18 @@ func getFreeBSDDataMock(sysctl string) []byte {
 			ips_delivered:   1240,
 		}
 		size := int(unsafe.Sizeof(C.struct_ipstat{}))
+
+		return unsafe.Slice((*byte)(unsafe.Pointer(&ipStats)), size)
+	} else if sysctl == "net.inet6.ip6.stats" {
+		ipStats := C.struct_ip6stat{
+			ip6s_localout:  1234,
+			ip6s_rawout:    1235,
+			ip6s_total:     1236,
+			ip6s_fragments: 1237,
+			ip6s_forward:   1238,
+			ip6s_delivered: 1240,
+		}
+		size := int(unsafe.Sizeof(C.struct_ip6stat{}))
 
 		return unsafe.Slice((*byte)(unsafe.Pointer(&ipStats)), size)
 	}

--- a/collector/netstat_freebsd.go
+++ b/collector/netstat_freebsd.go
@@ -32,6 +32,7 @@ import (
 #include <netinet/tcp.h>
 #include <netinet/tcp_var.h>
 #include <netinet/udp.h>
+#include <netinet/udp_var.h>
 #include <netinet/ip_var.h>
 #include <netinet6/ip6_var.h>
 */
@@ -41,6 +42,8 @@ var (
 	sysctlRaw              = unix.SysctlRaw
 	tcpSendTotal           = "bsdNetstatTcpSendPacketsTotal"
 	tcpRecvTotal           = "bsdNetstatTcpRecvPacketsTotal"
+	udpSendTotal           = "bsdNetstatUdpSendPacketsTotal"
+	udpRecvTotal           = "bsdNetstatUdpRecvPacketsTotal"
 	ipv4SendTotal          = "bsdNetstatIPv4SendPacketsTotal"
 	ipv4RawSendTotal       = "bsdNetstatIPv4RawSendPacketsTotal"
 	ipv4RecvTotal          = "bsdNetstatIPv4RecvPacketsTotal"
@@ -63,6 +66,14 @@ var (
 		tcpRecvTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "netstat", "tcp_receive_packets_total"),
 			"TCP packets received", nil, nil),
+
+		// UDP stats
+		udpSendTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "udp_transmit_packets_total"),
+			"UDP packets sent", nil, nil),
+		udpRecvTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "udp_receive_packets_total"),
+			"UDP packets received", nil, nil),
 
 		// IPv4 stats
 		ipv4SendTotal: prometheus.NewDesc(
@@ -136,6 +147,29 @@ func (netstatMetric *NetstatTCPData) GetData() (NetstatMetrics, error) {
 	return NetstatMetrics{
 		tcpSendTotal: float64(tcpStats.tcps_sndtotal),
 		tcpRecvTotal: float64(tcpStats.tcps_rcvtotal),
+	}, nil
+}
+
+type NetstatUDPData NetstatData
+
+func NewUDPStat() *NetstatUDPData {
+	return &NetstatUDPData{
+		structSize: int(unsafe.Sizeof(C.struct_udpstat{})),
+		sysctl:     "net.inet.udp.stats",
+	}
+}
+
+func (netstatMetric *NetstatUDPData) GetData() (NetstatMetrics, error) {
+	data, err := getData(netstatMetric.sysctl, netstatMetric.structSize)
+	if err != nil {
+		return nil, err
+	}
+
+	udpStats := *(*C.struct_udpstat)(unsafe.Pointer(&data[0]))
+
+	return NetstatMetrics{
+		udpSendTotal: float64(udpStats.udps_opackets),
+		udpRecvTotal: float64(udpStats.udps_ipackets),
 	}, nil
 }
 
@@ -233,6 +267,11 @@ func (c *netStatCollector) Update(ch chan<- prometheus.Metric) error {
 		return err
 	}
 
+	udpStats, err := NewUDPStat().GetData()
+	if err != nil {
+		return err
+	}
+
 	ipv4Stats, err := NewIPv4Stat().GetData()
 	if err != nil {
 		return err
@@ -246,6 +285,10 @@ func (c *netStatCollector) Update(ch chan<- prometheus.Metric) error {
 	allStats := make(map[string]float64)
 
 	for k, v := range tcpStats {
+		allStats[k] = v
+	}
+
+	for k, v := range udpStats {
 		allStats[k] = v
 	}
 
@@ -279,6 +322,14 @@ func getFreeBSDDataMock(sysctl string) []byte {
 		size := int(unsafe.Sizeof(C.struct_tcpstat{}))
 
 		return unsafe.Slice((*byte)(unsafe.Pointer(&tcpStats)), size)
+	} else if sysctl == "net.inet.udp.stats" {
+		udpStats := C.struct_udpstat{
+			udps_opackets: 1234,
+			udps_ipackets: 4321,
+		}
+		size := int(unsafe.Sizeof(C.struct_udpstat{}))
+
+		return unsafe.Slice((*byte)(unsafe.Pointer(&udpStats)), size)
 	} else if sysctl == "net.inet.ip.stats" {
 		ipStats := C.struct_ipstat{
 			ips_localout:    1234,

--- a/collector/netstat_freebsd.go
+++ b/collector/netstat_freebsd.go
@@ -36,18 +36,62 @@ import (
 import "C"
 
 var (
-	bsdNetstatTcpSendPacketsTotal = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "netstat", "tcp_transmit_packets_total"),
-		"TCP packets sent",
-		nil, nil,
-	)
+	sysctlRaw    = unix.SysctlRaw
+	tcpSendTotal = "bsdNetstatTcpSendPacketsTotal"
+	tcpRecvTotal = "bsdNetstatTcpRecvPacketsTotal"
 
-	bsdNetstatTcpRecvPacketsTotal = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "netstat", "tcp_receive_packets_total"),
-		"TCP packets received",
-		nil, nil,
-	)
+	counterMetrics = map[string]*prometheus.Desc{
+		tcpSendTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "tcp_transmit_packets_total"),
+			"TCP packets sent", nil, nil),
+		tcpRecvTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "netstat", "tcp_receive_packets_total"),
+			"TCP packets received", nil, nil),
+	}
 )
+
+type NetstatData struct {
+	structSize int
+	sysctl     string
+}
+
+type NetstatMetrics map[string]float64
+
+type NetstatTCPData NetstatData
+
+func NewTCPStat() *NetstatTCPData {
+	return &NetstatTCPData{
+		structSize: int(unsafe.Sizeof(C.struct_tcpstat{})),
+		sysctl:     "net.inet.tcp.stats",
+	}
+}
+
+func (netstatMetric *NetstatTCPData) GetData() (NetstatMetrics, error) {
+	data, err := getData(netstatMetric.sysctl, netstatMetric.structSize)
+	if err != nil {
+		return nil, err
+	}
+
+	tcpStats := *(*C.struct_tcpstat)(unsafe.Pointer(&data[0]))
+
+	return NetstatMetrics{
+		tcpSendTotal: float64(tcpStats.tcps_sndtotal),
+		tcpRecvTotal: float64(tcpStats.tcps_rcvtotal),
+	}, nil
+}
+
+func getData(queryString string, expectedSize int) ([]byte, error) {
+	data, err := sysctlRaw(queryString)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return nil, err
+	}
+
+	if len(data) < expectedSize {
+		return nil, errors.New("Data Size mismatch")
+	}
+	return data, nil
+}
 
 type netStatCollector struct {
 	netStatMetric *prometheus.Desc
@@ -69,39 +113,41 @@ func (c *netStatCollector) Collect(ch chan<- prometheus.Metric) {
 	_ = c.Update(ch)
 }
 
-func getData(queryString string) ([]byte, error) {
-	data, err := unix.SysctlRaw(queryString)
-	if err != nil {
-		fmt.Println("Error:", err)
-		return nil, err
-	}
-
-	if len(data) < int(unsafe.Sizeof(C.struct_tcpstat{})) {
-		return nil, errors.New("Data Size mismatch")
-	}
-	return data, nil
-}
-
 func (c *netStatCollector) Update(ch chan<- prometheus.Metric) error {
-
-	tcpData, err := getData("net.inet.tcp.stats")
+	tcpStats, err := NewTCPStat().GetData()
 	if err != nil {
 		return err
 	}
 
-	tcpStats := *(*C.struct_tcpstat)(unsafe.Pointer(&tcpData[0]))
+	allStats := make(map[string]float64)
 
-	ch <- prometheus.MustNewConstMetric(
-		bsdNetstatTcpSendPacketsTotal,
-		prometheus.CounterValue,
-		float64(tcpStats.tcps_sndtotal),
-	)
+	for k, v := range tcpStats {
+		allStats[k] = v
+	}
 
-	ch <- prometheus.MustNewConstMetric(
-		bsdNetstatTcpRecvPacketsTotal,
-		prometheus.CounterValue,
-		float64(tcpStats.tcps_rcvtotal),
-	)
+	for metricKey, metricData := range counterMetrics {
+		ch <- prometheus.MustNewConstMetric(
+			metricData,
+			prometheus.CounterValue,
+			allStats[metricKey],
+		)
+	}
 
 	return nil
+}
+
+// Used by tests to mock unix.SysctlRaw
+func getFreeBSDDataMock(sysctl string) []byte {
+
+	if sysctl == "net.inet.tcp.stats" {
+		tcpStats := C.struct_tcpstat{
+			tcps_sndtotal: 1234,
+			tcps_rcvtotal: 4321,
+		}
+		size := int(unsafe.Sizeof(C.struct_tcpstat{}))
+
+		return unsafe.Slice((*byte)(unsafe.Pointer(&tcpStats)), size)
+	}
+
+	return make([]byte, 0, 0)
 }

--- a/collector/netstat_freebsd.go
+++ b/collector/netstat_freebsd.go
@@ -16,6 +16,7 @@
 package collector
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -57,6 +58,16 @@ var (
 	ipv6RecvFragmentsTotal = "bsdNetstatIPv6RecvFragmentsTotal"
 	ipv6ForwardTotal       = "bsdNetstatIPv6ForwardTotal"
 	ipv6DeliveredTotal     = "bsdNetstatIPv6DeliveredTotal"
+
+	tcpStates = []string{
+		"CLOSED", "LISTEN", "SYN_SENT", "SYN_RCVD",
+		"ESTABLISHED", "CLOSE_WAIT", "FIN_WAIT_1", "CLOSING",
+		"LAST_ACK", "FIN_WAIT_2", "TIME_WAIT",
+	}
+
+	tcpStatesMetric = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "netstat", "tcp_connections"),
+		"Number of TCP connections per state", []string{"state"}, nil)
 
 	counterMetrics = map[string]*prometheus.Desc{
 		// TCP stats
@@ -241,6 +252,30 @@ func getData(queryString string, expectedSize int) ([]byte, error) {
 	return data, nil
 }
 
+func getTCPStates() ([]uint64, error) {
+
+	// This sysctl returns an array of uint64
+	data, err := sysctlRaw("net.inet.tcp.states")
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(data)/8 != len(tcpStates) {
+		return nil, fmt.Errorf("invalid TCP states data: expected %d entries, found %d", len(tcpStates), len(data)/8)
+	}
+
+	states := make([]uint64, 0)
+
+	offset := 0
+	for range len(tcpStates) {
+		s := data[offset : offset+8]
+		offset += 8
+		states = append(states, binary.NativeEndian.Uint64(s))
+	}
+	return states, nil
+}
+
 type netStatCollector struct {
 	netStatMetric *prometheus.Desc
 }
@@ -308,6 +343,15 @@ func (c *netStatCollector) Update(ch chan<- prometheus.Metric) error {
 		)
 	}
 
+	tcpConnsPerStates, err := getTCPStates()
+
+	if err != nil {
+		return err
+	}
+
+	for i, value := range tcpConnsPerStates {
+		ch <- prometheus.MustNewConstMetric(tcpStatesMetric, prometheus.GaugeValue, float64(value), tcpStates[i])
+	}
 	return nil
 }
 
@@ -322,6 +366,16 @@ func getFreeBSDDataMock(sysctl string) []byte {
 		size := int(unsafe.Sizeof(C.struct_tcpstat{}))
 
 		return unsafe.Slice((*byte)(unsafe.Pointer(&tcpStats)), size)
+	} else if sysctl == "net.inet.tcp.states" {
+		tcpStatesSlice := make([]byte, 0, len(tcpStates)*8)
+		tcpStatesValues := []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+
+		for _, value := range tcpStatesValues {
+			tcpStatesSlice = binary.NativeEndian.AppendUint64(tcpStatesSlice, value)
+		}
+
+		return tcpStatesSlice
+
 	} else if sysctl == "net.inet.udp.stats" {
 		udpStats := C.struct_udpstat{
 			udps_opackets: 1234,

--- a/collector/netstat_freebsd_test.go
+++ b/collector/netstat_freebsd_test.go
@@ -62,6 +62,36 @@ func TestGetTCPMetrics(t *testing.T) {
 	}
 }
 
+func TestGetIPv4Metrics(t *testing.T) {
+	testSetup()
+
+	ipv4Data, err := NewIPv4Stat().GetData()
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	sndTotal := ipv4Data[ipv4SendTotal]
+	rcvTotal := ipv4Data[ipv4RecvTotal]
+	forwardTotal := ipv4Data[ipv4ForwardTotal]
+	deliveredTotal := ipv4Data[ipv4DeliveredTotal]
+
+	if got, want := sndTotal, float64(1234); got != want {
+		t.Errorf("unexpected sndTotal value: want %f, got %f", want, got)
+	}
+
+	if got, want := rcvTotal, float64(1236); got != want {
+		t.Errorf("unexpected rcvTotal value: want %f, got %f", want, got)
+	}
+
+	if got, want := forwardTotal, float64(1238); got != want {
+		t.Errorf("unexpected forwardTotal value: want %f, got %f", want, got)
+	}
+
+	if got, want := deliveredTotal, float64(1240); got != want {
+		t.Errorf("unexpected deliveredTotal value: want %f, got %f", want, got)
+	}
+}
+
 func TestNetStatCollectorUpdate(t *testing.T) {
 	ch := make(chan prometheus.Metric, len(counterMetrics))
 	collector := &netStatCollector{

--- a/collector/netstat_freebsd_test.go
+++ b/collector/netstat_freebsd_test.go
@@ -62,6 +62,26 @@ func TestGetTCPMetrics(t *testing.T) {
 	}
 }
 
+func TestGetUDPMetrics(t *testing.T) {
+	testSetup()
+
+	udpData, err := NewUDPStat().GetData()
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	sndTotal := udpData[udpSendTotal]
+	rcvTotal := udpData[udpRecvTotal]
+
+	if got, want := sndTotal, float64(1234); got != want {
+		t.Errorf("unexpected sndTotal value: want %f, got %f", want, got)
+	}
+
+	if got, want := rcvTotal, float64(4321); got != want {
+		t.Errorf("unexpected rcvTotal value: want %f, got %f", want, got)
+	}
+}
+
 func TestGetIPv4Metrics(t *testing.T) {
 	testSetup()
 

--- a/collector/netstat_freebsd_test.go
+++ b/collector/netstat_freebsd_test.go
@@ -92,6 +92,36 @@ func TestGetIPv4Metrics(t *testing.T) {
 	}
 }
 
+func TestGetIPv6Metrics(t *testing.T) {
+	testSetup()
+
+	ipv6Data, err := NewIPv6Stat().GetData()
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	sndTotal := ipv6Data[ipv6SendTotal]
+	rcvTotal := ipv6Data[ipv6RecvTotal]
+	forwardTotal := ipv6Data[ipv6ForwardTotal]
+	deliveredTotal := ipv6Data[ipv6DeliveredTotal]
+
+	if got, want := sndTotal, float64(1234); got != want {
+		t.Errorf("unexpected sndTotal value: want %f, got %f", want, got)
+	}
+
+	if got, want := rcvTotal, float64(1236); got != want {
+		t.Errorf("unexpected rcvTotal value: want %f, got %f", want, got)
+	}
+
+	if got, want := forwardTotal, float64(1238); got != want {
+		t.Errorf("unexpected forwardTotal value: want %f, got %f", want, got)
+	}
+
+	if got, want := deliveredTotal, float64(1240); got != want {
+		t.Errorf("unexpected deliveredTotal value: want %f, got %f", want, got)
+	}
+}
+
 func TestNetStatCollectorUpdate(t *testing.T) {
 	ch := make(chan prometheus.Metric, len(counterMetrics))
 	collector := &netStatCollector{

--- a/collector/netstat_freebsd_test.go
+++ b/collector/netstat_freebsd_test.go
@@ -17,11 +17,16 @@ package collector
 
 import (
 	"testing"
-	"unsafe"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/sys/unix"
 )
+
+func testSetup() {
+	sysctlRaw = func(name string, _ ...int) ([]byte, error) {
+		mockData := getFreeBSDDataMock(name)
+		return mockData, nil
+	}
+}
 
 func TestNetStatCollectorDescribe(t *testing.T) {
 	ch := make(chan *prometheus.Desc, 1)
@@ -31,24 +36,34 @@ func TestNetStatCollectorDescribe(t *testing.T) {
 	collector.Describe(ch)
 	desc := <-ch
 
-	if want, got := "dummy_metric", desc.String(); want != got {
+	expected := "Desc{fqName: \"dummy_metric\", help: \"dummy\", constLabels: {}, variableLabels: {}}"
+	if want, got := expected, desc.String(); want != got {
 		t.Errorf("want %s, got %s", want, got)
 	}
 }
 
-func TestGetData(t *testing.T) {
-	data, err := getData("net.inet.tcp.stats")
+func TestGetTCPMetrics(t *testing.T) {
+	testSetup()
+
+	tcpData, err := NewTCPStat().GetData()
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
-	if got, want := len(data), int(unsafe.Sizeof(unix.TCPStats{})); got < want {
-		t.Errorf("data length too small: want >= %d, got %d", want, got)
+	sndTotal := tcpData[tcpSendTotal]
+	rcvTotal := tcpData[tcpRecvTotal]
+
+	if got, want := sndTotal, float64(1234); got != want {
+		t.Errorf("unexpected sndTotal value: want %f, got %f", want, got)
+	}
+
+	if got, want := rcvTotal, float64(4321); got != want {
+		t.Errorf("unexpected rcvTotal value: want %f, got %f", want, got)
 	}
 }
 
 func TestNetStatCollectorUpdate(t *testing.T) {
-	ch := make(chan prometheus.Metric, len(metrics))
+	ch := make(chan prometheus.Metric, len(counterMetrics))
 	collector := &netStatCollector{
 		netStatMetric: prometheus.NewDesc("netstat_metric", "NetStat Metric", nil, nil),
 	}
@@ -57,11 +72,11 @@ func TestNetStatCollectorUpdate(t *testing.T) {
 		t.Fatal("unexpected error:", err)
 	}
 
-	if got, want := len(ch), len(metrics); got != want {
+	if got, want := len(ch), len(counterMetrics); got != want {
 		t.Errorf("metric count mismatch: want %d, got %d", want, got)
 	}
 
-	for range metrics {
+	for range len(counterMetrics) {
 		<-ch
 	}
 }

--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -369,6 +369,24 @@ non_deterministic_metrics=$(cat << METRICS
   node_memory_wired_bytes
   node_netstat_tcp_receive_packets_total
   node_netstat_tcp_transmit_packets_total
+  node_netstat_ip4_delivered_total
+  node_netstat_ip4_fast_forward_total
+  node_netstat_ip4_forward_total
+  node_netstat_ip4_receive_fragments_total
+  node_netstat_ip4_receive_packets_total
+  node_netstat_ip4_transmit_packets_total
+  node_netstat_ip4_transmit_raw_packets_total
+  node_netstat_ip6_delivered_total
+  node_netstat_ip6_forward_total
+  node_netstat_ip6_receive_fragments_total
+  node_netstat_ip6_receive_packets_total
+  node_netstat_ip6_transmit_packets_total
+  node_netstat_ip6_transmit_raw_packets_total
+  node_netstat_tcp_connections
+  node_netstat_tcp_receive_packets_total
+  node_netstat_tcp_transmit_packets_total
+  node_netstat_udp_receive_packets_total
+  node_netstat_udp_transmit_packets_total
   node_network_receive_bytes_total
   node_network_receive_multicast_total
   node_network_transmit_multicast_total


### PR DESCRIPTION
This PR adds a number of new metrics to the `netstat_freebsd` module.

The first commit is a refactoring to make it easier to add new metrics. It also fixes the netstat_freebsd tests, which were completely broken. I added a function to return fake raw data so the code can be tested without calling the low level functions.

The new metrics are:

IPv4
```
ip4_transmit_packets_total
ip4_transmit_raw_packets_total
ip4_receive_packets_total
ip4_receive_fragments_total
ip4_forward_total
ip4_fast_forward_total
ip4_delivered_total
```

IPv6
```
ip6_transmit_packets_total
ip6_transmit_raw_packets_total
ip6_receive_packets_total
ip6_receive_fragments_total
ip6_forward_total
ip6_delivered_total
```

UDP
```
udp_transmit_packets_total
udp_receive_packets_total
```

TCP states
```
node_netstat_tcp_connections{state="CLOSED"}
node_netstat_tcp_connections{state="CLOSE_WAIT"}
node_netstat_tcp_connections{state="CLOSING"}
node_netstat_tcp_connections{state="ESTABLISHED"}
node_netstat_tcp_connections{state="FIN_WAIT_1"}
node_netstat_tcp_connections{state="FIN_WAIT_2"}
node_netstat_tcp_connections{state="LAST_ACK"}
node_netstat_tcp_connections{state="LISTEN"}
node_netstat_tcp_connections{state="SYN_RCVD"}
node_netstat_tcp_connections{state="SYN_SENT"}
node_netstat_tcp_connections{state="TIME_WAIT"}
```

Each commit has the list of metrics added, but here is the full list (including the ones that already existed):

```
# HELP node_netstat_ip4_delivered_total IPv4 packets delivered to the upper layer (packets for this host)
# TYPE node_netstat_ip4_delivered_total counter
node_netstat_ip4_delivered_total 1.5222157e+07
# HELP node_netstat_ip4_fast_forward_total IPv4 packets fast forwarded
# TYPE node_netstat_ip4_fast_forward_total counter
node_netstat_ip4_fast_forward_total 3.029054e+06
# HELP node_netstat_ip4_forward_total IPv4 packets forwarded
# TYPE node_netstat_ip4_forward_total counter
node_netstat_ip4_forward_total 1.0136014e+07
# HELP node_netstat_ip4_receive_fragments_total IPv4 fragments received
# TYPE node_netstat_ip4_receive_fragments_total counter
node_netstat_ip4_receive_fragments_total 0
# HELP node_netstat_ip4_receive_packets_total IPv4 packets received
# TYPE node_netstat_ip4_receive_packets_total counter
node_netstat_ip4_receive_packets_total 2.9040874e+07
# HELP node_netstat_ip4_transmit_packets_total IPv4 packets sent from this host
# TYPE node_netstat_ip4_transmit_packets_total counter
node_netstat_ip4_transmit_packets_total 1.308442e+07
# HELP node_netstat_ip4_transmit_raw_packets_total IPv4 raw packets generated
# TYPE node_netstat_ip4_transmit_raw_packets_total counter
node_netstat_ip4_transmit_raw_packets_total 262462
# HELP node_netstat_ip6_delivered_total IPv6 packets delivered to the upper layer (packets for this host)
# TYPE node_netstat_ip6_delivered_total counter
node_netstat_ip6_delivered_total 8.272913e+06
# HELP node_netstat_ip6_forward_total IPv6 packets forwarded
# TYPE node_netstat_ip6_forward_total counter
node_netstat_ip6_forward_total 0
# HELP node_netstat_ip6_receive_fragments_total IPv6 fragments received
# TYPE node_netstat_ip6_receive_fragments_total counter
node_netstat_ip6_receive_fragments_total 0
# HELP node_netstat_ip6_receive_packets_total IPv6 packets received
# TYPE node_netstat_ip6_receive_packets_total counter
node_netstat_ip6_receive_packets_total 8.363273e+06
# HELP node_netstat_ip6_transmit_packets_total IPv6 packets sent from this host
# TYPE node_netstat_ip6_transmit_packets_total counter
node_netstat_ip6_transmit_packets_total 5.106645e+06
# HELP node_netstat_ip6_transmit_raw_packets_total IPv6 raw packets generated
# TYPE node_netstat_ip6_transmit_raw_packets_total counter
node_netstat_ip6_transmit_raw_packets_total 0
# HELP node_netstat_tcp_connections Number of TCP connections per state
# TYPE node_netstat_tcp_connections gauge
node_netstat_tcp_connections{state="CLOSED"} 1
node_netstat_tcp_connections{state="CLOSE_WAIT"} 0
node_netstat_tcp_connections{state="CLOSING"} 138
node_netstat_tcp_connections{state="ESTABLISHED"} 39
node_netstat_tcp_connections{state="FIN_WAIT_1"} 0
node_netstat_tcp_connections{state="FIN_WAIT_2"} 0
node_netstat_tcp_connections{state="LAST_ACK"} 2
node_netstat_tcp_connections{state="LISTEN"} 10
node_netstat_tcp_connections{state="SYN_RCVD"} 0
node_netstat_tcp_connections{state="SYN_SENT"} 0
node_netstat_tcp_connections{state="TIME_WAIT"} 0
# HELP node_netstat_tcp_receive_packets_total TCP packets received
# TYPE node_netstat_tcp_receive_packets_total counter
node_netstat_tcp_receive_packets_total 2.1505317e+07
# HELP node_netstat_tcp_transmit_packets_total TCP packets sent
# TYPE node_netstat_tcp_transmit_packets_total counter
node_netstat_tcp_transmit_packets_total 1.6645327e+07
# HELP node_netstat_udp_receive_packets_total UDP packets received
# TYPE node_netstat_udp_receive_packets_total counter
node_netstat_udp_receive_packets_total 1.987699e+06
# HELP node_netstat_udp_transmit_packets_total UDP packets sent
# TYPE node_netstat_udp_transmit_packets_total counter
node_netstat_udp_transmit_packets_total 1.170068e+06
```