### PR TITLE
collector/thermal_zone: skip zones with read errors instead of failing

### DIFF
--- a/collector/thermal_zone_linux.go
+++ b/collector/thermal_zone_linux.go
@@ -79,6 +79,11 @@ func (c *thermalZoneCollector) Update(ch chan<- prometheus.Metric) error {
 	}
 
 	for _, stats := range thermalZones {
+		if stats.ReadErrors != nil {
+			c.logger.Debug("Could not read thermal zone", "zone", stats.Name, "err", stats.ReadErrors)
+			continue
+		}
+
 		ch <- prometheus.MustNewConstMetric(
 			c.zoneTemp,
 			prometheus.GaugeValue,

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
 	github.com/prometheus/exporter-toolkit v0.16.0
-	github.com/prometheus/procfs v0.20.1
+	github.com/prometheus/procfs v0.20.2-0.20260315100628-465fd94215fd
 	github.com/safchain/ethtool v0.7.0
 	golang.org/x/sys v0.42.0
 	howett.net/plist v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/exporter-toolkit v0.16.0 h1:xT/j7L2XKF+VJd6B4fpUw6xWabHrSmsUf6mYmFqyu0s=
 github.com/prometheus/exporter-toolkit v0.16.0/go.mod h1:d1EL8Z9674xQe/iWhwP2wDyCEoBPbXVeqDbqAUsgJWY=
-github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
-github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
+github.com/prometheus/procfs v0.20.2-0.20260315100628-465fd94215fd h1:BMGKlIvKVFQMeQxTthKyf1bHmOoqiY0T6LiXR6pxHiQ=
+github.com/prometheus/procfs v0.20.2-0.20260315100628-465fd94215fd/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
 github.com/safchain/ethtool v0.7.0 h1:rlJzfDetsVvT61uz8x1YIcFn12akMfuPulHtZjtb7Is=
 github.com/safchain/ethtool v0.7.0/go.mod h1:MenQKEjXdfkjD3mp2QdCk8B/hwvkrlOTm/FD4gTpFxQ=
 github.com/siebenmann/go-kstat v0.0.0-20210513183136-173c9b0a9973 h1:GfSdC6wKfTGcgCS7BtzF5694Amne1pGCSTY252WhlEY=


### PR DESCRIPTION
Fixes #2980.

When a thermal zone becomes unreadable (e.g., device removed at runtime),
the entire thermal_zone collector fails. Since prometheus/procfs#794 added
a `ReadErrors` field to `ClassThermalZoneStats`, we can check it per-zone
and skip zones with errors while continuing to report healthy ones.

Zones with read errors are logged at debug level and skipped.

Depends on unreleased procfs (pseudo-version for procfs#794). Can wait
for a tagged release if preferred.