### PR TITLE
feat: add IP whitelist support via CIDR networks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/prometheus/procfs v0.19.2
 	github.com/safchain/ethtool v0.7.0
 	golang.org/x/sys v0.40.0
+	gopkg.in/yaml.v2 v2.4.0
 	howett.net/plist v1.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Adds optional IP whitelist support to the HTTP server

New flags:
  `--web.allowed-networks`
  `--web.whitelist-config`

`--web.allowed-networks` accepts a comma-separated list of CIDR networks.
Single IPs are accepted and treated as /32 (IPv4) or /128 (IPv6).

If configured, requests from non-matching IPs receive HTTP 403.
If not configured, behavior remains unchanged.

Whitelist applies to both:
  - /metrics
  - /

Client IP resolution:

IP is resolved in the following order:
  - Custom headers defined in YAML (`whitelist.ip_headers`)
  - Default headers (if none configured):
      - `X-Forwarded-For` (first IP is used)
      - `X-Real-IP`
      - `X-Forwarded`
  - Fallback to `RemoteAddr`

Examples:

Allow single network:
 ` ./node_exporter --web.allowed-networks=10.0.0.0/24`

Allow multiple networks:
  `./node_exporter --web.allowed-networks=10.0.0.0/24,192.168.1.0/24`

Allow single host:
 ` ./node_exporter --web.allowed-networks=10.0.0.10`

With IPv6:
  `./node_exporter --web.allowed-networks=2001:db8::/32`

Using YAML configuration:
  `./node_exporter --web.whitelist-config=/etc/node_exporter/whitelist.yaml`

Example YAML:

```
  whitelist:
    allowed_networks:
      - "10.0.0.0/24"
      - "192.168.1.0/24"
    ip_headers:
      - "X-Forwarded-For"
      - "X-Real-IP"

```