### PR TITLE
Add `chip` label to DRM metrics

### DIFF
--- a/collector/drm_linux.go
+++ b/collector/drm_linux.go
@@ -40,7 +40,7 @@ var (
 	drmCardInfo = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, drmCollectorSubsystem, "card_info"),
 		"Card information",
-		[]string{"card", "memory_vendor", "power_performance_level", "unique_id", "vendor"}, nil,
+		[]string{"card", "memory_vendor", "power_performance_level", "unique_id", "chip", "vendor"}, nil,
 	)
 	drmGPUBusyPercent = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, drmCollectorSubsystem, "gpu_busy_percent"),
@@ -96,6 +96,17 @@ func (c *drmCollector) Update(ch chan<- prometheus.Metric) error {
 	return c.updateAMDCards(ch)
 }
 
+func chipName(s sysfs.ClassDRMCardAMDGPUStats) string {
+	// generate a chip name based on the deviceType and devName
+	cleanDevName := cleanMetricName(s.DevName)
+	cleanDevType := cleanMetricName(s.DevType)
+
+	if cleanDevType != "" && cleanDevName != "" {
+		return cleanDevType + "_" + cleanDevName
+	}
+	return cleanDevName
+}
+
 func (c *drmCollector) updateAMDCards(ch chan<- prometheus.Metric) error {
 	vendor := "amd"
 	stats, err := c.fs.ClassDRMCardAMDGPUStats()
@@ -106,7 +117,7 @@ func (c *drmCollector) updateAMDCards(ch chan<- prometheus.Metric) error {
 	for _, s := range stats {
 		ch <- prometheus.MustNewConstMetric(
 			drmCardInfo, prometheus.GaugeValue, 1,
-			s.Name, s.MemoryVRAMVendor, s.PowerDPMForcePerformanceLevel, s.UniqueID, vendor)
+			s.Name, s.MemoryVRAMVendor, s.PowerDPMForcePerformanceLevel, s.UniqueID, chipName(s), vendor)
 
 		ch <- prometheus.MustNewConstMetric(
 			drmGPUBusyPercent, prometheus.GaugeValue, float64(s.GPUBusyPercent), s.Name)

--- a/collector/helper_linux.go
+++ b/collector/helper_linux.go
@@ -1,0 +1,30 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	hwmonInvalidMetricChars = regexp.MustCompile("[^a-z0-9:_]")
+)
+
+func cleanMetricName(name string) string {
+	lower := strings.ToLower(name)
+	replaced := hwmonInvalidMetricChars.ReplaceAllLiteralString(lower, "_")
+	cleaned := strings.Trim(replaced, "_")
+	return cleaned
+}

--- a/collector/hwmon_linux.go
+++ b/collector/hwmon_linux.go
@@ -37,11 +37,10 @@ var (
 	collectorHWmonSensorInclude = kingpin.Flag("collector.hwmon.sensor-include", "Regexp of hwmon sensor to include (mutually exclusive to sensor-exclude).").String()
 	collectorHWmonSensorExclude = kingpin.Flag("collector.hwmon.sensor-exclude", "Regexp of hwmon sensor to exclude (mutually exclusive to sensor-include).").String()
 
-	hwmonInvalidMetricChars = regexp.MustCompile("[^a-z0-9:_]")
-	hwmonFilenameFormat     = regexp.MustCompile(`^(?P<type>[^0-9]+)(?P<id>[0-9]*)?(_(?P<property>.+))?$`)
-	hwmonLabelDesc          = []string{"chip", "sensor"}
-	hwmonChipNameLabelDesc  = []string{"chip", "chip_name"}
-	hwmonSensorTypes        = []string{
+	hwmonFilenameFormat    = regexp.MustCompile(`^(?P<type>[^0-9]+)(?P<id>[0-9]*)?(_(?P<property>.+))?$`)
+	hwmonLabelDesc         = []string{"chip", "sensor"}
+	hwmonChipNameLabelDesc = []string{"chip", "chip_name"}
+	hwmonSensorTypes       = []string{
 		"vrm", "beep_enable", "update_interval", "in", "cpu", "fan",
 		"pwm", "temp", "curr", "power", "energy", "humidity",
 		"intrusion", "freq",
@@ -67,13 +66,6 @@ func NewHwMonCollector(logger *slog.Logger) (Collector, error) {
 		deviceFilter: newDeviceFilter(*collectorHWmonChipExclude, *collectorHWmonChipInclude),
 		sensorFilter: newDeviceFilter(*collectorHWmonSensorExclude, *collectorHWmonSensorInclude),
 	}, nil
-}
-
-func cleanMetricName(name string) string {
-	lower := strings.ToLower(name)
-	replaced := hwmonInvalidMetricChars.ReplaceAllLiteralString(lower, "_")
-	cleaned := strings.Trim(replaced, "_")
-	return cleaned
 }
 
 func addValueFile(data map[string]map[string]string, sensor string, prop string, file string) {


### PR DESCRIPTION
## Issue
Add chip label to the `node_drm_card_info` metric.

## Solution
Extend the DRM collector to have the `chip` label from the `ClassDRMCardAMDGPUStats`.
The change was also proposed in the [procfs repo](https://github.com/prometheus/procfs), and the [PR](https://github.com/prometheus/procfs/pull/672) was merged.

## Context
The DRM metrics are impossible to relate to the `hwmon` metrics, which export other helpful information about AMD GPUs. The extension will allow us to relate metrics from both `hwmon` and `drm` and, in turn, create a better GPU Dashboard for AMD with proper filtering and labelling. 

Example metrics:

```
# DRM
node_drm_card_info{card="card0",chip="0000:9d:00_0_0000:9e:00_0",memory_vendor="unknown",power_performance_level="auto",unique_id="",vendor="amd"} 1

# HWMON
node_hwmon_chip_names{chip="0000:9d:00_0_0000:9e:00_0",chip_name="amdgpu"} 1
node_hwmon_fan_enable{chip="0000:9d:00_0_0000:9e:00_0",sensor="fan1"} 0
node_hwmon_fan_max_rpm{chip="0000:9d:00_0_0000:9e:00_0",sensor="fan1"} 6900
node_hwmon_fan_min_rpm{chip="0000:9d:00_0_0000:9e:00_0",sensor="fan1"} 1800
node_hwmon_fan_rpm{chip="0000:9d:00_0_0000:9e:00_0",sensor="fan1"} 2035
node_hwmon_fan_target_rpm{chip="0000:9d:00_0_0000:9e:00_0",sensor="fan1"} 2035
node_hwmon_freq_freq_mhz{chip="0000:9d:00_0_0000:9e:00_0",sensor="mclk"} 1500
node_hwmon_freq_freq_mhz{chip="0000:9d:00_0_0000:9e:00_0",sensor="sclk"} 214
node_hwmon_in_volts{chip="0000:9d:00_0_0000:9e:00_0",sensor="in0"} 0.85
node_hwmon_power_average_watt{chip="0000:9d:00_0_0000:9e:00_0",sensor="power1"} 6.075
node_hwmon_power_cap_default_watt{chip="0000:9d:00_0_0000:9e:00_0",sensor="power1"} 35
node_hwmon_power_cap_max_watt{chip="0000:9d:00_0_0000:9e:00_0",sensor="power1"} 35
node_hwmon_power_cap_min_watt{chip="0000:9d:00_0_0000:9e:00_0",sensor="power1"} 0
node_hwmon_power_cap_watt{chip="0000:9d:00_0_0000:9e:00_0",sensor="power1"} 35
node_hwmon_pwm{chip="0000:9d:00_0_0000:9e:00_0",sensor="pwm1"} 49
node_hwmon_pwm_enable{chip="0000:9d:00_0_0000:9e:00_0",sensor="pwm1"} 2
node_hwmon_pwm_max{chip="0000:9d:00_0_0000:9e:00_0",sensor="pwm1"} 255
node_hwmon_pwm_min{chip="0000:9d:00_0_0000:9e:00_0",sensor="pwm1"} 0
node_hwmon_sensor_label{chip="0000:9d:00_0_0000:9e:00_0",label="edge",sensor="temp1"} 1
node_hwmon_sensor_label{chip="0000:9d:00_0_0000:9e:00_0",label="mclk",sensor="freq2"} 1
node_hwmon_sensor_label{chip="0000:9d:00_0_0000:9e:00_0",label="sclk",sensor="freq1"} 1
node_hwmon_sensor_label{chip="0000:9d:00_0_0000:9e:00_0",label="slowPPT",sensor="power1"} 1
node_hwmon_sensor_label{chip="0000:9d:00_0_0000:9e:00_0",label="vddgfx",sensor="in0"} 1
node_hwmon_temp_celsius{chip="0000:9d:00_0_0000:9e:00_0",sensor="temp1"} 42
node_hwmon_temp_crit_celsius{chip="0000:9d:00_0_0000:9e:00_0",sensor="temp1"} 97
node_hwmon_temp_crit_hyst_celsius{chip="0000:9d:00_0_0000:9e:00_0",sensor="temp1"} -273.15000000000003
```