### PR TITLE
[Minor] update go version to 1.23.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/node_exporter
 
-go 1.23.0
+go 1.23.8
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
go 1.23.0 has cve and upgrade it to 1.23.8

https://github.com/prometheus/node_exporter/issues/3379


`(fixed in: 1.23.8, 1.24.2)(CVE-2025-22871 - https://nvd.nist.gov/vuln/detail/CVE-2025-22871)`