### PR TITLE
Update Go to 1.24.4 to resolve CVE scanner false positives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/node_exporter
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION


@SuperQ - 1-line update to go version to address #3359 (tested)

Resolves false positive CVE reports (CVE-2025-4673, CVE-2025-0913) without any functional changes.

- ✅ Build succeeds with Go 1.24.4
- ✅ All tests pass (`make test`)
- ✅ Metrics endpoint serves data correctly

**Risk Assessment:**
• CVE-2025-4673: Not applicable - no HTTP client usage in default configuration 
• CVE-2025-0913: Not applicable - node_exporter performs no file creation operations

Fixes #3359

<details>

<summary> CVE risk assessment details </summary>

Responding to Trivy report from [this comment](https://github.com/prometheus/node_exporter/issues/3359#issuecomment)-3074681010 -- two of the vulnerabilities (CVE-2025-22871 and CVE-2025-22872 have already been resolved due to dependency updates, leaving the other two (discussed below)

**CVE-2025-4673 Analysis (Proxy header leak on redirects):**
```bash
# Searched for HTTP client usage
grep -r "http\.Get\|http\.Post\|http\.Client" . --include="*.go" --exclude="*_test.go"
grep -r "http\.DefaultClient" . --include="*.go" --exclude="*_test.go"
```
**Findings:**
- No HTTP client usage in default configuration
- Only HTTP client usage: supervisord collector (disabled by default)
- Supervisord collector, if enabled, typically connects to localhost only
- **Conclusion:** No HTTP client requests in standard deployment

**CVE-2025-0913 Analysis (File creation through symlinks):**
```bash
# Searched for file creation operations
grep -r "OpenFile\|os\.Create\|CreateTemp\|WriteFile" . --include="*.go" --exclude="*_test.go"
grep -r "O_CREATE\|O_EXCL" . --include="*.go" --exclude="*_test.go"
```
**Findings:**
- Zero file creation operations found
- Node_exporter only reads existing system files (/proc, /sys, etc.)
- No usage of vulnerable os.OpenFile patterns
- **Conclusion:** Vulnerability requires file creation, which node_exporter never performs

**Testing Methodology:**
- Tested both Go 1.24.2 and 1.24.4 builds
- Verified identical functionality
- Confirmed metrics endpoint responds correctly
- All existing tests continue to pass

**Context:** Both CVEs affect specific code patterns (HTTP client redirects, file creation with O_CREATE|O_EXCL) that node_exporter doesn't use. This update resolves scanner false positives while maintaining identical functionality.

</details>

**Changed files:** go.mod: "go 1.24.2" -> "go 1.24.4"