### PR TITLE
tcpstat: use std lib binary.NativeEndian

### DIFF
--- a/collector/tcpstat_linux_test.go
+++ b/collector/tcpstat_linux_test.go
@@ -22,14 +22,13 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/josharian/native"
 	"github.com/mdlayher/netlink"
 )
 
 func Test_parseTCPStats(t *testing.T) {
 	encode := func(m InetDiagMsg) []byte {
 		var buf bytes.Buffer
-		err := binary.Write(&buf, native.Endian, m)
+		err := binary.Write(&buf, binary.NativeEndian, m)
 		if err != nil {
 			panic(err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/hashicorp/go-envparse v0.1.0
 	github.com/hodgesds/perf-utils v0.7.0
 	github.com/illumos/go-kstat v0.0.0-20210513183136-173c9b0a9973
-	github.com/josharian/native v1.1.0
 	github.com/jsimonetti/rtnetlink/v2 v2.0.5
 	github.com/lufia/iostat v1.2.1
 	github.com/mattn/go-xmlrpc v0.0.3
@@ -39,6 +38,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dennwc/ioctl v1.0.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/josharian/native v1.1.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mdlayher/genetlink v1.3.2 // indirect


### PR DESCRIPTION
Use standard lib binary.NativeEndian instead of third-party package. Supported since Go 1.21.