### PR TITLE
docs: clarify cloud native wording

### DIFF
--- a/docs/TIME.md
+++ b/docs/TIME.md
@@ -4,7 +4,7 @@
 
 NOTE: This collector is deprecated and will be removed in the next major version release.
 
-This collector is intended for usage with local NTP daemons including [ntp.org](http://ntp.org/), [chrony](https://chrony.tuxfamily.org/comparison.html), and [OpenNTPD](http://www.openntpd.org/).
+This collector is intended for use with local NTP daemons including [ntp.org](http://ntp.org/), [chrony](https://chrony.tuxfamily.org/comparison.html), and [OpenNTPD](http://www.openntpd.org/).
 
 Note, some chrony packages have `local stratum 10` configuration value making chrony a valid server when it is unsynchronised. This configuration makes one of the heuristics that derive `node_ntp_sanity` unreliable.
 

--- a/docs/V0_16_UPGRADE_GUIDE.md
+++ b/docs/V0_16_UPGRADE_GUIDE.md
@@ -14,7 +14,7 @@ We have provided a [sample recording rule set that translates old metrics to new
 
 ## Run both old and new versions simultaneously.
 
-It's possible to run both the old and new exporter on different ports, and include an additional scrape job in Prometheus.  It's recommended to enable only the collectors that have name changes that you care about.
+It's possible to run both the old and new exporter on different ports, and include an additional scrape job in Prometheus. We recommend enabling only the collectors whose name changes matter to you.
 
 [naming best practices]: https://prometheus.io/docs/practices/naming/
 [sample recording rule set that translates old metrics to new ones]: example-16-compatibility-rules.yml

--- a/docs/node-mixin/config.libsonnet
+++ b/docs/node-mixin/config.libsonnet
@@ -39,7 +39,7 @@
 
     // Some of the alerts are meant to fire if a critical failure of a
     // node is imminent (e.g. the disk is about to run full). In a
-    // true “cloud native” setup, failures of a single node should be
+    // true “cloud native” deployment, failures of a single node should be
     // tolerated. Hence, even imminent failure of a single node is no
     // reason to create a paging alert. However, in practice there are
     // still many situations where operators like to get paged in time


### PR DESCRIPTION
Small docs-only wording cleanup in the node mixin config. This updates a comment to use clearer deployment language without changing behavior.