### PR TITLE
meminfo: Add Zswap/Zswapped metrics

### DIFF
--- a/collector/meminfo_linux.go
+++ b/collector/meminfo_linux.go
@@ -184,6 +184,12 @@ func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
 	if meminfo.WritebackTmpBytes != nil {
 		metrics["WritebackTmp_bytes"] = float64(*meminfo.WritebackTmpBytes)
 	}
+	if meminfo.ZswapBytes != nil {
+		metrics["Zswap_ytes"] = float64(*meminfo.ZswapBytes)
+	}
+	if meminfo.ZswappedBytes != nil {
+		metrics["Zswapped_bytes"] = float64(*meminfo.ZswappedBytes)
+	}
 
 	// These fields are always in bytes and do not have `Bytes`
 	// suffixed counterparts in the procfs.Meminfo struct, nor do


### PR DESCRIPTION
Add metrics for Zswap and Zswapped to the meminfo collector.

Fixes: https://github.com/prometheus/node_exporter/issues/3449