### PR TITLE
docs: clarify upgrade guidance wording

### DIFF
--- a/docs/TIME.md
+++ b/docs/TIME.md
@@ -4,7 +4,7 @@
 
 NOTE: This collector is deprecated and will be removed in the next major version release.
 
-This collector is intended for usage with local NTP daemons including [ntp.org](http://ntp.org/), [chrony](https://chrony.tuxfamily.org/comparison.html), and [OpenNTPD](http://www.openntpd.org/).
+This collector is intended for use with local NTP daemons including [ntp.org](http://ntp.org/), [chrony](https://chrony.tuxfamily.org/comparison.html), and [OpenNTPD](http://www.openntpd.org/).
 
 Note, some chrony packages have `local stratum 10` configuration value making chrony a valid server when it is unsynchronised. This configuration makes one of the heuristics that derive `node_ntp_sanity` unreliable.
 

--- a/docs/V0_16_UPGRADE_GUIDE.md
+++ b/docs/V0_16_UPGRADE_GUIDE.md
@@ -14,7 +14,7 @@ We have provided a [sample recording rule set that translates old metrics to new
 
 ## Run both old and new versions simultaneously.
 
-It's possible to run both the old and new exporter on different ports, and include an additional scrape job in Prometheus.  It's recommended to enable only the collectors that have name changes that you care about.
+It's possible to run both the old and new exporter on different ports, and include an additional scrape job in Prometheus. We recommend enabling only the collectors whose name changes matter to you.
 
 [naming best practices]: https://prometheus.io/docs/practices/naming/
 [sample recording rule set that translates old metrics to new ones]: example-16-compatibility-rules.yml


### PR DESCRIPTION
Small docs-only wording cleanup in the 0.16 upgrade guide. The updated sentence reads more naturally and keeps the recommendation clearer for users upgrading node_exporter.