### PR TITLE
collector: add dmmultipath collector for DM-multipath sysfs metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ cpu | Exposes CPU statistics | Darwin, Dragonfly, FreeBSD, Linux, Solaris, OpenB
 cpufreq | Exposes CPU frequency statistics | Linux, Solaris
 diskstats | Exposes disk I/O statistics. | Darwin, Linux, OpenBSD
 dmi | Expose Desktop Management Interface (DMI) info from `/sys/class/dmi/id/` | Linux
+dmmultipath | Exposes DM-multipath device and path metrics from `/sys/block/dm-*`. | Linux
 edac | Exposes error detection and correction statistics. | Linux
 entropy | Exposes available entropy. | Linux
 exec | Exposes execution statistics. | Dragonfly, FreeBSD

--- a/collector/dmmultipath_linux.go
+++ b/collector/dmmultipath_linux.go
@@ -1,0 +1,136 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nodmmultipath
+
+package collector
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/procfs/blockdevice"
+)
+
+// isPathActive returns true for device states that indicate a healthy,
+// usable path. This covers SCSI ("running") and NVMe ("live") devices.
+func isPathActive(state string) bool {
+	return state == "running" || state == "live"
+}
+
+func init() {
+	registerCollector("dmmultipath", defaultEnabled, NewDMMultipathCollector)
+}
+
+var (
+	dmmultipathDeviceLabels = []string{"device", "sysfs_name"}
+
+	dmmultipathDeviceInfo = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dmmultipath", "device_info"),
+		"Non-numeric information about a DM-multipath device.",
+		[]string{"device", "sysfs_name", "uuid"}, nil,
+	)
+	dmmultipathDeviceActive = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dmmultipath", "device_active"),
+		"Whether the multipath device-mapper device is active (1) or suspended (0).",
+		dmmultipathDeviceLabels, nil,
+	)
+	dmmultipathDeviceSizeBytes = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dmmultipath", "device_size_bytes"),
+		"Size of the multipath device in bytes, read from /sys/block/<dm>/size.",
+		dmmultipathDeviceLabels, nil,
+	)
+	dmmultipathDevicePaths = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dmmultipath", "device_paths"),
+		"Number of paths for a multipath device.",
+		dmmultipathDeviceLabels, nil,
+	)
+	dmmultipathDevicePathsActive = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dmmultipath", "device_paths_active"),
+		"Number of paths in active state (SCSI running or NVMe live) for a multipath device.",
+		dmmultipathDeviceLabels, nil,
+	)
+	dmmultipathDevicePathsFailed = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dmmultipath", "device_paths_failed"),
+		"Number of paths not in active state for a multipath device.",
+		dmmultipathDeviceLabels, nil,
+	)
+	dmmultipathPathState = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dmmultipath", "path_state"),
+		"Reports the underlying device state for a multipath path, as read from /sys/block/<dev>/device/state.",
+		[]string{"device", "path", "state"}, nil,
+	)
+)
+
+type dmMultipathCollector struct {
+	fs     blockdevice.FS
+	logger *slog.Logger
+}
+
+// NewDMMultipathCollector returns a new Collector exposing Device Mapper
+// multipath device metrics from /sys/block/dm-*.
+func NewDMMultipathCollector(logger *slog.Logger) (Collector, error) {
+	fs, err := blockdevice.NewFS(*procPath, *sysPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open sysfs: %w", err)
+	}
+
+	return &dmMultipathCollector{
+		fs:     fs,
+		logger: logger,
+	}, nil
+}
+
+func (c *dmMultipathCollector) Update(ch chan<- prometheus.Metric) error {
+	devices, err := c.fs.DMMultipathDevices()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrPermission) {
+			c.logger.Debug("Could not read DM-multipath devices", "err", err)
+			return ErrNoData
+		}
+		return fmt.Errorf("failed to scan DM-multipath devices: %w", err)
+	}
+
+	for _, dev := range devices {
+		ch <- prometheus.MustNewConstMetric(dmmultipathDeviceInfo, prometheus.GaugeValue, 1,
+			dev.Name, dev.SysfsName, dev.UUID)
+
+		active := 0.0
+		if !dev.Suspended {
+			active = 1.0
+		}
+		ch <- prometheus.MustNewConstMetric(dmmultipathDeviceActive, prometheus.GaugeValue, active, dev.Name, dev.SysfsName)
+		ch <- prometheus.MustNewConstMetric(dmmultipathDeviceSizeBytes, prometheus.GaugeValue, float64(dev.SizeBytes), dev.Name, dev.SysfsName)
+
+		var activePaths, failedPaths float64
+		for _, p := range dev.Paths {
+			if isPathActive(p.State) {
+				activePaths++
+			} else {
+				failedPaths++
+			}
+
+			ch <- prometheus.MustNewConstMetric(dmmultipathPathState, prometheus.GaugeValue, 1,
+				dev.Name, p.Device, p.State)
+		}
+
+		ch <- prometheus.MustNewConstMetric(dmmultipathDevicePaths, prometheus.GaugeValue, float64(len(dev.Paths)), dev.Name, dev.SysfsName)
+		ch <- prometheus.MustNewConstMetric(dmmultipathDevicePathsActive, prometheus.GaugeValue, activePaths, dev.Name, dev.SysfsName)
+		ch <- prometheus.MustNewConstMetric(dmmultipathDevicePathsFailed, prometheus.GaugeValue, failedPaths, dev.Name, dev.SysfsName)
+	}
+
+	return nil
+}

--- a/collector/dmmultipath_linux_test.go
+++ b/collector/dmmultipath_linux_test.go
@@ -1,0 +1,144 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nodmmultipath
+
+package collector
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+type testDMMultipathCollector struct {
+	mc Collector
+}
+
+func (c testDMMultipathCollector) Collect(ch chan<- prometheus.Metric) {
+	c.mc.Update(ch)
+}
+
+func (c testDMMultipathCollector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(c, ch)
+}
+
+func newTestDMMultipathCollector(logger *slog.Logger) (prometheus.Collector, error) {
+	mc, err := NewDMMultipathCollector(logger)
+	if err != nil {
+		return testDMMultipathCollector{}, err
+	}
+	return &testDMMultipathCollector{mc}, nil
+}
+
+func TestDMMultipathMetrics(t *testing.T) {
+	*procPath = "fixtures/proc"
+	*sysPath = "fixtures/sys"
+
+	testcase := `# HELP node_dmmultipath_device_active Whether the multipath device-mapper device is active (1) or suspended (0).
+# TYPE node_dmmultipath_device_active gauge
+node_dmmultipath_device_active{device="mpathA",sysfs_name="dm-5"} 1
+node_dmmultipath_device_active{device="mpathB",sysfs_name="dm-6"} 1
+# HELP node_dmmultipath_device_info Non-numeric information about a DM-multipath device.
+# TYPE node_dmmultipath_device_info gauge
+node_dmmultipath_device_info{device="mpathA",sysfs_name="dm-5",uuid="mpath-3600508b1001c1234567890abcdef1234"} 1
+node_dmmultipath_device_info{device="mpathB",sysfs_name="dm-6",uuid="mpath-3600508b1001cabcdef4567890123456"} 1
+# HELP node_dmmultipath_device_paths Number of paths for a multipath device.
+# TYPE node_dmmultipath_device_paths gauge
+node_dmmultipath_device_paths{device="mpathA",sysfs_name="dm-5"} 4
+node_dmmultipath_device_paths{device="mpathB",sysfs_name="dm-6"} 2
+# HELP node_dmmultipath_device_paths_active Number of paths in active state (SCSI running or NVMe live) for a multipath device.
+# TYPE node_dmmultipath_device_paths_active gauge
+node_dmmultipath_device_paths_active{device="mpathA",sysfs_name="dm-5"} 3
+node_dmmultipath_device_paths_active{device="mpathB",sysfs_name="dm-6"} 2
+# HELP node_dmmultipath_device_paths_failed Number of paths not in active state for a multipath device.
+# TYPE node_dmmultipath_device_paths_failed gauge
+node_dmmultipath_device_paths_failed{device="mpathA",sysfs_name="dm-5"} 1
+node_dmmultipath_device_paths_failed{device="mpathB",sysfs_name="dm-6"} 0
+# HELP node_dmmultipath_device_size_bytes Size of the multipath device in bytes, read from /sys/block/<dm>/size.
+# TYPE node_dmmultipath_device_size_bytes gauge
+node_dmmultipath_device_size_bytes{device="mpathA",sysfs_name="dm-5"} 5.36870912e+10
+node_dmmultipath_device_size_bytes{device="mpathB",sysfs_name="dm-6"} 1.073741824e+11
+# HELP node_dmmultipath_path_state Reports the underlying device state for a multipath path, as read from /sys/block/<dev>/device/state.
+# TYPE node_dmmultipath_path_state gauge
+node_dmmultipath_path_state{device="mpathA",path="sdi",state="running"} 1
+node_dmmultipath_path_state{device="mpathA",path="sdj",state="running"} 1
+node_dmmultipath_path_state{device="mpathA",path="sdk",state="running"} 1
+node_dmmultipath_path_state{device="mpathA",path="sdl",state="offline"} 1
+node_dmmultipath_path_state{device="mpathB",path="sdm",state="running"} 1
+node_dmmultipath_path_state{device="mpathB",path="sdn",state="running"} 1
+`
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level:     slog.LevelError,
+		AddSource: true,
+	}))
+	c, err := newTestDMMultipathCollector(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(c)
+
+	err = testutil.GatherAndCompare(reg, strings.NewReader(testcase))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDMMultipathNoDevices(t *testing.T) {
+	*procPath = "fixtures/proc"
+	*sysPath = t.TempDir()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	coll, err := NewDMMultipathCollector(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := coll.(*dmMultipathCollector)
+
+	ch := make(chan prometheus.Metric, 200)
+	err = c.Update(ch)
+	close(ch)
+
+	if err != ErrNoData {
+		t.Fatalf("expected ErrNoData, got %v", err)
+	}
+}
+
+func TestIsPathActive(t *testing.T) {
+	tests := []struct {
+		state  string
+		active bool
+	}{
+		{"running", true},
+		{"live", true},
+		{"offline", false},
+		{"blocked", false},
+		{"transport-offline", false},
+		{"dead", false},
+		{"unknown", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		got := isPathActive(tc.state)
+		if got != tc.active {
+			t.Errorf("isPathActive(%q) = %v, want %v", tc.state, got, tc.active)
+		}
+	}
+}

--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -1284,6 +1284,38 @@ node_disk_written_bytes_total{device="vda"} 1.0938236928e+11
 # HELP node_dmi_info A metric with a constant '1' value labeled by bios_date, bios_release, bios_vendor, bios_version, board_asset_tag, board_name, board_serial, board_vendor, board_version, chassis_asset_tag, chassis_serial, chassis_vendor, chassis_version, product_family, product_name, product_serial, product_sku, product_uuid, product_version, system_vendor if provided by DMI.
 # TYPE node_dmi_info gauge
 node_dmi_info{bios_date="04/12/2021",bios_release="2.2",bios_vendor="Dell Inc.",bios_version="2.2.4",board_name="07PXPY",board_serial=".7N62AI2.GRTCL6944100GP.",board_vendor="Dell Inc.",board_version="A01",chassis_asset_tag="",chassis_serial="7N62AI2",chassis_vendor="Dell Inc.",chassis_version="",product_family="PowerEdge",product_name="PowerEdge R6515",product_serial="7N62AI2",product_sku="SKU=NotProvided;ModelName=PowerEdge R6515",product_uuid="83340ca8-cb49-4474-8c29-d2088ca84dd9",product_version="�[�",system_vendor="Dell Inc."} 1
+# HELP node_dmmultipath_device_active Whether the multipath device-mapper device is active (1) or suspended (0).
+# TYPE node_dmmultipath_device_active gauge
+node_dmmultipath_device_active{device="mpathA",sysfs_name="dm-5"} 1
+node_dmmultipath_device_active{device="mpathB",sysfs_name="dm-6"} 1
+# HELP node_dmmultipath_device_info Non-numeric information about a DM-multipath device.
+# TYPE node_dmmultipath_device_info gauge
+node_dmmultipath_device_info{device="mpathA",sysfs_name="dm-5",uuid="mpath-3600508b1001c1234567890abcdef1234"} 1
+node_dmmultipath_device_info{device="mpathB",sysfs_name="dm-6",uuid="mpath-3600508b1001cabcdef4567890123456"} 1
+# HELP node_dmmultipath_device_paths Number of paths for a multipath device.
+# TYPE node_dmmultipath_device_paths gauge
+node_dmmultipath_device_paths{device="mpathA",sysfs_name="dm-5"} 4
+node_dmmultipath_device_paths{device="mpathB",sysfs_name="dm-6"} 2
+# HELP node_dmmultipath_device_paths_active Number of paths in active state (SCSI running or NVMe live) for a multipath device.
+# TYPE node_dmmultipath_device_paths_active gauge
+node_dmmultipath_device_paths_active{device="mpathA",sysfs_name="dm-5"} 3
+node_dmmultipath_device_paths_active{device="mpathB",sysfs_name="dm-6"} 2
+# HELP node_dmmultipath_device_paths_failed Number of paths not in active state for a multipath device.
+# TYPE node_dmmultipath_device_paths_failed gauge
+node_dmmultipath_device_paths_failed{device="mpathA",sysfs_name="dm-5"} 1
+node_dmmultipath_device_paths_failed{device="mpathB",sysfs_name="dm-6"} 0
+# HELP node_dmmultipath_device_size_bytes Size of the multipath device in bytes, read from /sys/block/<dm>/size.
+# TYPE node_dmmultipath_device_size_bytes gauge
+node_dmmultipath_device_size_bytes{device="mpathA",sysfs_name="dm-5"} 5.36870912e+10
+node_dmmultipath_device_size_bytes{device="mpathB",sysfs_name="dm-6"} 1.073741824e+11
+# HELP node_dmmultipath_path_state Reports the underlying device state for a multipath path, as read from /sys/block/<dev>/device/state.
+# TYPE node_dmmultipath_path_state gauge
+node_dmmultipath_path_state{device="mpathA",path="sdi",state="running"} 1
+node_dmmultipath_path_state{device="mpathA",path="sdj",state="running"} 1
+node_dmmultipath_path_state{device="mpathA",path="sdk",state="running"} 1
+node_dmmultipath_path_state{device="mpathA",path="sdl",state="offline"} 1
+node_dmmultipath_path_state{device="mpathB",path="sdm",state="running"} 1
+node_dmmultipath_path_state{device="mpathB",path="sdn",state="running"} 1
 # HELP node_drbd_activitylog_writes_total Number of updates of the activity log area of the meta data.
 # TYPE node_drbd_activitylog_writes_total counter
 node_drbd_activitylog_writes_total{device="drbd1"} 1100
@@ -3659,6 +3691,7 @@ node_scrape_collector_success{collector="cpu_vulnerabilities"} 1
 node_scrape_collector_success{collector="cpufreq"} 1
 node_scrape_collector_success{collector="diskstats"} 1
 node_scrape_collector_success{collector="dmi"} 1
+node_scrape_collector_success{collector="dmmultipath"} 1
 node_scrape_collector_success{collector="drbd"} 1
 node_scrape_collector_success{collector="edac"} 1
 node_scrape_collector_success{collector="entropy"} 1

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -1316,6 +1316,38 @@ node_disk_written_bytes_total{device="vda"} 1.0938236928e+11
 # HELP node_dmi_info A metric with a constant '1' value labeled by bios_date, bios_release, bios_vendor, bios_version, board_asset_tag, board_name, board_serial, board_vendor, board_version, chassis_asset_tag, chassis_serial, chassis_vendor, chassis_version, product_family, product_name, product_serial, product_sku, product_uuid, product_version, system_vendor if provided by DMI.
 # TYPE node_dmi_info gauge
 node_dmi_info{bios_date="04/12/2021",bios_release="2.2",bios_vendor="Dell Inc.",bios_version="2.2.4",board_name="07PXPY",board_serial=".7N62AI2.GRTCL6944100GP.",board_vendor="Dell Inc.",board_version="A01",chassis_asset_tag="",chassis_serial="7N62AI2",chassis_vendor="Dell Inc.",chassis_version="",product_family="PowerEdge",product_name="PowerEdge R6515",product_serial="7N62AI2",product_sku="SKU=NotProvided;ModelName=PowerEdge R6515",product_uuid="83340ca8-cb49-4474-8c29-d2088ca84dd9",product_version="�[�",system_vendor="Dell Inc."} 1
+# HELP node_dmmultipath_device_active Whether the multipath device-mapper device is active (1) or suspended (0).
+# TYPE node_dmmultipath_device_active gauge
+node_dmmultipath_device_active{device="mpathA",sysfs_name="dm-5"} 1
+node_dmmultipath_device_active{device="mpathB",sysfs_name="dm-6"} 1
+# HELP node_dmmultipath_device_info Non-numeric information about a DM-multipath device.
+# TYPE node_dmmultipath_device_info gauge
+node_dmmultipath_device_info{device="mpathA",sysfs_name="dm-5",uuid="mpath-3600508b1001c1234567890abcdef1234"} 1
+node_dmmultipath_device_info{device="mpathB",sysfs_name="dm-6",uuid="mpath-3600508b1001cabcdef4567890123456"} 1
+# HELP node_dmmultipath_device_paths Number of paths for a multipath device.
+# TYPE node_dmmultipath_device_paths gauge
+node_dmmultipath_device_paths{device="mpathA",sysfs_name="dm-5"} 4
+node_dmmultipath_device_paths{device="mpathB",sysfs_name="dm-6"} 2
+# HELP node_dmmultipath_device_paths_active Number of paths in active state (SCSI running or NVMe live) for a multipath device.
+# TYPE node_dmmultipath_device_paths_active gauge
+node_dmmultipath_device_paths_active{device="mpathA",sysfs_name="dm-5"} 3
+node_dmmultipath_device_paths_active{device="mpathB",sysfs_name="dm-6"} 2
+# HELP node_dmmultipath_device_paths_failed Number of paths not in active state for a multipath device.
+# TYPE node_dmmultipath_device_paths_failed gauge
+node_dmmultipath_device_paths_failed{device="mpathA",sysfs_name="dm-5"} 1
+node_dmmultipath_device_paths_failed{device="mpathB",sysfs_name="dm-6"} 0
+# HELP node_dmmultipath_device_size_bytes Size of the multipath device in bytes, read from /sys/block/<dm>/size.
+# TYPE node_dmmultipath_device_size_bytes gauge
+node_dmmultipath_device_size_bytes{device="mpathA",sysfs_name="dm-5"} 5.36870912e+10
+node_dmmultipath_device_size_bytes{device="mpathB",sysfs_name="dm-6"} 1.073741824e+11
+# HELP node_dmmultipath_path_state Reports the underlying device state for a multipath path, as read from /sys/block/<dev>/device/state.
+# TYPE node_dmmultipath_path_state gauge
+node_dmmultipath_path_state{device="mpathA",path="sdi",state="running"} 1
+node_dmmultipath_path_state{device="mpathA",path="sdj",state="running"} 1
+node_dmmultipath_path_state{device="mpathA",path="sdk",state="running"} 1
+node_dmmultipath_path_state{device="mpathA",path="sdl",state="offline"} 1
+node_dmmultipath_path_state{device="mpathB",path="sdm",state="running"} 1
+node_dmmultipath_path_state{device="mpathB",path="sdn",state="running"} 1
 # HELP node_drbd_activitylog_writes_total Number of updates of the activity log area of the meta data.
 # TYPE node_drbd_activitylog_writes_total counter
 node_drbd_activitylog_writes_total{device="drbd1"} 1100
@@ -3691,6 +3723,7 @@ node_scrape_collector_success{collector="cpu_vulnerabilities"} 1
 node_scrape_collector_success{collector="cpufreq"} 1
 node_scrape_collector_success{collector="diskstats"} 1
 node_scrape_collector_success{collector="dmi"} 1
+node_scrape_collector_success{collector="dmmultipath"} 1
 node_scrape_collector_success{collector="drbd"} 1
 node_scrape_collector_success{collector="edac"} 1
 node_scrape_collector_success{collector="entropy"} 1

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -826,6 +826,174 @@ Lines: 1
 none
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-5
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-5/dm
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-5/dm/name
+Lines: 1
+mpathAEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-5/dm/suspended
+Lines: 1
+0EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-5/dm/uuid
+Lines: 1
+mpath-3600508b1001c1234567890abcdef1234EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-5/size
+Lines: 1
+104857600EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-5/slaves
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-5/slaves/sdi
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-5/slaves/sdj
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-5/slaves/sdk
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-5/slaves/sdl
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-6
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-6/dm
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-6/dm/name
+Lines: 1
+mpathBEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-6/dm/suspended
+Lines: 1
+0EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-6/dm/uuid
+Lines: 1
+mpath-3600508b1001cabcdef4567890123456EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-6/size
+Lines: 1
+209715200EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-6/slaves
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-6/slaves/sdm
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-6/slaves/sdn
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-7
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-7/dm
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-7/dm/name
+Lines: 1
+vg0-rootEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-7/dm/suspended
+Lines: 1
+0EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-7/dm/uuid
+Lines: 1
+LVM-abcdef1234567890abcdef1234567890EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-7/size
+Lines: 1
+41943040EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/sdi
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/sdi/device
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/sdi/device/state
+Lines: 1
+runningEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/sdj
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/sdj/device
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/sdj/device/state
+Lines: 1
+runningEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/sdk
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/sdk/device
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/sdk/device/state
+Lines: 1
+runningEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/sdl
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/sdl/device
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/sdl/device/state
+Lines: 1
+offlineEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/sdm
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/sdm/device
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/sdm/device/state
+Lines: 1
+runningEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/sdn
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/sdn/device
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/sdn/device/state
+Lines: 1
+runningEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/bus
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
## Summary

Add a new disabled-by-default `dmmultipath` collector that reads
`/sys/block/dm-*/dm/` to expose Device Mapper multipath device
health metrics.

## Exposed metrics

| Metric | Type | Labels | Description |
|--------|------|--------|-------------|
| node_dmmultipath_info | Gauge (info) | device, name, uuid, vendor, revision | Device identity |
| node_dmmultipath_paths | Gauge | device | Total paths |
| node_dmmultipath_active_paths | Gauge | device | Active paths |
| node_dmmultipath_path_state | Gauge | device, path, state | Per-path state |
| node_dmmultipath_device_state | Gauge | device, state | Device state |

## Enable

```
--collector.dmmultipath
```

No special permissions required — reads only world-readable sysfs attributes.

## Dependencies

- Stacked on #3715 (`build(deps): bump prometheus/procfs to v0.21.1`)
- Depends on prometheus/procfs#796

## Test plan

- [x] Unit tests with `testutil.GatherAndCompare` for all metrics
- [x] Tests for no-devices case
- [x] End-to-end test passing