### PR TITLE
Add wifi packet received and transmitted metrics

### DIFF
--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -3356,6 +3356,10 @@ node_wifi_station_receive_bits_per_second{device="wlan0",mac_address="aa:bb:cc:d
 # TYPE node_wifi_station_receive_bytes_total counter
 node_wifi_station_receive_bytes_total{device="wlan0",mac_address="01:02:03:04:05:06"} 0
 node_wifi_station_receive_bytes_total{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 0
+# HELP node_wifi_station_received_packets_total The total number of packets received by a station.
+# TYPE node_wifi_station_received_packets_total counter
+node_wifi_station_received_packets_total{device="wlan0",mac_address="01:02:03:04:05:06"} 0
+node_wifi_station_received_packets_total{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 0
 # HELP node_wifi_station_signal_dbm The current WiFi signal strength, in decibel-milliwatts (dBm).
 # TYPE node_wifi_station_signal_dbm gauge
 node_wifi_station_signal_dbm{device="wlan0",mac_address="01:02:03:04:05:06"} -26
@@ -3376,6 +3380,10 @@ node_wifi_station_transmit_failed_total{device="wlan0",mac_address="aa:bb:cc:dd:
 # TYPE node_wifi_station_transmit_retries_total counter
 node_wifi_station_transmit_retries_total{device="wlan0",mac_address="01:02:03:04:05:06"} 20
 node_wifi_station_transmit_retries_total{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 10
+# HELP node_wifi_station_transmitted_packets_total The total number of packets transmitted by a station.
+# TYPE node_wifi_station_transmitted_packets_total counter
+node_wifi_station_transmitted_packets_total{device="wlan0",mac_address="01:02:03:04:05:06"} 0
+node_wifi_station_transmitted_packets_total{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 0
 # HELP node_xfrm_acquire_error_packets_total State hasn’t been fully acquired before use
 # TYPE node_xfrm_acquire_error_packets_total counter
 node_xfrm_acquire_error_packets_total 24532

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -3378,6 +3378,10 @@ node_wifi_station_receive_bits_per_second{device="wlan0",mac_address="aa:bb:cc:d
 # TYPE node_wifi_station_receive_bytes_total counter
 node_wifi_station_receive_bytes_total{device="wlan0",mac_address="01:02:03:04:05:06"} 0
 node_wifi_station_receive_bytes_total{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 0
+# HELP node_wifi_station_received_packets_total The total number of packets received by a station.
+# TYPE node_wifi_station_received_packets_total counter
+node_wifi_station_received_packets_total{device="wlan0",mac_address="01:02:03:04:05:06"} 0
+node_wifi_station_received_packets_total{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 0
 # HELP node_wifi_station_signal_dbm The current WiFi signal strength, in decibel-milliwatts (dBm).
 # TYPE node_wifi_station_signal_dbm gauge
 node_wifi_station_signal_dbm{device="wlan0",mac_address="01:02:03:04:05:06"} -26
@@ -3398,6 +3402,10 @@ node_wifi_station_transmit_failed_total{device="wlan0",mac_address="aa:bb:cc:dd:
 # TYPE node_wifi_station_transmit_retries_total counter
 node_wifi_station_transmit_retries_total{device="wlan0",mac_address="01:02:03:04:05:06"} 20
 node_wifi_station_transmit_retries_total{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 10
+# HELP node_wifi_station_transmitted_packets_total The total number of packets transmitted by a station.
+# TYPE node_wifi_station_transmitted_packets_total counter
+node_wifi_station_transmitted_packets_total{device="wlan0",mac_address="01:02:03:04:05:06"} 0
+node_wifi_station_transmitted_packets_total{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} 0
 # HELP node_xfrm_acquire_error_packets_total State hasn’t been fully acquired before use
 # TYPE node_xfrm_acquire_error_packets_total counter
 node_xfrm_acquire_error_packets_total 24532

--- a/collector/wifi_linux.go
+++ b/collector/wifi_linux.go
@@ -33,16 +33,18 @@ type wifiCollector struct {
 	interfaceFrequencyHertz *prometheus.Desc
 	stationInfo             *prometheus.Desc
 
-	stationConnectedSecondsTotal *prometheus.Desc
-	stationInactiveSeconds       *prometheus.Desc
-	stationReceiveBitsPerSecond  *prometheus.Desc
-	stationTransmitBitsPerSecond *prometheus.Desc
-	stationReceiveBytesTotal     *prometheus.Desc
-	stationTransmitBytesTotal    *prometheus.Desc
-	stationSignalDBM             *prometheus.Desc
-	stationTransmitRetriesTotal  *prometheus.Desc
-	stationTransmitFailedTotal   *prometheus.Desc
-	stationBeaconLossTotal       *prometheus.Desc
+	stationConnectedSecondsTotal   *prometheus.Desc
+	stationInactiveSeconds         *prometheus.Desc
+	stationReceiveBitsPerSecond    *prometheus.Desc
+	stationTransmitBitsPerSecond   *prometheus.Desc
+	stationReceiveBytesTotal       *prometheus.Desc
+	stationTransmitBytesTotal      *prometheus.Desc
+	stationSignalDBM               *prometheus.Desc
+	stationTransmitRetriesTotal    *prometheus.Desc
+	stationTransmitFailedTotal     *prometheus.Desc
+	stationBeaconLossTotal         *prometheus.Desc
+	stationTransmittedPacketsTotal *prometheus.Desc
+	stationReceivedPacketsTotal    *prometheus.Desc
 
 	logger *slog.Logger
 }
@@ -156,6 +158,20 @@ func NewWifiCollector(logger *slog.Logger) (Collector, error) {
 		stationBeaconLossTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, subsystem, "station_beacon_loss_total"),
 			"The total number of times a station has detected a beacon loss.",
+			labels,
+			nil,
+		),
+
+		stationTransmittedPacketsTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "station_transmitted_packets_total"),
+			"The total number of packets transmitted by a station.",
+			labels,
+			nil,
+		),
+
+		stationReceivedPacketsTotal: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "station_received_packets_total"),
+			"The total number of packets received by a station.",
 			labels,
 			nil,
 		),
@@ -322,6 +338,22 @@ func (c *wifiCollector) updateStationStats(ch chan<- prometheus.Metric, device s
 		c.stationBeaconLossTotal,
 		prometheus.CounterValue,
 		float64(info.BeaconLoss),
+		device,
+		info.HardwareAddr.String(),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.stationTransmittedPacketsTotal,
+		prometheus.CounterValue,
+		float64(info.TransmittedPackets),
+		device,
+		info.HardwareAddr.String(),
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.stationReceivedPacketsTotal,
+		prometheus.CounterValue,
+		float64(info.ReceivedPackets),
 		device,
 		info.HardwareAddr.String(),
 	)


### PR DESCRIPTION
These metrics were missing and are needed for calculating the ratio of retries to total packets sent