### PR TITLE
collector: add nvmesubsystem collector for NVMe-oF path health

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ logind | Exposes session counts from [logind](http://www.freedesktop.org/wiki/So
 meminfo\_numa | Exposes memory statistics from `/sys/devices/system/node/node[0-9]*/meminfo`, `/sys/devices/system/node/node[0-9]*/numastat`. | Linux
 mountstats | Exposes filesystem statistics from `/proc/self/mountstats`. Exposes detailed NFS client statistics. | Linux
 network_route | Exposes the routing table as metrics | Linux
+nvmesubsystem | Exposes NVMe over Fabrics subsystem path health metrics from `/sys/class/nvme-subsystem/`. | Linux
 pcidevice | Exposes pci devices' information including their link status and parent devices. | Linux
 perf | Exposes perf based metrics (Warning: Metrics are dependent on kernel configuration and settings). | Linux
 processes | Exposes aggregate process statistics from `/proc`. | Linux

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -2255,6 +2255,107 @@ Lines: 1
 4096
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/class/nvme-subsystem
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/class/nvme-subsystem/nvme-subsys0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/iopolicy
+Lines: 1
+round-robinEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/model
+Lines: 1
+Dell PowerStoreEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/class/nvme-subsystem/nvme-subsys0/nvme0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/nvme0/address
+Lines: 1
+nn-0x200000109b123456:pn-0x100000109b123456EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/nvme0/state
+Lines: 1
+liveEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/nvme0/transport
+Lines: 1
+fcEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/class/nvme-subsystem/nvme-subsys0/nvme0n1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/class/nvme-subsystem/nvme-subsys0/nvme1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/nvme1/address
+Lines: 1
+nn-0x200000109b123457:pn-0x100000109b123457EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/nvme1/state
+Lines: 1
+liveEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/nvme1/transport
+Lines: 1
+fcEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/class/nvme-subsystem/nvme-subsys0/nvme2
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/nvme2/address
+Lines: 1
+nn-0x200000109b123458:pn-0x100000109b123458EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/nvme2/state
+Lines: 1
+liveEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/nvme2/transport
+Lines: 1
+fcEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/class/nvme-subsystem/nvme-subsys0/nvme3
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/nvme3/address
+Lines: 1
+nn-0x200000109b123459:pn-0x100000109b123459EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/nvme3/state
+Lines: 1
+deadEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/nvme3/transport
+Lines: 1
+fcEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/serial
+Lines: 1
+SN12345678EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme-subsystem/nvme-subsys0/subsysnqn
+Lines: 1
+nqn.2014-08.org.nvmexpress:uuid:a34c4f3a-0d6f-5cec-dead-beefcafebabeEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/class/power_supply
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/collector/nvmesubsystem_linux.go
+++ b/collector/nvmesubsystem_linux.go
@@ -1,0 +1,156 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nonvmesubsystem
+
+package collector
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/procfs/sysfs"
+)
+
+// nvmeControllerStateMap maps each kernel-reported controller state to
+// its metric label value. States not in this map are reported as "unknown".
+var nvmeControllerStateMap = map[string]string{
+	"live":             "live",
+	"connecting":       "connecting",
+	"resetting":        "resetting",
+	"dead":             "dead",
+	"deleting":         "deleting",
+	"deleting (no IO)": "deleting",
+	"new":              "new",
+}
+
+// nvmeMetricStates is the sorted, unique set of metric-level states
+// derived from nvmeControllerStateMap values plus "unknown".
+var nvmeMetricStates = func() []string {
+	seen := map[string]struct{}{"unknown": {}}
+	for _, v := range nvmeControllerStateMap {
+		seen[v] = struct{}{}
+	}
+	states := make([]string, 0, len(seen))
+	for s := range seen {
+		states = append(states, s)
+	}
+	sort.Strings(states)
+	return states
+}()
+
+func normalizeControllerState(raw string) string {
+	if s, ok := nvmeControllerStateMap[raw]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+func init() {
+	registerCollector("nvmesubsystem", defaultDisabled, NewNVMeSubsystemCollector)
+}
+
+var (
+	nvmesubsystemInfo = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "nvmesubsystem", "info"),
+		"Non-numeric information about an NVMe subsystem.",
+		[]string{"subsystem", "nqn", "model", "serial", "iopolicy"}, nil,
+	)
+	nvmesubsystemNamespaceInfo = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "nvmesubsystem", "namespace_info"),
+		"Maps an NVMe namespace block device to its subsystem.",
+		[]string{"subsystem", "device"}, nil,
+	)
+	nvmesubsystemPaths = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "nvmesubsystem", "paths"),
+		"Number of controller paths for an NVMe subsystem.",
+		[]string{"subsystem"}, nil,
+	)
+	nvmesubsystemPathsLive = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "nvmesubsystem", "paths_live"),
+		"Number of controller paths in live state for an NVMe subsystem.",
+		[]string{"subsystem"}, nil,
+	)
+	nvmesubsystemPathState = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "nvmesubsystem", "path_state"),
+		"Current NVMe controller path state (1 for the current state, 0 for all others).",
+		[]string{"subsystem", "controller", "transport", "state"}, nil,
+	)
+)
+
+type nvmeSubsystemCollector struct {
+	fs     sysfs.FS
+	logger *slog.Logger
+}
+
+// NewNVMeSubsystemCollector returns a new Collector exposing NVMe-oF subsystem
+// path health from /sys/class/nvme-subsystem/.
+func NewNVMeSubsystemCollector(logger *slog.Logger) (Collector, error) {
+	fs, err := sysfs.NewFS(*sysPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open sysfs: %w", err)
+	}
+
+	return &nvmeSubsystemCollector{
+		fs:     fs,
+		logger: logger,
+	}, nil
+}
+
+func (c *nvmeSubsystemCollector) Update(ch chan<- prometheus.Metric) error {
+	subsystems, err := c.fs.NVMeSubsystemClass()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrPermission) {
+			c.logger.Debug("Could not read NVMe subsystem info", "err", err)
+			return ErrNoData
+		}
+		return fmt.Errorf("failed to scan NVMe subsystems: %w", err)
+	}
+
+	for _, subsys := range subsystems {
+		ch <- prometheus.MustNewConstMetric(nvmesubsystemInfo, prometheus.GaugeValue, 1,
+			subsys.Name, subsys.NQN, subsys.Model, subsys.Serial, subsys.IOPolicy)
+
+		for _, ns := range subsys.Namespaces {
+			ch <- prometheus.MustNewConstMetric(nvmesubsystemNamespaceInfo, prometheus.GaugeValue, 1,
+				subsys.Name, ns)
+		}
+
+		total := float64(len(subsys.Controllers))
+		var live float64
+		for _, ctrl := range subsys.Controllers {
+			state := normalizeControllerState(ctrl.State)
+			if state == "live" {
+				live++
+			}
+
+			for _, s := range nvmeMetricStates {
+				val := 0.0
+				if s == state {
+					val = 1.0
+				}
+				ch <- prometheus.MustNewConstMetric(nvmesubsystemPathState, prometheus.GaugeValue, val,
+					subsys.Name, ctrl.Name, ctrl.Transport, s)
+			}
+		}
+
+		ch <- prometheus.MustNewConstMetric(nvmesubsystemPaths, prometheus.GaugeValue, total, subsys.Name)
+		ch <- prometheus.MustNewConstMetric(nvmesubsystemPathsLive, prometheus.GaugeValue, live, subsys.Name)
+	}
+
+	return nil
+}

--- a/collector/nvmesubsystem_linux_test.go
+++ b/collector/nvmesubsystem_linux_test.go
@@ -1,0 +1,153 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nonvmesubsystem
+
+package collector
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+type testNVMeSubsystemCollector struct {
+	mc Collector
+}
+
+func (c testNVMeSubsystemCollector) Collect(ch chan<- prometheus.Metric) {
+	c.mc.Update(ch)
+}
+
+func (c testNVMeSubsystemCollector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(c, ch)
+}
+
+func newTestNVMeSubsystemCollector(logger *slog.Logger) (prometheus.Collector, error) {
+	mc, err := NewNVMeSubsystemCollector(logger)
+	if err != nil {
+		return testNVMeSubsystemCollector{}, err
+	}
+	return &testNVMeSubsystemCollector{mc}, nil
+}
+
+func TestNVMeSubsystemMetrics(t *testing.T) {
+	*sysPath = "fixtures/sys"
+
+	testcase := `# HELP node_nvmesubsystem_info Non-numeric information about an NVMe subsystem.
+# TYPE node_nvmesubsystem_info gauge
+node_nvmesubsystem_info{iopolicy="round-robin",model="Dell PowerStore",nqn="nqn.2014-08.org.nvmexpress:uuid:a34c4f3a-0d6f-5cec-dead-beefcafebabe",serial="SN12345678",subsystem="nvme-subsys0"} 1
+# HELP node_nvmesubsystem_namespace_info Maps an NVMe namespace block device to its subsystem.
+# TYPE node_nvmesubsystem_namespace_info gauge
+node_nvmesubsystem_namespace_info{device="nvme0n1",subsystem="nvme-subsys0"} 1
+# HELP node_nvmesubsystem_path_state Current NVMe controller path state (1 for the current state, 0 for all others).
+# TYPE node_nvmesubsystem_path_state gauge
+node_nvmesubsystem_path_state{controller="nvme0",state="connecting",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme0",state="dead",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme0",state="deleting",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme0",state="live",subsystem="nvme-subsys0",transport="fc"} 1
+node_nvmesubsystem_path_state{controller="nvme0",state="new",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme0",state="resetting",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme0",state="unknown",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme1",state="connecting",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme1",state="dead",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme1",state="deleting",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme1",state="live",subsystem="nvme-subsys0",transport="fc"} 1
+node_nvmesubsystem_path_state{controller="nvme1",state="new",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme1",state="resetting",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme1",state="unknown",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme2",state="connecting",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme2",state="dead",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme2",state="deleting",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme2",state="live",subsystem="nvme-subsys0",transport="fc"} 1
+node_nvmesubsystem_path_state{controller="nvme2",state="new",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme2",state="resetting",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme2",state="unknown",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme3",state="connecting",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme3",state="dead",subsystem="nvme-subsys0",transport="fc"} 1
+node_nvmesubsystem_path_state{controller="nvme3",state="deleting",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme3",state="live",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme3",state="new",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme3",state="resetting",subsystem="nvme-subsys0",transport="fc"} 0
+node_nvmesubsystem_path_state{controller="nvme3",state="unknown",subsystem="nvme-subsys0",transport="fc"} 0
+# HELP node_nvmesubsystem_paths Number of controller paths for an NVMe subsystem.
+# TYPE node_nvmesubsystem_paths gauge
+node_nvmesubsystem_paths{subsystem="nvme-subsys0"} 4
+# HELP node_nvmesubsystem_paths_live Number of controller paths in live state for an NVMe subsystem.
+# TYPE node_nvmesubsystem_paths_live gauge
+node_nvmesubsystem_paths_live{subsystem="nvme-subsys0"} 3
+`
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level:     slog.LevelError,
+		AddSource: true,
+	}))
+	c, err := newTestNVMeSubsystemCollector(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(c)
+
+	err = testutil.GatherAndCompare(reg, strings.NewReader(testcase))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNVMeSubsystemNoDevices(t *testing.T) {
+	*sysPath = t.TempDir()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	coll, err := NewNVMeSubsystemCollector(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := coll.(*nvmeSubsystemCollector)
+
+	ch := make(chan prometheus.Metric, 200)
+	err = c.Update(ch)
+	close(ch)
+
+	if err != ErrNoData {
+		t.Fatalf("expected ErrNoData, got %v", err)
+	}
+}
+
+func TestNormalizeControllerState(t *testing.T) {
+	tests := []struct {
+		raw      string
+		expected string
+	}{
+		{"live", "live"},
+		{"connecting", "connecting"},
+		{"resetting", "resetting"},
+		{"dead", "dead"},
+		{"deleting", "deleting"},
+		{"deleting (no IO)", "deleting"},
+		{"new", "new"},
+		{"", "unknown"},
+		{"something-else", "unknown"},
+	}
+	for _, tc := range tests {
+		got := normalizeControllerState(tc.raw)
+		if got != tc.expected {
+			t.Errorf("normalizeControllerState(%q) = %q, want %q", tc.raw, got, tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add a new disabled-by-default `nvmesubsystem` collector that reads
`/sys/class/nvme-subsystem/` to expose NVMe over Fabrics subsystem
path health metrics.

## Exposed metrics

| Metric | Type | Labels | Description |
|--------|------|--------|-------------|
| node_nvmesubsystem_info | Gauge (info) | subsystem, nqn, model, serial, iopolicy | Subsystem identity |
| node_nvmesubsystem_namespace_info | Gauge (info) | subsystem, device | Maps namespace block device to subsystem |
| node_nvmesubsystem_paths | Gauge | subsystem | Total controller paths |
| node_nvmesubsystem_paths_live | Gauge | subsystem | Controller paths in live state |
| node_nvmesubsystem_path_state | Gauge | subsystem, controller, transport, state | Per-controller state |

The `namespace_info` metric enables precise correlation between NVMe
block devices (e.g. `nvme0n1`) and their parent subsystems, which is
needed for workload-aware storage path health alerting in Kubernetes
environments.

## Enable

```
--collector.nvmesubsystem
```

No special permissions required — reads only world-readable sysfs attributes.

## Dependencies

- Stacked on #3715 (`build(deps): bump prometheus/procfs to v0.21.1`)
- sysfs: add NVMeSubsystemClass for NVMe-oF subsystem parsing procfs#797

## Test plan

- [x] Unit tests with `testutil.GatherAndCompare` for all metrics
- [x] Tests for no-devices case
- [x] State normalization tests (`normalizeControllerState`)
- [x] End-to-end test passing