### PR TITLE
additional metrics for pcidevice and id to name conversion

### DIFF
--- a/collector/fixtures/pci.ids
+++ b/collector/fixtures/pci.ids
@@ -1,0 +1,26 @@
+# Test PCI IDs file for node_exporter testing
+# This file contains sample entries for testing PCI name resolution
+
+# Classes
+C 06  Bridge device
+	04  PCI bridge
+C 01  Mass storage controller
+	08  Non-Volatile memory controller
+		02  NVM Express
+C 02  Network controller
+	00  Ethernet controller
+
+# Vendors
+1022  Advanced Micro Devices, Inc. [AMD]
+	1634  Renoir/Cezanne PCIe GPP Bridge
+		17aa 5095  T540-5095 Unified Wire Ethernet Controller
+
+c0a9  Micron/Crucial Technology
+	540a  P2 [Nick P2] / P3 / P3 Plus NVMe PCIe SSD (DRAM-less)
+		c0a9 5021  PS5021-E21 PCIe4 NVMe Controller (DRAM-less)
+
+8086  Intel Corporation
+	1521  I350 Gigabit Network Connection
+		8086 00a3  Ethernet Network Adapter I350-T4 for OCP NIC 3.0
+
+17aa  Lenovo

--- a/collector/fixtures/pcidevice-names-output.txt
+++ b/collector/fixtures/pcidevice-names-output.txt
@@ -1,0 +1,73 @@
+# Test output for PCI device collector with name resolution enabled
+# This file demonstrates the --collector.pcidevice.names=true functionality
+
+# HELP node_pcidevice_current_link_transfers_per_second Value of current link's transfers per second (T/s)
+# TYPE node_pcidevice_current_link_transfers_per_second gauge
+node_pcidevice_current_link_transfers_per_second{bus="00",device="02",function="1",segment="0000"} 8e+09
+node_pcidevice_current_link_transfers_per_second{bus="01",device="00",function="0",segment="0000"} 8e+09
+node_pcidevice_current_link_transfers_per_second{bus="45",device="00",function="0",segment="0000"} 5e+09
+
+# HELP node_pcidevice_current_link_width Value of current link's width (number of lanes)
+# TYPE node_pcidevice_current_link_width gauge
+node_pcidevice_current_link_width{bus="00",device="02",function="1",segment="0000"} 4
+node_pcidevice_current_link_width{bus="01",device="00",function="0",segment="0000"} 4
+node_pcidevice_current_link_width{bus="45",device="00",function="0",segment="0000"} 4
+
+# HELP node_pcidevice_d3cold_allowed Whether the PCIe device supports D3cold power state (0/1).
+# TYPE node_pcidevice_d3cold_allowed gauge
+node_pcidevice_d3cold_allowed{bus="00",device="02",function="1",segment="0000"} 1
+node_pcidevice_d3cold_allowed{bus="01",device="00",function="0",segment="0000"} 1
+node_pcidevice_d3cold_allowed{bus="45",device="00",function="0",segment="0000"} 1
+
+# HELP node_pcidevice_info Non-numeric data from /sys/bus/pci/devices/<location>, value is always 1.
+# TYPE node_pcidevice_info gauge
+# Example 1: AMD PCIe Bridge with Lenovo subsystem
+node_pcidevice_info{bus="00",class_id="0x060400",class_name="PCI bridge",device="02",device_id="0x1634",device_name="Renoir/Cezanne PCIe GPP Bridge",function="1",parent_bus="*",parent_device="*",parent_function="*",parent_segment="*",revision="0x00",segment="0000",subsystem_device_id="0x5095",subsystem_device_name="T540-5095 Unified Wire Ethernet Controller",subsystem_vendor_id="0x17aa",subsystem_vendor_name="Lenovo",vendor_id="0x1022",vendor_name="Advanced Micro Devices, Inc. [AMD]"} 1
+
+# Example 2: Micron/Crucial NVMe Controller
+node_pcidevice_info{bus="01",class_id="0x010802",class_name="NVM Express",device="00",device_id="0x540a",device_name="P2 [Nick P2] / P3 / P3 Plus NVMe PCIe SSD (DRAM-less)",function="0",parent_bus="00",parent_device="02",parent_function="1",parent_segment="0000",revision="0x01",segment="0000",subsystem_device_id="0x5021",subsystem_device_name="PS5021-E21 PCIe4 NVMe Controller (DRAM-less)",subsystem_vendor_id="0xc0a9",subsystem_vendor_name="Micron/Crucial Technology",vendor_id="0xc0a9",vendor_name="Micron/Crucial Technology"} 1
+
+# Example 3: Intel Network Controller
+node_pcidevice_info{bus="45",class_id="0x020000",class_name="Ethernet controller",device="00",device_id="0x1521",device_name="I350 Gigabit Network Connection",function="0",parent_bus="40",parent_device="01",parent_function="3",parent_segment="0000",revision="0x01",segment="0000",subsystem_device_id="0x00a3",subsystem_device_name="Ethernet Network Adapter I350-T4 for OCP NIC 3.0",subsystem_vendor_id="0x8086",subsystem_vendor_name="Intel Corporation",vendor_id="0x8086",vendor_name="Intel Corporation"} 1
+
+# HELP node_pcidevice_max_link_transfers_per_second Value of maximum link's transfers per second (T/s)
+# TYPE node_pcidevice_max_link_transfers_per_second gauge
+node_pcidevice_max_link_transfers_per_second{bus="00",device="02",function="1",segment="0000"} 8e+09
+node_pcidevice_max_link_transfers_per_second{bus="01",device="00",function="0",segment="0000"} 1.6e+10
+node_pcidevice_max_link_transfers_per_second{bus="45",device="00",function="0",segment="0000"} 5e+09
+
+# HELP node_pcidevice_max_link_width Value of maximum link's width (number of lanes)
+# TYPE node_pcidevice_max_link_width gauge
+node_pcidevice_max_link_width{bus="00",device="02",function="1",segment="0000"} 8
+node_pcidevice_max_link_width{bus="01",device="00",function="0",segment="0000"} 4
+node_pcidevice_max_link_width{bus="45",device="00",function="0",segment="0000"} 4
+
+# HELP node_pcidevice_power_state PCIe device power state: 0 = D0 (fully powered), 1 = D1, 2 = D2, 3 = D3hot, 4 = D3cold (lowest power), -1 = Unknown, -2 = Error.
+# TYPE node_pcidevice_power_state gauge
+node_pcidevice_power_state{bus="00",device="02",function="1",segment="0000"} 0
+node_pcidevice_power_state{bus="01",device="00",function="0",segment="0000"} 0
+node_pcidevice_power_state{bus="45",device="00",function="0",segment="0000"} 0
+
+# HELP node_pcidevice_sriov_drivers_autoprobe Whether SR-IOV drivers autoprobe is enabled for the device (0/1).
+# TYPE node_pcidevice_sriov_drivers_autoprobe gauge
+node_pcidevice_sriov_drivers_autoprobe{bus="00",device="02",function="1",segment="0000"} 0
+node_pcidevice_sriov_drivers_autoprobe{bus="01",device="00",function="0",segment="0000"} 1
+node_pcidevice_sriov_drivers_autoprobe{bus="45",device="00",function="0",segment="0000"} 1
+
+# HELP node_pcidevice_sriov_numvfs Number of Virtual Functions (VFs) currently enabled for SR-IOV.
+# TYPE node_pcidevice_sriov_numvfs gauge
+node_pcidevice_sriov_numvfs{bus="00",device="02",function="1",segment="0000"} 0
+node_pcidevice_sriov_numvfs{bus="01",device="00",function="0",segment="0000"} 4
+node_pcidevice_sriov_numvfs{bus="45",device="00",function="0",segment="0000"} 0
+
+# HELP node_pcidevice_sriov_totalvfs Total number of Virtual Functions (VFs) supported by the device.
+# TYPE node_pcidevice_sriov_totalvfs gauge
+node_pcidevice_sriov_totalvfs{bus="00",device="02",function="1",segment="0000"} 0
+node_pcidevice_sriov_totalvfs{bus="01",device="00",function="0",segment="0000"} 8
+node_pcidevice_sriov_totalvfs{bus="45",device="00",function="0",segment="0000"} 7
+
+# HELP node_pcidevice_sriov_vf_total_msix Total number of MSI-X vectors for Virtual Functions.
+# TYPE node_pcidevice_sriov_vf_total_msix gauge
+node_pcidevice_sriov_vf_total_msix{bus="00",device="02",function="1",segment="0000"} 0
+node_pcidevice_sriov_vf_total_msix{bus="01",device="00",function="0",segment="0000"} 16
+node_pcidevice_sriov_vf_total_msix{bus="45",device="00",function="0",segment="0000"} 0

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -871,6 +871,9 @@ SymlinkTo: ../../../devices/pci0000:00/0000:00:02.1
 Path: sys/bus/pci/devices/0000:01:00.0
 SymlinkTo: ../../../devices/pci0000:00/0000:00:02.1/0000:01:00.0
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/pci/devices/0000:45:00.0
+SymlinkTo: ../../../devices/pci0000:40/0000:40:01.3/0000:45:00.0
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/class
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -5104,6 +5107,26 @@ Lines: 1
 0x01
 Mode: 444
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:00/0000:00:02.1/0000:01:00.0/sriov_drivers_autoprobe
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:00/0000:00:02.1/0000:01:00.0/sriov_numvfs
+Lines: 1
+4
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:00/0000:00:02.1/0000:01:00.0/sriov_totalvfs
+Lines: 1
+8
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:00/0000:00:02.1/0000:01:00.0/sriov_vf_total_msix
+Lines: 1
+16
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/pci0000:00/0000:00:02.1/0000:01:00.0/subsystem
 SymlinkTo: ../../../../bus/pci
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -5461,6 +5484,26 @@ Path: sys/devices/pci0000:00/0000:00:02.1/secondary_bus_number
 Lines: 1
 1
 Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:00/0000:00:02.1/sriov_drivers_autoprobe
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:00/0000:00:02.1/sriov_numvfs
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:00/0000:00:02.1/sriov_totalvfs
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:00/0000:00:02.1/sriov_vf_total_msix
+Lines: 1
+0
+Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/pci0000:00/0000:00:02.1/subordinate_bus_number
 Lines: 1
@@ -5889,6 +5932,2146 @@ Path: sys/devices/pci0000:00/0000:00:0d.0/ata5/host4/target4:0:0/4:0:0:0/block/s
 Lines: 1
 0
 Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/aer_dev_correctable
+Lines: 9
+RxErr 0
+BadTLP 0
+BadDLLP 0
+Rollover 0
+Timeout 0
+NonFatalErr 0
+CorrIntErr 0
+HeaderOF 0
+TOTAL_ERR_COR 0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/aer_dev_fatal
+Lines: 19
+Undefined 0
+DLP 0
+SDES 0
+TLP 0
+FCP 0
+CmpltTO 0
+CmpltAbrt 0
+UnxCmplt 0
+RxOF 0
+MalfTLP 0
+ECRC 0
+UnsupReq 0
+ACSViol 0
+UncorrIntErr 0
+BlockedTLP 0
+AtomicOpBlocked 0
+TLPBlockedErr 0
+PoisonTLPBlocked 0
+TOTAL_ERR_FATAL 0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/aer_dev_nonfatal
+Lines: 19
+Undefined 0
+DLP 0
+SDES 0
+TLP 0
+FCP 0
+CmpltTO 0
+CmpltAbrt 0
+UnxCmplt 0
+RxOF 0
+MalfTLP 0
+ECRC 0
+UnsupReq 0
+ACSViol 0
+UncorrIntErr 0
+BlockedTLP 0
+AtomicOpBlocked 0
+TLPBlockedErr 0
+PoisonTLPBlocked 0
+TOTAL_ERR_NONFATAL 0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ari_enabled
+Lines: 1
+1
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/broken_parity_status
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/class
+Lines: 1
+0x020000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/consistent_dma_mask_bits
+Lines: 1
+64
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/current_link_speed
+Lines: 1
+5.0 GT/s PCIe
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/current_link_width
+Lines: 1
+4
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/d3cold_allowed
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/device
+Lines: 1
+0x1521
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/dma_mask_bits
+Lines: 1
+64
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/driver
+SymlinkTo: ../../../../bus/pci/drivers/igb
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/driver_override
+Lines: 1
+(null)
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/enable
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/firmware_node
+SymlinkTo: ../../../LNXSYSTM:00/LNXSYBUS:00/PNP0A08:01/device:18/device:19
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/device
+SymlinkTo: ../../../0000:45:00.0
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/name
+Lines: 1
+i350bb
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/power
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/power/async
+Lines: 1
+disabled
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/power/autosuspend_delay_ms
+Lines: 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/power/control
+Lines: 1
+auto
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/power/runtime_active_kids
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/power/runtime_active_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/power/runtime_enabled
+Lines: 1
+disabled
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/power/runtime_status
+Lines: 1
+unsupported
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/power/runtime_suspended_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/power/runtime_usage
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/subsystem
+SymlinkTo: ../../../../../../class/hwmon
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/temp1_crit
+Lines: 1
+110000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/temp1_input
+Lines: 1
+50000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/temp1_label
+Lines: 1
+loc1
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/temp1_max
+Lines: 1
+120000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/hwmon/hwmon0/uevent
+Lines: 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c/modalias
+Lines: 1
+i2c:i350bb
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c/name
+Lines: 1
+i350bb
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c/power
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c/power/async
+Lines: 1
+enabled
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c/power/autosuspend_delay_ms
+Lines: 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c/power/control
+Lines: 1
+auto
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c/power/runtime_active_kids
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c/power/runtime_active_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c/power/runtime_enabled
+Lines: 1
+disabled
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c/power/runtime_status
+Lines: 1
+unsupported
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c/power/runtime_suspended_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c/power/runtime_usage
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c/subsystem
+SymlinkTo: ../../../../../../bus/i2c
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/3-007c/uevent
+Lines: 1
+MODALIAS=i2c:i350bb
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/dev
+Lines: 1
+89:3
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/device
+SymlinkTo: ../../../i2c-3
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/name
+Lines: 1
+igb BB
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/power
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/power/async
+Lines: 1
+disabled
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/power/autosuspend_delay_ms
+Lines: 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/power/control
+Lines: 1
+auto
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/power/runtime_active_kids
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/power/runtime_active_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/power/runtime_enabled
+Lines: 1
+disabled
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/power/runtime_status
+Lines: 1
+unsupported
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/power/runtime_suspended_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/power/runtime_usage
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/subsystem
+SymlinkTo: ../../../../../../../class/i2c-dev
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/i2c-dev/i2c-3/uevent
+Lines: 3
+MAJOR=89
+MINOR=3
+DEVNAME=i2c-3
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/name
+Lines: 1
+igb BB
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/power
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/power/async
+Lines: 1
+enabled
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/power/runtime_active_kids
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/power/runtime_enabled
+Lines: 1
+enabled
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/power/runtime_status
+Lines: 1
+suspended
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/power/runtime_usage
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/subsystem
+SymlinkTo: ../../../../../bus/i2c
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/i2c-3/uevent
+Lines: 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/iommu
+SymlinkTo: ../../0000:40:00.2/iommu/ivhd1
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/iommu_group
+SymlinkTo: ../../../../kernel/iommu_groups/25
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/irq
+Lines: 1
+58
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/link
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/local_cpulist
+Lines: 1
+0-63,128-191
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/local_cpus
+Lines: 1
+00000000,00000000,ffffffff,ffffffff,00000000,00000000,ffffffff,ffffffff
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/max_link_speed
+Lines: 1
+5.0 GT/s PCIe
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/max_link_width
+Lines: 1
+4
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/modalias
+Lines: 1
+pci:v00008086d00001521sv00008086sd000000A3bc02sc00i00
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/msi_bus
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/msi_irqs
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/msi_irqs/147
+Lines: 1
+msix
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/msi_irqs/148
+Lines: 1
+msix
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/msi_irqs/149
+Lines: 1
+msix
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/msi_irqs/150
+Lines: 1
+msix
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/msi_irqs/151
+Lines: 1
+msix
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/msi_irqs/152
+Lines: 1
+msix
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/msi_irqs/153
+Lines: 1
+msix
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/msi_irqs/154
+Lines: 1
+msix
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/msi_irqs/155
+Lines: 1
+msix
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/addr_assign_type
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/addr_len
+Lines: 1
+6
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/address
+Lines: 1
+68:05:ca:f0:cb:12
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/broadcast
+Lines: 1
+ff:ff:ff:ff:ff:ff
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/backup_port
+Lines: 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/bpdu_guard
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/bridge
+SymlinkTo: ../../../../../../virtual/net/vmbr0
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/broadcast_flood
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/change_ack
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/config_pending
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/designated_bridge
+Lines: 1
+8000.6805caf0cb12
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/designated_cost
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/designated_port
+Lines: 1
+32769
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/designated_root
+Lines: 1
+8000.6805caf0cb12
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/forward_delay_timer
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/group_fwd_mask
+Lines: 1
+0x0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/hairpin_mode
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/hold_timer
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/isolated
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/learning
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/message_age_timer
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/multicast_fast_leave
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/multicast_flood
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/multicast_router
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/multicast_to_unicast
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/neigh_suppress
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/path_cost
+Lines: 1
+5
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/port_id
+Lines: 1
+0x8001
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/port_no
+Lines: 1
+0x1
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/priority
+Lines: 1
+32
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/proxyarp
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/proxyarp_wifi
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/root_block
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/state
+Lines: 1
+3
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/brport/unicast_flood
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/carrier
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/carrier_changes
+Lines: 1
+2
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/carrier_down_count
+Lines: 1
+1
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/carrier_up_count
+Lines: 1
+1
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/dev_id
+Lines: 1
+0x0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/dev_port
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/device
+SymlinkTo: ../../../0000:45:00.0
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/dormant
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/duplex
+Lines: 1
+full
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/flags
+Lines: 1
+0x1303
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/gro_flush_timeout
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/ifalias
+Lines: 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/ifindex
+Lines: 1
+2
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/iflink
+Lines: 1
+2
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/link_mode
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/master
+SymlinkTo: ../../../../../virtual/net/vmbr0
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/mtu
+Lines: 1
+1500
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/name_assign_type
+Lines: 1
+4
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/napi_defer_hard_irqs
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/netdev_group
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/operstate
+Lines: 1
+up
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/phys_port_id
+Lines: 0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/phys_port_name
+Lines: 0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/phys_switch_id
+Lines: 0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/power
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/power/async
+Lines: 1
+disabled
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/power/autosuspend_delay_ms
+Lines: 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/power/control
+Lines: 1
+auto
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/power/runtime_active_kids
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/power/runtime_active_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/power/runtime_enabled
+Lines: 1
+disabled
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/power/runtime_status
+Lines: 1
+unsupported
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/power/runtime_suspended_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/power/runtime_usage
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/proto_down
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-0/rps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-0/rps_flow_cnt
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-1/rps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-1/rps_flow_cnt
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-2
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-2/rps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-2/rps_flow_cnt
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-3
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-3/rps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-3/rps_flow_cnt
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-4
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-4/rps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-4/rps_flow_cnt
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-5
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-5/rps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-5/rps_flow_cnt
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-6
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-6/rps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-6/rps_flow_cnt
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-7
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-7/rps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/rx-7/rps_flow_cnt
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0/byte_queue_limits
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0/byte_queue_limits/hold_time
+Lines: 1
+1000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0/byte_queue_limits/inflight
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0/byte_queue_limits/limit
+Lines: 1
+67893
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0/byte_queue_limits/limit_max
+Lines: 1
+1879048192
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0/byte_queue_limits/limit_min
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0/byte_queue_limits/stall_cnt
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0/byte_queue_limits/stall_max
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0/byte_queue_limits/stall_thrs
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0/traffic_class
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0/tx_maxrate
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0/tx_timeout
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0/xps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-0/xps_rxqs
+Lines: 1
+00
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1/byte_queue_limits
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1/byte_queue_limits/hold_time
+Lines: 1
+1000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1/byte_queue_limits/inflight
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1/byte_queue_limits/limit
+Lines: 1
+137370
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1/byte_queue_limits/limit_max
+Lines: 1
+1879048192
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1/byte_queue_limits/limit_min
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1/byte_queue_limits/stall_cnt
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1/byte_queue_limits/stall_max
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1/byte_queue_limits/stall_thrs
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1/traffic_class
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1/tx_maxrate
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1/tx_timeout
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1/xps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-1/xps_rxqs
+Lines: 1
+00
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2/byte_queue_limits
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2/byte_queue_limits/hold_time
+Lines: 1
+1000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2/byte_queue_limits/inflight
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2/byte_queue_limits/limit
+Lines: 1
+137370
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2/byte_queue_limits/limit_max
+Lines: 1
+1879048192
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2/byte_queue_limits/limit_min
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2/byte_queue_limits/stall_cnt
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2/byte_queue_limits/stall_max
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2/byte_queue_limits/stall_thrs
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2/traffic_class
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2/tx_maxrate
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2/tx_timeout
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2/xps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-2/xps_rxqs
+Lines: 1
+00
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3/byte_queue_limits
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3/byte_queue_limits/hold_time
+Lines: 1
+1000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3/byte_queue_limits/inflight
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3/byte_queue_limits/limit
+Lines: 1
+137370
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3/byte_queue_limits/limit_max
+Lines: 1
+1879048192
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3/byte_queue_limits/limit_min
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3/byte_queue_limits/stall_cnt
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3/byte_queue_limits/stall_max
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3/byte_queue_limits/stall_thrs
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3/traffic_class
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3/tx_maxrate
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3/tx_timeout
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3/xps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-3/xps_rxqs
+Lines: 1
+00
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4/byte_queue_limits
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4/byte_queue_limits/hold_time
+Lines: 1
+1000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4/byte_queue_limits/inflight
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4/byte_queue_limits/limit
+Lines: 1
+68879
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4/byte_queue_limits/limit_max
+Lines: 1
+1879048192
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4/byte_queue_limits/limit_min
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4/byte_queue_limits/stall_cnt
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4/byte_queue_limits/stall_max
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4/byte_queue_limits/stall_thrs
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4/traffic_class
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4/tx_maxrate
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4/tx_timeout
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4/xps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-4/xps_rxqs
+Lines: 1
+00
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5/byte_queue_limits
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5/byte_queue_limits/hold_time
+Lines: 1
+1000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5/byte_queue_limits/inflight
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5/byte_queue_limits/limit
+Lines: 1
+137370
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5/byte_queue_limits/limit_max
+Lines: 1
+1879048192
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5/byte_queue_limits/limit_min
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5/byte_queue_limits/stall_cnt
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5/byte_queue_limits/stall_max
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5/byte_queue_limits/stall_thrs
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5/traffic_class
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5/tx_maxrate
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5/tx_timeout
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5/xps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-5/xps_rxqs
+Lines: 1
+00
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6/byte_queue_limits
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6/byte_queue_limits/hold_time
+Lines: 1
+1000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6/byte_queue_limits/inflight
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6/byte_queue_limits/limit
+Lines: 1
+54464
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6/byte_queue_limits/limit_max
+Lines: 1
+1879048192
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6/byte_queue_limits/limit_min
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6/byte_queue_limits/stall_cnt
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6/byte_queue_limits/stall_max
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6/byte_queue_limits/stall_thrs
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6/traffic_class
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6/tx_maxrate
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6/tx_timeout
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6/xps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-6/xps_rxqs
+Lines: 1
+00
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7/byte_queue_limits
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7/byte_queue_limits/hold_time
+Lines: 1
+1000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7/byte_queue_limits/inflight
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7/byte_queue_limits/limit
+Lines: 1
+71700
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7/byte_queue_limits/limit_max
+Lines: 1
+1879048192
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7/byte_queue_limits/limit_min
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7/byte_queue_limits/stall_cnt
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7/byte_queue_limits/stall_max
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7/byte_queue_limits/stall_thrs
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7/traffic_class
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7/tx_maxrate
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7/tx_timeout
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7/xps_cpus
+Lines: 1
+00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/queues/tx-7/xps_rxqs
+Lines: 1
+00
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/speed
+Lines: 1
+1000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/collisions
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/multicast
+Lines: 1
+656633
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/rx_bytes
+Lines: 1
+10013625365
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/rx_compressed
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/rx_crc_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/rx_dropped
+Lines: 1
+29220
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/rx_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/rx_fifo_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/rx_frame_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/rx_length_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/rx_missed_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/rx_nohandler
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/rx_over_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/rx_packets
+Lines: 1
+46422718
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/tx_aborted_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/tx_bytes
+Lines: 1
+10275718925
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/tx_carrier_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/tx_compressed
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/tx_dropped
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/tx_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/tx_fifo_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/tx_heartbeat_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/tx_packets
+Lines: 1
+47308115
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/statistics/tx_window_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/subsystem
+SymlinkTo: ../../../../../../class/net
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/testing
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/threaded
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/tx_queue_len
+Lines: 1
+1000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/type
+Lines: 1
+1
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/uevent
+Lines: 2
+INTERFACE=ens10f0
+IFINDEX=2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/net/ens10f0/upper_vmbr0
+SymlinkTo: ../../../../../virtual/net/vmbr0
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/numa_node
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/async
+Lines: 1
+enabled
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/autosuspend_delay_ms
+Lines: 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/control
+Lines: 1
+on
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/runtime_active_kids
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/runtime_active_time
+Lines: 1
+862796974
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/runtime_enabled
+Lines: 1
+forbidden
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/runtime_status
+Lines: 1
+active
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/runtime_suspended_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/runtime_usage
+Lines: 1
+1
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/wakeup
+Lines: 1
+enabled
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/wakeup_abort_count
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/wakeup_active
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/wakeup_active_count
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/wakeup_count
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/wakeup_expire_count
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/wakeup_last_time_ms
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/wakeup_max_time_ms
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power/wakeup_total_time_ms
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/power_state
+Lines: 1
+D0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/clock_name
+Lines: 1
+6805caf0cb12
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/dev
+Lines: 1
+246:0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/device
+SymlinkTo: ../../../0000:45:00.0
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/fifo
+Lines: 1
+NULLBYTEEOF
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/max_adjustment
+Lines: 1
+62499999
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/max_vclocks
+Lines: 1
+20
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/n_alarms
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/n_external_timestamps
+Lines: 1
+2
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/n_periodic_outputs
+Lines: 1
+2
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/n_programmable_pins
+Lines: 1
+4
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/n_vclocks
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/pins
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/pins/SDP0
+Lines: 1
+0 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/pins/SDP1
+Lines: 1
+0 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/pins/SDP2
+Lines: 1
+0 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/pins/SDP3
+Lines: 1
+0 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/power
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/power/async
+Lines: 1
+disabled
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/power/autosuspend_delay_ms
+Lines: 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/power/control
+Lines: 1
+auto
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/power/runtime_active_kids
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/power/runtime_active_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/power/runtime_enabled
+Lines: 1
+disabled
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/power/runtime_status
+Lines: 1
+unsupported
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/power/runtime_suspended_time
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/power/runtime_usage
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/pps_available
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/subsystem
+SymlinkTo: ../../../../../../class/ptp
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/ptp/ptp0/uevent
+Lines: 3
+MAJOR=246
+MINOR=0
+DEVNAME=ptp0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/reset_method
+Lines: 1
+flr bus
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/resource
+Lines: 13
+0x0000000097100000 0x00000000971fffff 0x0000000000040200
+0x0000000000000000 0x0000000000000000 0x0000000000000000
+0x0000000000003060 0x000000000000307f 0x0000000000040101
+0x000000009720c000 0x000000009720ffff 0x0000000000040200
+0x0000000000000000 0x0000000000000000 0x0000000000000000
+0x0000000000000000 0x0000000000000000 0x0000000000000000
+0x0000000097280000 0x00000000972fffff 0x0000000000046200
+0x000000f0a03e0000 0x000000f0a03fffff 0x000000000014220c
+0x0000000000000000 0x0000000000000000 0x0000000000000000
+0x0000000000000000 0x0000000000000000 0x0000000000000000
+0x000000f0a03c0000 0x000000f0a03dffff 0x000000000014220c
+0x0000000000000000 0x0000000000000000 0x0000000000000000
+0x0000000000000000 0x0000000000000000 0x0000000000000000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/resource0
+Lines: 0
+Mode: 600
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/resource2
+Lines: 0
+Mode: 600
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/resource3
+Lines: 0
+Mode: 600
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/revision
+Lines: 1
+0x01
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/rom
+Lines: 0
+Mode: 600
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/sriov_drivers_autoprobe
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/sriov_numvfs
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/sriov_offset
+Lines: 1
+128
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/sriov_stride
+Lines: 1
+4
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/sriov_totalvfs
+Lines: 1
+7
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/sriov_vf_device
+Lines: 1
+1520
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/sriov_vf_total_msix
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/subsystem
+SymlinkTo: ../../../../bus/pci
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/subsystem_device
+Lines: 1
+0x00a3
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/subsystem_vendor
+Lines: 1
+0x8086
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/uevent
+Lines: 6
+DRIVER=igb
+PCI_CLASS=20000
+PCI_ID=8086:1521
+PCI_SUBSYS_ID=8086:00A3
+PCI_SLOT_NAME=0000:45:00.0
+MODALIAS=pci:v00008086d00001521sv00008086sd000000A3bc02sc00i00
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/vendor
+Lines: 1
+0x8086
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/vpd
+Lines: 2
+Ç:NULLBYTEIntel (r) Ethernet Network Adapter I350-T4 for OCP NIC 3.0êdNULLBYTEV1:Intel (r) Ethernet Network Adapter I350-T4 for OCP NIC 3.0PN
+K53978-004SN6805CAF0CB12V24521RVÇxEOF
+Mode: 600
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup/wakeup87
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup/wakeup87/active_count
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup/wakeup87/active_time_ms
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup/wakeup87/device
+SymlinkTo: ../../../0000:45:00.0
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup/wakeup87/event_count
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup/wakeup87/expire_count
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup/wakeup87/last_change_ms
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup/wakeup87/max_time_ms
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup/wakeup87/name
+Lines: 1
+0000:45:00.0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup/wakeup87/prevent_suspend_time_ms
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup/wakeup87/subsystem
+SymlinkTo: ../../../../../../class/wakeup
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup/wakeup87/total_time_ms
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup/wakeup87/uevent
+Lines: 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/0000:45:00.0/wakeup/wakeup87/wakeup_count
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/class
+Lines: 1
+0x060400
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/d3cold_allowed
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/device
+Lines: 1
+0x1483
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/power_state
+Lines: 1
+D0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/revision
+Lines: 1
+0x00
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/subsystem_device
+Lines: 1
+0x1453
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/subsystem_vendor
+Lines: 1
+0x1022
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/pci0000:40/0000:40:01.3/vendor
+Lines: 1
+0x1022
+Mode: 444
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/devices/platform
 Mode: 755

--- a/collector/pcidevice_linux.go
+++ b/collector/pcidevice_linux.go
@@ -17,11 +17,14 @@
 package collector
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs/sysfs"
 )
@@ -31,6 +34,13 @@ const (
 )
 
 var (
+	pciIdsPaths = []string{
+		"/usr/share/misc/pci.ids",
+		"/usr/share/hwdata/pci.ids",
+	}
+	pciIdsFile = kingpin.Flag("collector.pcidevice.idsfile", "Path to pci.ids file to use for PCI device identification.").String()
+	pciNames   = kingpin.Flag("collector.pcidevice.names", "Enable PCI device name resolution (requires pci.ids file).").Default("false").Bool()
+
 	pcideviceLabelNames = []string{"segment", "bus", "device", "function"}
 
 	pcideviceMaxLinkTSDesc = prometheus.NewDesc(
@@ -54,13 +64,56 @@ var (
 		"Value of current link's width (number of lanes)",
 		pcideviceLabelNames, nil,
 	)
+
+	pcidevicePowerStateDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, pcideviceSubsystem, "power_state"),
+		"PCIe device power state: 0 = D0 (fully powered), 1 = D1, 2 = D2, 3 = D3hot, 4 = D3cold (lowest power), -1 = Unknown, -2 = Error.",
+		pcideviceLabelNames, nil,
+	)
+
+	pcideviceD3coldAllowedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, pcideviceSubsystem, "d3cold_allowed"),
+		"Whether the PCIe device supports D3cold power state (0/1).",
+		pcideviceLabelNames, nil,
+	)
+
+	pcideviceSriovDriversAutoprobeDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, pcideviceSubsystem, "sriov_drivers_autoprobe"),
+		"Whether SR-IOV drivers autoprobe is enabled for the device (0/1).",
+		pcideviceLabelNames, nil,
+	)
+
+	pcideviceSriovNumvfsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, pcideviceSubsystem, "sriov_numvfs"),
+		"Number of Virtual Functions (VFs) currently enabled for SR-IOV.",
+		pcideviceLabelNames, nil,
+	)
+
+	pcideviceSriovTotalvfsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, pcideviceSubsystem, "sriov_totalvfs"),
+		"Total number of Virtual Functions (VFs) supported by the device.",
+		pcideviceLabelNames, nil,
+	)
+
+	pcideviceSriovVfTotalMsixDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, pcideviceSubsystem, "sriov_vf_total_msix"),
+		"Total number of MSI-X vectors for Virtual Functions.",
+		pcideviceLabelNames, nil,
+	)
 )
 
 type pcideviceCollector struct {
-	fs       sysfs.FS
-	infoDesc typedDesc
-	descs    []typedFactorDesc
-	logger   *slog.Logger
+	fs            sysfs.FS
+	infoDesc      typedDesc
+	descs         []typedFactorDesc
+	logger        *slog.Logger
+	pciVendors    map[string]string
+	pciDevices    map[string]map[string]string
+	pciSubsystems map[string]map[string]string
+	pciClasses    map[string]string
+	pciSubclasses map[string]string
+	pciProgIfs    map[string]string
+	pciNames      bool
 }
 
 func init() {
@@ -74,29 +127,48 @@ func NewPcideviceCollector(logger *slog.Logger) (Collector, error) {
 		return nil, fmt.Errorf("failed to open sysfs: %w", err)
 	}
 
-	c := pcideviceCollector{
-		fs:     fs,
-		logger: logger,
-		infoDesc: typedDesc{
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, pcideviceSubsystem, "info"),
-				"Non-numeric data from /sys/bus/pci/devices/<location>, value is always 1.",
-				append(pcideviceLabelNames,
-					[]string{"parent_segment", "parent_bus", "parent_device", "parent_function",
-						"class_id", "vendor_id", "subsystem_vendor_id", "subsystem_device_id", "revision"}...),
-				nil,
-			),
-			valueType: prometheus.GaugeValue,
-		},
-		descs: []typedFactorDesc{
-			{desc: pcideviceMaxLinkTSDesc, valueType: prometheus.GaugeValue},
-			{desc: pcideviceMaxLinkWidthDesc, valueType: prometheus.GaugeValue},
-			{desc: pcideviceCurrentLinkTSDesc, valueType: prometheus.GaugeValue},
-			{desc: pcideviceCurrentLinkWidthDesc, valueType: prometheus.GaugeValue},
-		},
+	// Initialize PCI ID maps
+	c := &pcideviceCollector{
+		fs:       fs,
+		logger:   logger,
+		pciNames: *pciNames,
 	}
 
-	return &c, nil
+	// Build label names based on whether name resolution is enabled
+	labelNames := append(pcideviceLabelNames,
+		[]string{"parent_segment", "parent_bus", "parent_device", "parent_function",
+			"class_id", "vendor_id", "device_id", "subsystem_vendor_id", "subsystem_device_id", "revision"}...)
+
+	if c.pciNames {
+		c.loadPCIIds()
+		// Add name labels when name resolution is enabled
+		labelNames = append(labelNames, "vendor_name", "device_name", "subsystem_vendor_name", "subsystem_device_name", "class_name")
+	}
+
+	c.infoDesc = typedDesc{
+		desc: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, pcideviceSubsystem, "info"),
+			"Non-numeric data from /sys/bus/pci/devices/<location>, value is always 1.",
+			labelNames,
+			nil,
+		),
+		valueType: prometheus.GaugeValue,
+	}
+
+	c.descs = []typedFactorDesc{
+		{desc: pcideviceMaxLinkTSDesc, valueType: prometheus.GaugeValue},
+		{desc: pcideviceMaxLinkWidthDesc, valueType: prometheus.GaugeValue},
+		{desc: pcideviceCurrentLinkTSDesc, valueType: prometheus.GaugeValue},
+		{desc: pcideviceCurrentLinkWidthDesc, valueType: prometheus.GaugeValue},
+		{desc: pcidevicePowerStateDesc, valueType: prometheus.GaugeValue},
+		{desc: pcideviceD3coldAllowedDesc, valueType: prometheus.GaugeValue},
+		{desc: pcideviceSriovDriversAutoprobeDesc, valueType: prometheus.GaugeValue},
+		{desc: pcideviceSriovNumvfsDesc, valueType: prometheus.GaugeValue},
+		{desc: pcideviceSriovTotalvfsDesc, valueType: prometheus.GaugeValue},
+		{desc: pcideviceSriovVfTotalMsixDesc, valueType: prometheus.GaugeValue},
+	}
+
+	return c, nil
 }
 
 func (c *pcideviceCollector) Update(ch chan<- prometheus.Metric) error {
@@ -117,27 +189,394 @@ func (c *pcideviceCollector) Update(ch chan<- prometheus.Metric) error {
 		} else {
 			values = append(values, []string{"*", "*", "*", "*"}...)
 		}
-		values = append(values, fmt.Sprintf("0x%06x", device.Class))
-		values = append(values, fmt.Sprintf("0x%04x", device.Device))
-		values = append(values, fmt.Sprintf("0x%04x", device.SubsystemVendor))
-		values = append(values, fmt.Sprintf("0x%04x", device.SubsystemDevice))
-		values = append(values, fmt.Sprintf("0x%02x", device.Revision))
+
+		// Add basic device information
+		classID := fmt.Sprintf("0x%06x", device.Class)
+		vendorID := fmt.Sprintf("0x%04x", device.Vendor)
+		deviceID := fmt.Sprintf("0x%04x", device.Device)
+		subsysVendorID := fmt.Sprintf("0x%04x", device.SubsystemVendor)
+		subsysDeviceID := fmt.Sprintf("0x%04x", device.SubsystemDevice)
+
+		values = append(values, classID, vendorID, deviceID, subsysVendorID, subsysDeviceID, fmt.Sprintf("0x%02x", device.Revision))
+
+		// Add name values if name resolution is enabled
+		if c.pciNames {
+			vendorName := c.getPCIVendorName(vendorID)
+			deviceName := c.getPCIDeviceName(vendorID, deviceID)
+			subsysVendorName := c.getPCIVendorName(subsysVendorID)
+			subsysDeviceName := c.getPCISubsystemName(vendorID, deviceID, subsysVendorID, subsysDeviceID)
+			className := c.getPCIClassName(classID)
+
+			values = append(values, vendorName, deviceName, subsysVendorName, subsysDeviceName, className)
+		}
 
 		ch <- c.infoDesc.mustNewConstMetric(1.0, values...)
 
-		// MaxLinkSpeed and CurrentLinkSpeed are represnted in GT/s
-		maxLinkSpeedTS := float64(int64(*device.MaxLinkSpeed * 1e9))
-		currentLinkSpeedTS := float64(int64(*device.CurrentLinkSpeed * 1e9))
+		// MaxLinkSpeed and CurrentLinkSpeed are represented in GT/s
+		var maxLinkSpeedTS float64
+		if device.MaxLinkSpeed != nil {
+			maxLinkSpeedTS = (*device.MaxLinkSpeed) * 1e9
+		} else {
+			maxLinkSpeedTS = -1
+		}
+
+		var currentLinkSpeedTS float64
+		if device.CurrentLinkSpeed != nil {
+			currentLinkSpeedTS = (*device.CurrentLinkSpeed) * 1e9
+		} else {
+			currentLinkSpeedTS = -1
+		}
+
+		// Get power state information directly from device object
+		var powerState float64
+		if device.PowerState != nil {
+			powerState = parsePowerStateFromEnum(*device.PowerState)
+		}
+
+		var d3coldAllowed float64
+		if device.D3coldAllowed != nil {
+			if *device.D3coldAllowed {
+				d3coldAllowed = 1
+			} else {
+				d3coldAllowed = 0
+			}
+		}
+
+		// Get SR-IOV information directly from device object
+		var sriovDriversAutoprobe float64
+		if device.SriovDriversAutoprobe != nil {
+			if *device.SriovDriversAutoprobe {
+				sriovDriversAutoprobe = 1
+			} else {
+				sriovDriversAutoprobe = 0
+			}
+		}
+
+		var sriovNumvfs float64
+		if device.SriovNumvfs != nil {
+			sriovNumvfs = float64(*device.SriovNumvfs)
+		}
+
+		var sriovTotalvfs float64
+		if device.SriovTotalvfs != nil {
+			sriovTotalvfs = float64(*device.SriovTotalvfs)
+		}
+
+		var sriovVfTotalMsix float64
+		if device.SriovVfTotalMsix != nil {
+			sriovVfTotalMsix = float64(*device.SriovVfTotalMsix)
+		}
+
+		// Handle link width fields with nil safety
+		var maxLinkWidth float64
+		if device.MaxLinkWidth != nil {
+			maxLinkWidth = float64(*device.MaxLinkWidth)
+		} else {
+			maxLinkWidth = -1
+		}
+
+		var currentLinkWidth float64
+		if device.CurrentLinkWidth != nil {
+			currentLinkWidth = float64(*device.CurrentLinkWidth)
+		} else {
+			currentLinkWidth = -1
+		}
 
 		for i, val := range []float64{
 			maxLinkSpeedTS,
-			float64(*device.MaxLinkWidth),
+			maxLinkWidth,
 			currentLinkSpeedTS,
-			float64(*device.CurrentLinkWidth),
+			currentLinkWidth,
+			powerState,
+			d3coldAllowed,
+			sriovDriversAutoprobe,
+			sriovNumvfs,
+			sriovTotalvfs,
+			sriovVfTotalMsix,
 		} {
 			ch <- c.descs[i].mustNewConstMetric(val, device.Location.Strings()...)
 		}
 	}
 
 	return nil
+}
+
+// parsePowerStateFromEnum converts PciPowerState enum to numeric value
+func parsePowerStateFromEnum(powerState sysfs.PciPowerState) float64 {
+	switch powerState {
+	case sysfs.PciPowerStateD0:
+		return 0
+	case sysfs.PciPowerStateD1:
+		return 1
+	case sysfs.PciPowerStateD2:
+		return 2
+	case sysfs.PciPowerStateD3Hot:
+		return 3
+	case sysfs.PciPowerStateD3Cold:
+		return 4
+	case sysfs.PciPowerStateUnknown:
+		return -1
+	case sysfs.PciPowerStateError:
+		return -2
+	default:
+		return -2
+	}
+}
+
+// loadPCIIds loads PCI device information from pci.ids file
+func (c *pcideviceCollector) loadPCIIds() {
+	var file *os.File
+	var err error
+
+	c.pciVendors = make(map[string]string)
+	c.pciDevices = make(map[string]map[string]string)
+	c.pciSubsystems = make(map[string]map[string]string)
+	c.pciClasses = make(map[string]string)
+	c.pciSubclasses = make(map[string]string)
+	c.pciProgIfs = make(map[string]string)
+
+	// Use custom pci.ids file if specified
+	if *pciIdsFile != "" {
+		file, err = os.Open(*pciIdsFile)
+		if err != nil {
+			c.logger.Debug("Failed to open PCI IDs file", "file", *pciIdsFile, "error", err)
+			return
+		}
+		c.logger.Debug("Loading PCI IDs from", "file", *pciIdsFile)
+	} else {
+		// Try each possible default path
+		for _, path := range pciIdsPaths {
+			file, err = os.Open(path)
+			if err == nil {
+				c.logger.Debug("Loading PCI IDs from default path", "path", path)
+				break
+			}
+		}
+		if err != nil {
+			c.logger.Debug("Failed to open any default PCI IDs file", "error", err)
+			return
+		}
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var currentVendor, currentDevice, currentBaseClass, currentSubclass string
+	var inClassContext bool
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Handle class lines (starts with 'C')
+		if strings.HasPrefix(line, "C ") {
+			parts := strings.SplitN(line, "  ", 2)
+			if len(parts) >= 2 {
+				classID := strings.TrimSpace(parts[0][1:]) // Remove 'C' prefix
+				className := strings.TrimSpace(parts[1])
+				c.pciClasses[classID] = className
+				currentBaseClass = classID
+				inClassContext = true
+			}
+			continue
+		}
+
+		// Handle subclass lines (single tab after class)
+		if strings.HasPrefix(line, "\t") && !strings.HasPrefix(line, "\t\t") && inClassContext {
+			line = strings.TrimPrefix(line, "\t")
+			parts := strings.SplitN(line, "  ", 2)
+			if len(parts) >= 2 && currentBaseClass != "" {
+				subclassID := strings.TrimSpace(parts[0])
+				subclassName := strings.TrimSpace(parts[1])
+				// Store as base class + subclass (e.g., "0100" for SCSI storage controller)
+				fullClassID := currentBaseClass + subclassID
+				c.pciSubclasses[fullClassID] = subclassName
+				currentSubclass = fullClassID
+			}
+			continue
+		}
+
+		// Handle programming interface lines (double tab after subclass)
+		if strings.HasPrefix(line, "\t\t") && !strings.HasPrefix(line, "\t\t\t") && inClassContext {
+			line = strings.TrimPrefix(line, "\t\t")
+			parts := strings.SplitN(line, "  ", 2)
+			if len(parts) >= 2 && currentSubclass != "" {
+				progIfID := strings.TrimSpace(parts[0])
+				progIfName := strings.TrimSpace(parts[1])
+				// Store as base class + subclass + programming interface (e.g., "010802" for NVM Express)
+				fullClassID := currentSubclass + progIfID
+				c.pciProgIfs[fullClassID] = progIfName
+			}
+			continue
+		}
+
+		// Handle vendor lines (no leading whitespace, not starting with 'C')
+		if !strings.HasPrefix(line, "\t") && !strings.HasPrefix(line, "C ") {
+			parts := strings.SplitN(line, "  ", 2)
+			if len(parts) >= 2 {
+				currentVendor = strings.TrimSpace(parts[0])
+				c.pciVendors[currentVendor] = strings.TrimSpace(parts[1])
+				currentDevice = ""
+				inClassContext = false
+			}
+			continue
+		}
+
+		// Handle device lines (single tab)
+		if strings.HasPrefix(line, "\t") && !strings.HasPrefix(line, "\t\t") {
+			line = strings.TrimPrefix(line, "\t")
+			parts := strings.SplitN(line, "  ", 2)
+			if len(parts) >= 2 && currentVendor != "" {
+				currentDevice = strings.TrimSpace(parts[0])
+				if c.pciDevices[currentVendor] == nil {
+					c.pciDevices[currentVendor] = make(map[string]string)
+				}
+				c.pciDevices[currentVendor][currentDevice] = strings.TrimSpace(parts[1])
+			}
+			continue
+		}
+
+		// Handle subsystem lines (double tab)
+		if strings.HasPrefix(line, "\t\t") {
+			line = strings.TrimPrefix(line, "\t\t")
+			parts := strings.SplitN(line, "  ", 2)
+			if len(parts) >= 2 && currentVendor != "" && currentDevice != "" {
+				subsysID := strings.TrimSpace(parts[0])
+				subsysName := strings.TrimSpace(parts[1])
+				key := fmt.Sprintf("%s:%s", currentVendor, currentDevice)
+				if c.pciSubsystems[key] == nil {
+					c.pciSubsystems[key] = make(map[string]string)
+				}
+				// Convert subsystem ID from "vendor device" format to "vendor:device" format
+				subsysParts := strings.Fields(subsysID)
+				if len(subsysParts) == 2 {
+					subsysKey := fmt.Sprintf("%s:%s", subsysParts[0], subsysParts[1])
+					c.pciSubsystems[key][subsysKey] = subsysName
+				}
+			}
+		}
+	}
+
+	// Debug summary
+	fmt.Printf("DEBUG: Loaded %d vendors, %d devices, %d subsystems, %d classes, %d subclasses, %d programming interfaces\n",
+		len(c.pciVendors),
+		func() int {
+			total := 0
+			for _, devices := range c.pciDevices {
+				total += len(devices)
+			}
+			return total
+		}(),
+		func() int {
+			total := 0
+			for _, subsystems := range c.pciSubsystems {
+				total += len(subsystems)
+			}
+			return total
+		}(),
+		len(c.pciClasses),
+		len(c.pciSubclasses),
+		len(c.pciProgIfs))
+}
+
+// getPCIVendorName converts PCI vendor ID to human-readable string using pci.ids
+func (c *pcideviceCollector) getPCIVendorName(vendorID string) string {
+	// Return original ID if name resolution is disabled
+	if !c.pciNames {
+		return vendorID
+	}
+
+	// Remove "0x" prefix if present
+	vendorID = strings.TrimPrefix(vendorID, "0x")
+	vendorID = strings.ToLower(vendorID)
+
+	if name, ok := c.pciVendors[vendorID]; ok {
+		return name
+	}
+	return vendorID // Return ID if name not found
+}
+
+// getPCIDeviceName converts PCI device ID to human-readable string using pci.ids
+func (c *pcideviceCollector) getPCIDeviceName(vendorID, deviceID string) string {
+	// Return original ID if name resolution is disabled
+	if !c.pciNames {
+		return deviceID
+	}
+
+	// Remove "0x" prefix if present
+	vendorID = strings.TrimPrefix(vendorID, "0x")
+	deviceID = strings.TrimPrefix(deviceID, "0x")
+	vendorID = strings.ToLower(vendorID)
+	deviceID = strings.ToLower(deviceID)
+
+	if devices, ok := c.pciDevices[vendorID]; ok {
+		if name, ok := devices[deviceID]; ok {
+			return name
+		}
+	}
+	return deviceID // Return ID if name not found
+}
+
+// getPCISubsystemName converts PCI subsystem ID to human-readable string using pci.ids
+func (c *pcideviceCollector) getPCISubsystemName(vendorID, deviceID, subsysVendorID, subsysDeviceID string) string {
+	// Return original ID if name resolution is disabled
+	if !c.pciNames {
+		return subsysDeviceID
+	}
+
+	// Normalize all IDs
+	vendorID = strings.TrimPrefix(vendorID, "0x")
+	deviceID = strings.TrimPrefix(deviceID, "0x")
+	subsysVendorID = strings.TrimPrefix(subsysVendorID, "0x")
+	subsysDeviceID = strings.TrimPrefix(subsysDeviceID, "0x")
+
+	key := fmt.Sprintf("%s:%s", vendorID, deviceID)
+	subsysKey := fmt.Sprintf("%s:%s", subsysVendorID, subsysDeviceID)
+
+	if subsystems, ok := c.pciSubsystems[key]; ok {
+		if name, ok := subsystems[subsysKey]; ok {
+			return name
+		}
+	}
+	return subsysDeviceID
+}
+
+// getPCIClassName converts PCI class ID to human-readable string using pci.ids
+func (c *pcideviceCollector) getPCIClassName(classID string) string {
+	// Return original ID if name resolution is disabled
+	if !c.pciNames {
+		return classID
+	}
+
+	// Remove "0x" prefix if present and normalize
+	classID = strings.TrimPrefix(classID, "0x")
+	classID = strings.ToLower(classID)
+
+	// Try to find the programming interface first (6 digits: base class + subclass + programming interface)
+	if len(classID) >= 6 {
+		progIf := classID[:6]
+		if className, exists := c.pciProgIfs[progIf]; exists {
+			return className
+		}
+	}
+
+	// Try to find the subclass (4 digits: base class + subclass)
+	if len(classID) >= 4 {
+		subclass := classID[:4]
+		if className, exists := c.pciSubclasses[subclass]; exists {
+			return className
+		}
+	}
+
+	// If not found, try with just the base class (first 2 digits)
+	if len(classID) >= 2 {
+		baseClass := classID[:2]
+		if className, exists := c.pciClasses[baseClass]; exists {
+			return className
+		}
+	}
+
+	// Return the original class ID if not found
+	return "Unknown class (" + classID + ")"
 }

--- a/collector/pcidevice_linux_test.go
+++ b/collector/pcidevice_linux_test.go
@@ -1,0 +1,89 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nopcidevice
+// +build !nopcidevice
+
+package collector
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestPCICollectorWithNameResolution(t *testing.T) {
+	// Test the PCI collector with name resolution enabled and compare against expected output
+	if _, err := kingpin.CommandLine.Parse([]string{
+		"--path.sysfs", "fixtures/sys",
+		"--path.procfs", "fixtures/proc",
+		"--path.rootfs", "fixtures",
+		"--collector.pcidevice",
+		"--collector.pcidevice.names",
+		//	"--collector.pcidevice.idsfile", "/usr/share/misc/pci.ids",
+		"--collector.pcidevice.idsfile", "fixtures/pci.ids",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	c, err := NewPcideviceCollector(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(&testPCICollector{pc: c})
+
+	// Read expected output from fixture file
+	expectedOutput, err := os.ReadFile("fixtures/pcidevice-names-output.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = testutil.GatherAndCompare(reg, strings.NewReader(string(expectedOutput)))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// testPCICollector wraps the PCI collector for testing
+type testPCICollector struct {
+	pc Collector
+}
+
+func (tc *testPCICollector) Collect(ch chan<- prometheus.Metric) {
+	sink := make(chan prometheus.Metric)
+	go func() {
+		err := tc.pc.Update(sink)
+		if err != nil {
+			panic(fmt.Errorf("failed to update collector: %s", err))
+		}
+		close(sink)
+	}()
+
+	for m := range sink {
+		ch <- m
+	}
+}
+
+func (tc *testPCICollector) Describe(ch chan<- *prometheus.Desc) {
+	// No-op for testing
+}


### PR DESCRIPTION
There are two changes in this PR.

[1] Enabling additional metrics including SRIOV, power management details and numa node of the pci device. This depends on https://github.com/prometheus/procfs/pull/748
[2] Optional (disabled by default) feature to convert pci vendor/device/class ids to names from the system pci.ids file or a file passed as argument.

I had an internal repo where I had done this earlier. Recently saw [the PR for pcidevice_linux.go](https://github.com/prometheus/node_exporter/pull/3339) and thought it will be a good idea to add my work into the same collector.
I have also added nil pointer checks to all optional fields in sysfs.PciDevice struct.

I understand that some might find [2] unnecessary, but it has been very useful in our use cases (both LLM and human use). Hence I have added it but kept disabled by default. Please let me know your thoughts. @discordianfish 