### PR TITLE
Use dedicated ServeMux and add configurable pprof endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,16 @@ The exporter supports TLS via a new web configuration file.
 
 See the [exporter-toolkit web-configuration](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md) for more details.
 
+## `pprof` profiling endpoint
+
+`node_exporter` exposes Go runtime profiling endpoints at `/debug/pprof/` by default.
+These are useful for debugging performance issues but can reveal sensitive information about the running process.
+
+To disable the profiling endpoints:
+```bash
+./node_exporter --web.enable-pprof=false
+```
+
 [travis]: https://travis-ci.org/prometheus/node_exporter
 [hub]: https://hub.docker.com/r/prom/node-exporter/
 [circleci]: https://circleci.com/gh/prometheus/node_exporter


### PR DESCRIPTION
## Summary

This PR switches from `http.DefaultServeMux` to a dedicated `http.ServeMux` and makes pprof profiling endpoints configurable.

## The issue

By default, `node-exporter` exposes `/debug/pprof/*` routes. These routes are often flagged by security scanners as being a security risk. Even though it's low, and doesn't directly expose sensitive data, we should be able to disable these routes. 

As per this [CNCF-funded, Prometheus-maintainer-requested security audit](https://cure53.de/pentest-report_nodeexporter.pdf), it is recommended that the exposure of these routes be at least configurable :

> **PRM-02-006 Web: Runtime profiling data exposed via pprof** *(Low)*
> 
> It was discovered that the net/http/pprof package is included in the application, which
> gives access to extensive debugging information like traces and memory mappings.
> While this is not a large problem on its own, it could be leveraged favorably in
> combination with other, more severe vulnerabilities.
> 
> Accessing pprof profiler:
> http://localhost:9100/debug/pprof/
> 
> It is recommended to disable the profiler in order to prevent the information leak. If there
> are cases where a process profiler is actually required, it is recommended to give users
> the option to disable the component via the configuration.

Fixes :
- #2397
- #1911
- #2860

Rework of :
- #2859

## Issue

This is caused by the way we import `net/http/pprof` package and use it. We don't declare our own `http.ServeMux`, so packages are free to register things in the `http.DefaultServeMux`. 

Importing `net/http/pprof` like this :

```go
import (
    _ "net/http/pprof"
)
```

Causes the `net/http/pprof` to call it's init function, that registers the routes to the `http.DefaultServeMux`.

Additionally, transitive dependencies (like `golang.org/x/net/trace` via `go-conntrack`) can register unintended handlers on `DefaultServeMux`.

## Changes

- **Dedicated ServeMux**: Replaced `http.DefaultServeMux` with a new `http.ServeMux` instance
- **Explicit pprof registration**: Changed from blank import `_ "net/http/pprof"` to explicit handler registration
- **New flag `--web.enable-pprof`**: Made pprof endpoints disableable (defaults to `true` for backward compatibility)
- **Landing page sync**: The landing page profiling links are now shown only when pprof is enabled, as per [`exporter-toolkit`](https://github.com/prometheus/exporter-toolkit/blob/7f8f4610a9a73abe1c1dba83d7dca0539ef1a00d/web/landing_page.go#L41) code suggests.
- **Pass mux to exporter-toolkit**: Ensure `web.ListenAndServe` uses our mux instead of `DefaultServeMux`

## New Flag

| Flag | Default | Description |
|------|---------|-------------|
| `--web.enable-pprof` | `true` | Enable pprof profiling endpoints under `/debug/pprof/` |

## Backward Compatibility

- pprof endpoints remain enabled by default
- All existing flags and behaviors are preserved
- The `/debug/requests` and `/debug/events` endpoints (from `x/net/trace`) were never intentionally exposed; they were a side-effect of transitive imports and are no longer accessible

## Security Considerations

pprof endpoints can expose sensitive information (heap contents, goroutine stacks, CPU profiles). Operators in security-sensitive environments can now disable them:

```bash
./node_exporter --web.enable-pprof=false
```

## AI notice

Code written by hand, then code-reviewed by humans and Opus 4.5.