### PR TITLE
collector/cpu: replace 'wait' with 'intr' for Solaris

### DIFF
--- a/collector/cpu_solaris.go
+++ b/collector/cpu_solaris.go
@@ -60,9 +60,9 @@ func (c *cpuCollector) Update(ch chan<- prometheus.Metric) error {
 
 		for k, v := range map[string]string{
 			"idle":   "cpu_nsec_idle",
+			"intr":   "cpu_nsec_intr",
 			"kernel": "cpu_nsec_kernel",
 			"user":   "cpu_nsec_user",
-			"wait":   "cpu_nsec_wait",
 		} {
 			kstatValue, err := ksCPU.GetNamed(v)
 			if err != nil {


### PR DESCRIPTION
Addresses #3238.
Replace the kernel 'wait' stat with 'intr' which is supported by both Solaris and Illumos kernels.