### PR TITLE
Rollback FreeBSD version

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -30,7 +30,7 @@ jobs:
       - name: test-e2e
         uses: vmactions/freebsd-vm@487ce35b96fae3e60d45b521735f5aa436ecfade  # v1.2.4
         with:
-          release: "15.0"
+          release: "14.3"
           copyback: false
           envs: 'GO_VERSION_FREEBSD GNU_TAR_VERSION'
           usesh: true

--- a/collector/fixtures/e2e-output-freebsd.txt
+++ b/collector/fixtures/e2e-output-freebsd.txt
@@ -261,18 +261,6 @@ node_xfrm_out_state_proto_error_packets_total 4542
 # HELP node_xfrm_out_state_seq_error_packets_total Sequence error i.e. Sequence number overflow
 # TYPE node_xfrm_out_state_seq_error_packets_total counter
 node_xfrm_out_state_seq_error_packets_total 543
-# HELP node_zfs_arcstats_c_min_bytes ZFS ARC minimum size
-# TYPE node_zfs_arcstats_c_min_bytes gauge
-node_zfs_arcstats_c_min_bytes 1.99932544e+08
-# HELP node_zfs_arcstats_mfu_ghost_size ZFS ARC MFU ghost size
-# TYPE node_zfs_arcstats_mfu_ghost_size gauge
-node_zfs_arcstats_mfu_ghost_size 0
-# HELP node_zfs_arcstats_mru_ghost_hits_total ZFS ARC MRU ghost hits
-# TYPE node_zfs_arcstats_mru_ghost_hits_total counter
-node_zfs_arcstats_mru_ghost_hits_total 0
-# HELP node_zfs_arcstats_pm_bytes ZFS ARC meta MRU target frac
-# TYPE node_zfs_arcstats_pm_bytes gauge
-node_zfs_arcstats_pm_bytes 2.147483648e+09
 # HELP promhttp_metric_handler_errors_total Total number of internal errors encountered by the promhttp metric handler.
 # TYPE promhttp_metric_handler_errors_total counter
 promhttp_metric_handler_errors_total{cause="encoding"} 0


### PR DESCRIPTION
Rollback to FreeBSD 14.x to avoid breakage in the 15.x pre-release.