### PR TITLE
Add HTTP/3 (QUIC) support via --web.enable-http3 flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,8 @@ require (
 	github.com/mdlayher/vsock v1.2.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
+	github.com/quic-go/qpack v0.6.0 // indirect
+	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/siebenmann/go-kstat v0.0.0-20210513183136-173c9b0a9973 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,10 @@ github.com/prometheus/exporter-toolkit v0.15.0 h1:Pcle5sSViwR1x0gdPd0wtYrPQENBie
 github.com/prometheus/exporter-toolkit v0.15.0/go.mod h1:OyRWd2iTo6Xge9Kedvv0IhCrJSBu36JCfJ2yVniRIYk=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
+github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
+github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
+github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
+github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/safchain/ethtool v0.7.0 h1:rlJzfDetsVvT61uz8x1YIcFn12akMfuPulHtZjtb7Is=

--- a/http3.go
+++ b/http3.go
@@ -1,0 +1,273 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/exporter-toolkit/web"
+	"github.com/quic-go/quic-go/http3"
+	"golang.org/x/crypto/bcrypt"
+	"go.yaml.in/yaml/v2"
+)
+
+// webConfig mirrors the exporter-toolkit web.Config struct for YAML parsing.
+// We need our own copy because getConfig() in exporter-toolkit is unexported.
+type webConfig struct {
+	TLSConfig tlsConfig                     `yaml:"tls_server_config"`
+	Users     map[string]config_util.Secret `yaml:"basic_auth_users"`
+}
+
+// tlsConfig mirrors the fields we need from web.TLSConfig.
+type tlsConfig struct {
+	TLSCert    string             `yaml:"cert"`
+	TLSKey     config_util.Secret `yaml:"key"`
+	TLSCertPath string            `yaml:"cert_file"`
+	TLSKeyPath  string            `yaml:"key_file"`
+	ClientCAs   string            `yaml:"client_ca_file"`
+	ClientAuth  string            `yaml:"client_auth_type"`
+	MinVersion  web.TLSVersion    `yaml:"min_version"`
+	MaxVersion  web.TLSVersion    `yaml:"max_version"`
+}
+
+// loadWebConfig reads and parses the web config YAML file, resolving relative
+// cert paths against the config file's directory. This replicates the behavior
+// of the unexported getConfig() in exporter-toolkit.
+func loadWebConfig(configPath string) (*webConfig, error) {
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+	c := &webConfig{
+		TLSConfig: tlsConfig{
+			MinVersion: web.TLSVersion(tls.VersionTLS12),
+			MaxVersion: web.TLSVersion(tls.VersionTLS13),
+		},
+	}
+	if err := yaml.UnmarshalStrict(content, c); err != nil {
+		return nil, fmt.Errorf("parsing web config: %w", err)
+	}
+
+	// Resolve relative cert paths against config file directory.
+	dir := filepath.Dir(configPath)
+	c.TLSConfig.TLSCertPath = config_util.JoinDir(dir, c.TLSConfig.TLSCertPath)
+	c.TLSConfig.TLSKeyPath = config_util.JoinDir(dir, c.TLSConfig.TLSKeyPath)
+	c.TLSConfig.ClientCAs = config_util.JoinDir(dir, c.TLSConfig.ClientCAs)
+	return c, nil
+}
+
+// hasTLS returns true if the web config has TLS certificate configuration.
+func (c *webConfig) hasTLS() bool {
+	return c.TLSConfig.TLSCertPath != "" || c.TLSConfig.TLSCert != ""
+}
+
+// altSvcMiddleware wraps an http.Handler to inject Alt-Svc headers advertising
+// HTTP/3 availability via the given http3.Server.
+type altSvcMiddleware struct {
+	inner    http.Handler
+	h3Server *http3.Server
+}
+
+func (m *altSvcMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if err := m.h3Server.SetQUICHeaders(w.Header()); err == nil {
+		// SetQUICHeaders adds Alt-Svc header advertising HTTP/3
+	}
+	m.inner.ServeHTTP(w, r)
+}
+
+// http3AuthHandler provides basic auth for the HTTP/3 path, matching the
+// behavior of exporter-toolkit's webHandler. This is needed because
+// exporter-toolkit only wraps the TCP server handler internally.
+type http3AuthHandler struct {
+	inner      http.Handler
+	configPath string
+	logger     *slog.Logger
+	bcryptMtx  sync.Mutex
+}
+
+func (h *http3AuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	c, err := loadWebConfig(h.configPath)
+	if err != nil {
+		h.logger.Error("Unable to parse configuration", "err", err.Error())
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	if len(c.Users) == 0 {
+		h.inner.ServeHTTP(w, r)
+		return
+	}
+
+	user, pass, auth := r.BasicAuth()
+	if auth {
+		hashedPassword, validUser := c.Users[user]
+
+		if !validUser {
+			// Use a fixed password hash to prevent user enumeration by timing.
+			// This is a bcrypt-hashed version of "fakepassword".
+			hashedPassword = "$2y$10$QOauhQNbBCuQDKes6eFzPeMqBSjb7Mr5DUmpZ/VcEd00UAV/LDeSi"
+		}
+
+		// Use a cache key for logging only; we always verify for correctness.
+		_ = strings.Join([]string{
+			hex.EncodeToString([]byte(user)),
+			hex.EncodeToString([]byte(hashedPassword)),
+			hex.EncodeToString([]byte(pass)),
+		}, ":")
+
+		h.bcryptMtx.Lock()
+		err := bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(pass))
+		h.bcryptMtx.Unlock()
+
+		if validUser && err == nil {
+			h.inner.ServeHTTP(w, r)
+			return
+		}
+	}
+
+	w.Header().Set("WWW-Authenticate", "Basic")
+	http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+}
+
+// startHTTP3Server starts a QUIC/HTTP3 server on the given addresses using
+// the TLS configuration from the web config file. It returns the http3.Server
+// (for use with Alt-Svc header injection), a cleanup function, and any error.
+func startHTTP3Server(addresses []string, configPath string, handler http.Handler, logger *slog.Logger) (*http3.Server, func(), error) {
+	c, err := loadWebConfig(configPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading web config for HTTP/3: %w", err)
+	}
+
+	if !c.hasTLS() {
+		return nil, nil, fmt.Errorf("HTTP/3 requires TLS configuration in %s", configPath)
+	}
+
+	// Build TLS config using the exported ConfigToTLSConfig.
+	// We need to construct a web.TLSConfig to pass to it.
+	webTLSConfig := &web.TLSConfig{
+		TLSCertPath: c.TLSConfig.TLSCertPath,
+		TLSKeyPath:  c.TLSConfig.TLSKeyPath,
+		TLSCert:     c.TLSConfig.TLSCert,
+		TLSKey:      c.TLSConfig.TLSKey,
+		ClientCAs:   c.TLSConfig.ClientCAs,
+		ClientAuth:  c.TLSConfig.ClientAuth,
+		MinVersion:  c.TLSConfig.MinVersion,
+		MaxVersion:  c.TLSConfig.MaxVersion,
+	}
+
+	tlsConf, err := web.ConfigToTLSConfig(webTLSConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating TLS config for HTTP/3: %w", err)
+	}
+
+	// QUIC requires TLS 1.3 minimum.
+	if tlsConf.MinVersion < tls.VersionTLS13 {
+		tlsConf.MinVersion = tls.VersionTLS13
+	}
+
+	// Set up GetConfigForClient for TLS config hot-reloading.
+	tlsConf.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+		newC, err := loadWebConfig(configPath)
+		if err != nil {
+			return nil, err
+		}
+		newWebTLS := &web.TLSConfig{
+			TLSCertPath: newC.TLSConfig.TLSCertPath,
+			TLSKeyPath:  newC.TLSConfig.TLSKeyPath,
+			TLSCert:     newC.TLSConfig.TLSCert,
+			TLSKey:      newC.TLSConfig.TLSKey,
+			ClientCAs:   newC.TLSConfig.ClientCAs,
+			ClientAuth:  newC.TLSConfig.ClientAuth,
+			MinVersion:  newC.TLSConfig.MinVersion,
+			MaxVersion:  newC.TLSConfig.MaxVersion,
+		}
+		newTLS, err := web.ConfigToTLSConfig(newWebTLS)
+		if err != nil {
+			return nil, err
+		}
+		if newTLS.MinVersion < tls.VersionTLS13 {
+			newTLS.MinVersion = tls.VersionTLS13
+		}
+		return newTLS, nil
+	}
+
+	// Configure ALPN for HTTP/3.
+	quicTLSConf := http3.ConfigureTLSConfig(tlsConf)
+
+	h3Server := &http3.Server{
+		TLSConfig: quicTLSConf,
+		Handler:   handler,
+		Logger:    logger,
+	}
+
+	var conns []net.PacketConn
+	for _, addr := range addresses {
+		if strings.HasPrefix(addr, "vsock://") {
+			logger.Warn("HTTP/3 does not support vsock addresses, skipping", "address", addr)
+			continue
+		}
+
+		udpAddr, err := net.ResolveUDPAddr("udp", addr)
+		if err != nil {
+			// Close any already-opened connections.
+			for _, c := range conns {
+				c.Close()
+			}
+			return nil, nil, fmt.Errorf("resolving UDP address %q: %w", addr, err)
+		}
+
+		conn, err := net.ListenUDP("udp", udpAddr)
+		if err != nil {
+			for _, c := range conns {
+				c.Close()
+			}
+			return nil, nil, fmt.Errorf("listening on UDP %s: %w", addr, err)
+		}
+
+		conns = append(conns, conn)
+		logger.Info("HTTP/3 (QUIC) listener started", "address", addr)
+
+		go func(c net.PacketConn) {
+			if err := h3Server.Serve(c); err != nil && err != http.ErrServerClosed {
+				logger.Error("HTTP/3 server error", "err", err)
+			}
+		}(conn)
+	}
+
+	if len(conns) == 0 {
+		return nil, nil, fmt.Errorf("no valid addresses for HTTP/3 listener")
+	}
+
+	cleanup := func() {
+		if err := h3Server.Shutdown(context.Background()); err != nil {
+			logger.Error("HTTP/3 server shutdown error", "err", err)
+		}
+		for _, c := range conns {
+			c.Close()
+		}
+	}
+
+	return h3Server, cleanup, nil
+}

--- a/http3_test.go
+++ b/http3_test.go
@@ -1,0 +1,481 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"log/slog"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go/http3"
+)
+
+func TestLoadWebConfig(t *testing.T) {
+	t.Run("valid TLS config", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "web.yml")
+		content := `
+tls_server_config:
+  cert_file: server.crt
+  key_file: server.key
+`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		c, err := loadWebConfig(configPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Paths should be resolved relative to config dir.
+		if c.TLSConfig.TLSCertPath != filepath.Join(dir, "server.crt") {
+			t.Errorf("expected cert path %q, got %q", filepath.Join(dir, "server.crt"), c.TLSConfig.TLSCertPath)
+		}
+		if c.TLSConfig.TLSKeyPath != filepath.Join(dir, "server.key") {
+			t.Errorf("expected key path %q, got %q", filepath.Join(dir, "server.key"), c.TLSConfig.TLSKeyPath)
+		}
+		if !c.hasTLS() {
+			t.Error("expected hasTLS() to be true")
+		}
+	})
+
+	t.Run("with basic auth users", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "web.yml")
+		content := `
+tls_server_config:
+  cert_file: server.crt
+  key_file: server.key
+basic_auth_users:
+  alice: "$2y$10$QOauhQNbBCuQDKes6eFzPeMqBSjb7Mr5DUmpZ/VcEd00UAV/LDeSi"
+`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		c, err := loadWebConfig(configPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(c.Users) != 1 {
+			t.Errorf("expected 1 user, got %d", len(c.Users))
+		}
+		if _, ok := c.Users["alice"]; !ok {
+			t.Error("expected user 'alice' to be present")
+		}
+	})
+
+	t.Run("no TLS config", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "web.yml")
+		content := `
+basic_auth_users:
+  alice: "$2y$10$QOauhQNbBCuQDKes6eFzPeMqBSjb7Mr5DUmpZ/VcEd00UAV/LDeSi"
+`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		c, err := loadWebConfig(configPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if c.hasTLS() {
+			t.Error("expected hasTLS() to be false")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := loadWebConfig("/nonexistent/web.yml")
+		if err == nil {
+			t.Error("expected error for missing file")
+		}
+	})
+
+	t.Run("invalid YAML", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "web.yml")
+		if err := os.WriteFile(configPath, []byte("invalid: [yaml: content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := loadWebConfig(configPath)
+		if err == nil {
+			t.Error("expected error for invalid YAML")
+		}
+	})
+
+	t.Run("default TLS versions", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "web.yml")
+		content := `
+tls_server_config:
+  cert_file: server.crt
+  key_file: server.key
+`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		c, err := loadWebConfig(configPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if uint16(c.TLSConfig.MinVersion) != tls.VersionTLS12 {
+			t.Errorf("expected default min TLS 1.2, got %d", c.TLSConfig.MinVersion)
+		}
+		if uint16(c.TLSConfig.MaxVersion) != tls.VersionTLS13 {
+			t.Errorf("expected default max TLS 1.3, got %d", c.TLSConfig.MaxVersion)
+		}
+	})
+}
+
+// generateTestCert creates a self-signed TLS certificate for testing.
+func generateTestCert(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+
+	certFile, err := os.Create(certPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	certFile.Close()
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyFile, err := os.Create(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pem.Encode(keyFile, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	keyFile.Close()
+
+	return certPath, keyPath
+}
+
+func TestAltSvcMiddleware(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	dir := t.TempDir()
+	certPath, keyPath := generateTestCert(t, dir)
+
+	// Build a real TLS config so we can start a QUIC listener.
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsConf := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+		NextProtos:   []string{http3.NextProtoH3},
+	}
+
+	// Open a real UDP listener so SetQUICHeaders has port info.
+	udpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer udpConn.Close()
+
+	h3Server := &http3.Server{
+		TLSConfig: tlsConf,
+		Handler:   inner,
+	}
+	// Start serving in background so the listener is registered.
+	go h3Server.Serve(udpConn)
+	defer h3Server.Close()
+
+	// Give the server a moment to register the listener.
+	time.Sleep(50 * time.Millisecond)
+
+	middleware := &altSvcMiddleware{
+		inner:    inner,
+		h3Server: h3Server,
+	}
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	rec := httptest.NewRecorder()
+	middleware.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	// The Alt-Svc header should be set.
+	altSvc := rec.Header().Get("Alt-Svc")
+	if altSvc == "" {
+		t.Error("expected Alt-Svc header to be set")
+	}
+
+	if rec.Body.String() != "ok" {
+		t.Errorf("expected body 'ok', got %q", rec.Body.String())
+	}
+}
+
+func TestHTTP3AuthHandler(t *testing.T) {
+	logger := slog.Default()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("authenticated"))
+	})
+
+	t.Run("no users configured passes through", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "web.yml")
+		content := `
+tls_server_config:
+  cert_file: server.crt
+  key_file: server.key
+`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		handler := &http3AuthHandler{
+			inner:      inner,
+			configPath: configPath,
+			logger:     logger,
+		}
+
+		req := httptest.NewRequest("GET", "/metrics", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("valid credentials", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "web.yml")
+		// bcrypt hash of "fakepassword"
+		content := `
+tls_server_config:
+  cert_file: server.crt
+  key_file: server.key
+basic_auth_users:
+  alice: "$2y$10$QOauhQNbBCuQDKes6eFzPeMqBSjb7Mr5DUmpZ/VcEd00UAV/LDeSi"
+`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		handler := &http3AuthHandler{
+			inner:      inner,
+			configPath: configPath,
+			logger:     logger,
+		}
+
+		req := httptest.NewRequest("GET", "/metrics", nil)
+		req.SetBasicAuth("alice", "fakepassword")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("invalid credentials", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "web.yml")
+		content := `
+tls_server_config:
+  cert_file: server.crt
+  key_file: server.key
+basic_auth_users:
+  alice: "$2y$10$QOauhQNbBCuQDKes6eFzPeMqBSjb7Mr5DUmpZ/VcEd00UAV/LDeSi"
+`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		handler := &http3AuthHandler{
+			inner:      inner,
+			configPath: configPath,
+			logger:     logger,
+		}
+
+		req := httptest.NewRequest("GET", "/metrics", nil)
+		req.SetBasicAuth("alice", "wrongpassword")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected status 401, got %d", rec.Code)
+		}
+	})
+
+	t.Run("no credentials when required", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "web.yml")
+		content := `
+tls_server_config:
+  cert_file: server.crt
+  key_file: server.key
+basic_auth_users:
+  alice: "$2y$10$QOauhQNbBCuQDKes6eFzPeMqBSjb7Mr5DUmpZ/VcEd00UAV/LDeSi"
+`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		handler := &http3AuthHandler{
+			inner:      inner,
+			configPath: configPath,
+			logger:     logger,
+		}
+
+		req := httptest.NewRequest("GET", "/metrics", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected status 401, got %d", rec.Code)
+		}
+
+		if rec.Header().Get("WWW-Authenticate") != "Basic" {
+			t.Errorf("expected WWW-Authenticate header 'Basic', got %q", rec.Header().Get("WWW-Authenticate"))
+		}
+	})
+
+	t.Run("unknown user", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "web.yml")
+		content := `
+tls_server_config:
+  cert_file: server.crt
+  key_file: server.key
+basic_auth_users:
+  alice: "$2y$10$QOauhQNbBCuQDKes6eFzPeMqBSjb7Mr5DUmpZ/VcEd00UAV/LDeSi"
+`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		handler := &http3AuthHandler{
+			inner:      inner,
+			configPath: configPath,
+			logger:     logger,
+		}
+
+		req := httptest.NewRequest("GET", "/metrics", nil)
+		req.SetBasicAuth("bob", "fakepassword")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected status 401, got %d", rec.Code)
+		}
+	})
+
+	t.Run("broken config file", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "web.yml")
+		if err := os.WriteFile(configPath, []byte("invalid: [yaml"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		handler := &http3AuthHandler{
+			inner:      inner,
+			configPath: configPath,
+			logger:     logger,
+		}
+
+		req := httptest.NewRequest("GET", "/metrics", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("expected status 500, got %d", rec.Code)
+		}
+	})
+}
+
+func TestHTTP3RequiresTLS(t *testing.T) {
+	logger := slog.Default()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("no TLS config returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "web.yml")
+		content := `
+basic_auth_users:
+  alice: "$2y$10$QOauhQNbBCuQDKes6eFzPeMqBSjb7Mr5DUmpZ/VcEd00UAV/LDeSi"
+`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, err := startHTTP3Server([]string{":0"}, configPath, handler, logger)
+		if err == nil {
+			t.Error("expected error when TLS is not configured")
+		}
+	})
+
+	t.Run("missing config file returns error", func(t *testing.T) {
+		_, _, err := startHTTP3Server([]string{":0"}, "/nonexistent/web.yml", handler, logger)
+		if err == nil {
+			t.Error("expected error when config file is missing")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add optional HTTP/3 (QUIC) listener via new `--web.enable-http3` flag, using `quic-go/quic-go`
- Advertise HTTP/3 availability on TCP responses via `Alt-Svc` headers so clients can upgrade automatically
- Reuse existing `--web.config.file` TLS configuration with hot-reloading support and basic auth parity with exporter-toolkit

## Details

When `--web.enable-http3` is enabled, node_exporter starts a QUIC/UDP listener on the same address(es) as the TCP listener. This requires TLS to be configured via `--web.config.file` (QUIC mandates TLS 1.3, which is automatically enforced).

### New files
- **`http3.go`** — Web config parsing, `Alt-Svc` middleware, HTTP/3 auth handler, and QUIC server lifecycle management
- **`http3_test.go`** — Comprehensive tests for config loading, Alt-Svc header injection, basic auth (valid/invalid/missing credentials, unknown users, broken config)

### Modified files
- **`node_exporter.go`** — Adds `--web.enable-http3` flag, HTTP/3 server startup with validation, and `Alt-Svc` middleware wiring
- **`go.mod` / `go.sum`** — Adds `quic-go/quic-go` and `quic-go/qpack` dependencies

### Key design decisions
- HTTP/3 is opt-in (disabled by default) to avoid breaking existing deployments
- TLS config is re-read on each QUIC handshake (`GetConfigForClient`) for hot-reloading
- Basic auth is reimplemented for the HTTP/3 path since exporter-toolkit only wraps the TCP handler internally
- Graceful shutdown closes QUIC connections and UDP listeners on exit
- vsock addresses are skipped with a warning (QUIC requires UDP)

## Test plan
- [x] Unit tests for `loadWebConfig` (valid TLS, basic auth, no TLS, missing file, invalid YAML, default versions)
- [x] Unit tests for `altSvcMiddleware` (verifies Alt-Svc header injection with real QUIC listener)
- [x] Unit tests for `http3AuthHandler` (no users, valid creds, invalid creds, no creds, unknown user, broken config)
- [x] Unit tests for `startHTTP3Server` error paths (no TLS config, missing config file)
- [ ] Manual: `go build && ./node_exporter --web.enable-http3 --web.config.file=web.yml` and verify with `curl --http3`
- [ ] Manual: Verify Alt-Svc header appears on TCP responses
- [ ] Manual: Verify startup fails gracefully without TLS config

🤖 Generated with [Claude Code](https://claude.com/claude-code)