### PR TITLE
Fix mount points being collected multiple times in filesystem_linux

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -128,6 +128,12 @@ func (c *filesystemCollector) processStat(labels filesystemLabels) filesystemSta
 	}
 	stuckMountsMtx.Unlock()
 
+	// Remove options from labels because options will not be used from this point forward
+	// and keeping them can lead to errors when the same device is mounted to the same mountpoint
+	// twice, with different options (metrics would be recorded multiple times).
+	labels.mountOptions = ""
+	labels.superOptions = ""
+
 	if err != nil {
 		labels.deviceError = err.Error()
 		c.logger.Debug("Error on statfs() system call", "rootfs", rootfsFilePath(labels.mountPoint), "err", err)


### PR DESCRIPTION
Hi,

this PR attempts to address https://github.com/prometheus/node_exporter/issues/2805.

The issue we encountered is a case in which a path is bind-mounted to itself, the same issue you can see in [this latest comment](https://github.com/prometheus/node_exporter/issues/2805#issuecomment-2882667578).

NixOS bind-mounts the `/nix/store` path to `/nix/store` to remount the same mount read-only and (nosuid, nodev), as you can see [here](https://github.com/nixos/nixpkgs/blob/master/nixos/modules/system/boot/stage-2-init.sh#L96). If the `/nix/store` path is already a mount from some device, this will lead to metrics being collected twice for the same (mountPoint, device) combination if the mount options differ.

This issue only occurs, when the filesystem options of the two mounts are different. The core issue is, that the existing filter that wants to prevent this issue [here](https://github.com/prometheus/node_exporter/blob/master/collector/filesystem_common.go#L190) takes the entire `labels` struct into account, including mount options.

The mount options themselves are not used or exposed by node_exporter. So this minimal fix only removes the filesystem options after they are used to extract the `ro` gauge. This way, the `seen := map[filesystemLabels]bool{}` filter works correctly (as the options are always `""`).

This has a side-effect: Previously, the `ro` gauge was exported twice in this case, if the two mounts were read only and read-write (once `ro`, once `rw`). Now, the gauge is exported only once and in the example, it would be exported `rw`, even though the mount actually used by the kernel (the upper mount), is `ro`.

Additional options we came up with to fix this:

- Filter this earlier, like the previous commit in this PR tried.
- Remove the `options` from `fileSystemLabels` alltogether (only used in Linux anyway).
- Add more logic to export the "correct" `ro` state.
- Add the `ro` option to gauges as a label.

@discordianfish You were involved in the original issue. What do you think?