### PR TITLE
Add filesystem UUID based filter

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -20,8 +20,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -79,6 +81,11 @@ func (c *filesystemCollector) GetStats() ([]filesystemStats, error) {
 			}
 			if c.fsTypeFilter.ignored(labels.fsType) {
 				c.logger.Debug("Ignoring fs type", "type", labels.fsType)
+				continue
+			}
+
+			if c.fsUUIDFilter.ignored(labels.fsUUID) {
+				c.logger.Debug("Ignoring fs UUID", "uuid", labels.fsUUID)
 				continue
 			}
 
@@ -193,11 +200,47 @@ func mountPointDetails(logger *slog.Logger) ([]filesystemLabels, error) {
 	if err != nil {
 		return nil, err
 	}
+	UUIDMap := buildUUIDMap(logger)
 
-	return parseFilesystemLabels(mountInfo)
+	return parseFilesystemLabels(mountInfo, UUIDMap)
 }
 
-func parseFilesystemLabels(mountInfo []*procfs.MountInfo) ([]filesystemLabels, error) {
+// buildUUIDMap builds a map of device major:minor numbers to their filesystem UUIDs.
+func buildUUIDMap(logger *slog.Logger) map[string]string {
+	UUIDMap := map[string]string{}
+	dir := devDiskFilePath("by-uuid")
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			logger.Debug("Skipping non-file entry", "path", path, "err", err)
+			return nil
+		}
+		uuid := d.Name()
+		target, err := os.Readlink(path)
+		if err != nil {
+			if t, err := filepath.EvalSymlinks(path); err == nil {
+				target = t
+			} else {
+				logger.Debug("Failed to read symlink", "path", path, "err", err)
+				return nil
+			}
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(path), target)
+		}
+		var stat unix.Stat_t
+		if err := unix.Stat(target, &stat); err != nil {
+			logger.Debug("Failed to stat device", "path", path, "err", err)
+			return nil
+		}
+		maj := unix.Major(uint64(stat.Rdev))
+		min := unix.Minor(uint64(stat.Rdev))
+		UUIDMap[fmt.Sprintf("%d:%d", maj, min)] = uuid
+		return nil
+	})
+	return UUIDMap
+}
+
+func parseFilesystemLabels(mountInfo []*procfs.MountInfo, UUIDMap map[string]string) ([]filesystemLabels, error) {
 	var filesystems []filesystemLabels
 
 	for _, mount := range mountInfo {
@@ -205,6 +248,11 @@ func parseFilesystemLabels(mountInfo []*procfs.MountInfo) ([]filesystemLabels, e
 		_, err := fmt.Sscanf(mount.MajorMinorVer, "%d:%d", &major, &minor)
 		if err != nil {
 			return nil, fmt.Errorf("malformed mount point MajorMinorVer: %q", mount.MajorMinorVer)
+		}
+
+		fsUUID, ok := UUIDMap[fmt.Sprintf("%d:%d", major, minor)]
+		if !ok {
+			fsUUID = ""
 		}
 
 		// Ensure we handle the translation of \040 and \011
@@ -218,6 +266,7 @@ func parseFilesystemLabels(mountInfo []*procfs.MountInfo) ([]filesystemLabels, e
 			fsType:       mount.FSType,
 			mountOptions: mountOptionsString(mount.Options),
 			superOptions: mountOptionsString(mount.SuperOptions),
+			fsUUID:       fsUUID,
 			major:        strconv.Itoa(major),
 			minor:        strconv.Itoa(minor),
 			deviceError:  "",

--- a/collector/filesystem_linux_test.go
+++ b/collector/filesystem_linux_test.go
@@ -28,8 +28,9 @@ import (
 
 func Test_parseFilesystemLabelsError(t *testing.T) {
 	tests := []struct {
-		name string
-		in   []*procfs.MountInfo
+		name  string
+		in    []*procfs.MountInfo
+		uuids map[string]string
 	}{
 		{
 			name: "malformed Major:Minor",
@@ -38,12 +39,13 @@ func Test_parseFilesystemLabelsError(t *testing.T) {
 					MajorMinorVer: "nope",
 				},
 			},
+			uuids: map[string]string{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := parseFilesystemLabels(tt.in); err == nil {
+			if _, err := parseFilesystemLabels(tt.in, tt.uuids); err == nil {
 				t.Fatal("expected an error, but none occurred")
 			}
 		})

--- a/collector/paths.go
+++ b/collector/paths.go
@@ -27,6 +27,7 @@ var (
 	sysPath      = kingpin.Flag("path.sysfs", "sysfs mountpoint.").Default("/sys").String()
 	rootfsPath   = kingpin.Flag("path.rootfs", "rootfs mountpoint.").Default("/").String()
 	udevDataPath = kingpin.Flag("path.udev.data", "udev data path.").Default("/run/udev/data").String()
+	devDiskPath  = kingpin.Flag("path.dev.disk", "path to /dev/disk").Default("/dev/disk").String()
 )
 
 func procFilePath(name string) string {
@@ -43,6 +44,10 @@ func rootfsFilePath(name string) string {
 
 func udevDataFilePath(name string) string {
 	return filepath.Join(*udevDataPath, name)
+}
+
+func devDiskFilePath(name string) string {
+	return filepath.Join(*devDiskPath, name)
 }
 
 func rootfsStripPrefix(path string) string {


### PR DESCRIPTION
Add filesystem UUID based filter to the `filesystemCollector`

The implementation currently only includes Linux and I would be glad to hear feedback before continuing to implement this for other OS' file system collectors.

I tried to create unit test for the `buildUUIDMap` function but couldn't figure out how could I create device major:minor for the fixture block device nodes that I tried to add. So currently there is no test for this feature. I have tested this locally.

Fixes #3380 