### PR TITLE
Fix kernel_hung metric description

### DIFF
--- a/collector/kernel_hung_linux.go
+++ b/collector/kernel_hung_linux.go
@@ -46,7 +46,7 @@ func NewKernelHungCollector(logger *slog.Logger) (Collector, error) {
 var (
 	taskDetectCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "kernel_hung", "task_detect_count"),
-		"Total number of interrupts serviced.",
+		"Total number of tasks that have been detected as hung since the system booted.",
 		nil, nil,
 	)
 )


### PR DESCRIPTION
Fix the description of the kernel_hung metric to actually describe the number of hung tasks, not the number of interrupts serviced.

cc: @SuperQ @discordianfish 