### PR TITLE
Fix Darwin/MacOS end-to-end test

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -271,7 +271,7 @@ jobs:
             echo "::endgroup::"
 
   test_macos:
-    name: Run end-to-end tests on macOS
+    name: Run end-to-end tests on Darwin/MacOS
     runs-on: macos-latest
     steps:
       - name: Checkout the repository
@@ -308,5 +308,5 @@ jobs:
 
           echo "::group::Run End-to-End Tests"
           git config --global --add safe.directory $(pwd)
-          make test-e2e
+          make test-e2e E2E_EXTRA_FLAGS='--collector.diskstats.device-include=disk[04]'
           echo "::endgroup::"

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ include Makefile.common
 PROMTOOL_VERSION ?= 2.30.0
 PROMTOOL_URL     ?= https://github.com/prometheus/prometheus/releases/download/v$(PROMTOOL_VERSION)/prometheus-$(PROMTOOL_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 PROMTOOL         ?= $(FIRST_GOPATH)/bin/promtool
+E2E_EXTRA_FLAGS  ?=
 
 DOCKER_IMAGE_NAME       ?= node-exporter
 MACH                    ?= $(shell uname -m)
@@ -121,7 +122,7 @@ tools:
 .PHONY: test-e2e
 test-e2e: build collector/fixtures/sys/.unpacked collector/fixtures/udev/.unpacked tools
 	@echo ">> running end-to-end tests"
-	./end-to-end-test.sh
+	./end-to-end-test.sh -e "$(E2E_EXTRA_FLAGS)"
 
 .PHONY: skip-test-e2e
 skip-test-e2e:

--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -127,10 +127,13 @@ case "${arch}" in
     ;;
 esac
 
-keep=0; update=0; verbose=0
-while getopts 'hkuv' opt
+extra_flags=""; keep=0; update=0; verbose=0
+while getopts 'e:hkuv' opt
 do
   case "$opt" in
+    e)
+      extra_flags="${OPTARG}"
+      ;;
     k)
       keep=1
       ;;
@@ -158,6 +161,7 @@ then
 fi
 
 collector_flags=$(cat << FLAGS
+  ${extra_flags}
   ${cpu_info_collector}
   --collector.arp.device-exclude=nope
   --collector.bcache.priorityStats


### PR DESCRIPTION
Pass a filtered list of disks to test in the MacOS/Darwin end-to-end test to avoid CI runner changes from disturbing the output.