### PR TITLE
collector/ethtool: Expose NIC channel configuration

### DIFF
--- a/collector/fixtures/ethtool/eth0/channels
+++ b/collector/fixtures/ethtool/eth0/channels
@@ -1,0 +1,13 @@
+# ethtool --show-channels eth0
+Channel parameters for eth0:
+Pre-set maximums:
+RX:		252
+TX:		252
+Other:		1
+Combined:	252
+Current hardware settings:
+# Testing n/a (which will be translated into 0)
+RX:		n/a
+TX:		0
+Other:		1
+Combined:	128


### PR DESCRIPTION
When running a large fleet of machines running network-heavy loads and with different hardware configurations, it is important to get an overview about their configuration.  Ethtool exporter already exposes a lot of useful info like port configuration, driver, and obviously stats, however did not expose the channel configuration.

This commit adds two new metrics exposing the current and maximum supported channel configuration, with each metric exposing one instance for combined, other, rx, and tx.

I'd consider this a fairly trivial improvement, so directly opening a PR, hope that's OK :grin: 