### PR TITLE
fix duplicate `cgo` import in macos filesystem

### DIFF
--- a/collector/filesystem_macos.go
+++ b/collector/filesystem_macos.go
@@ -20,8 +20,13 @@ package collector
 #cgo CFLAGS: -x objective-c
 #cgo LDFLAGS: -framework Foundation
 #import <Foundation/Foundation.h>
-Float64 purgeable(char *path) {
-  Float64 value = -1.0f;
+#include <sys/param.h>
+#include <sys/ucred.h>
+#include <sys/mount.h>
+#include <stdio.h>
+
+double purgeable(char *path) {
+  double value = -1.0f;
 
   @autoreleasepool {
     NSError *error = nil;
@@ -48,14 +53,6 @@ import (
 	"errors"
 	"unsafe"
 )
-
-/*
-#include <sys/param.h>
-#include <sys/ucred.h>
-#include <sys/mount.h>
-#include <stdio.h>
-*/
-import "C"
 
 const (
 	defMountPointsExcluded = "^/(dev)($|/)"

--- a/collector/meminfo_darwin.go
+++ b/collector/meminfo_darwin.go
@@ -52,7 +52,7 @@ func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 		&infoCount,
 	)
 	if ret != C.KERN_SUCCESS {
-		return nil, fmt.Errorf("Couldn't get memory statistics, host_statistics returned %d", ret)
+		return nil, fmt.Errorf("couldn't get memory statistics, host_statistics returned %d", ret)
 	}
 	totalb, err := unix.Sysctl("hw.memsize")
 	if err != nil {


### PR DESCRIPTION
@SuperQ @discordianfish

I noticed duplicate "C" import in a file when I was testing the exporter on my local laptop.