### PR TITLE
Add error counts / dimm channel for edac collector 

### DIFF
--- a/collector/edac_linux.go
+++ b/collector/edac_linux.go
@@ -30,7 +30,7 @@ const (
 
 var (
 	edacMemControllerRE = regexp.MustCompile(`.*devices/system/edac/mc/mc([0-9]*)`)
-	edacMemCsrowRE      = regexp.MustCompile(`.*devices/system/edac/mc/mc[0-9]*/csrow([0-9]*)`)
+	edacMemCsrowRE      = regexp.MustCompile(`.*devices/system/edac/mc/mc([0-9]*)/csrow([0-9]*)`)
 )
 
 type edacCollector struct {
@@ -47,24 +47,26 @@ var (
 		"Total correctable memory errors.",
 		[]string{"controller"}, nil,
 	)
+
 	edacUeCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, edacSubsystem, "uncorrectable_errors_total"),
 		"Total uncorrectable memory errors.",
 		[]string{"controller"}, nil,
 	)
-	edacCsRowCECount = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, edacSubsystem, "csrow_correctable_errors_total"),
-		"Total correctable memory errors for this csrow.",
-		[]string{"controller", "csrow"}, nil,
+
+	edacChannelCECount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, edacSubsystem, "channel_correctable_errors_total"),
+		"Total correctable memory errors for this channel.",
+		[]string{"controller", "csrow", "channel", "dimm_label"}, nil,
 	)
-	edacCsRowUECount = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, edacSubsystem, "csrow_uncorrectable_errors_total"),
-		"Total uncorrectable memory errors for this csrow.",
-		[]string{"controller", "csrow"}, nil,
+
+	edacChannelUECount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, edacSubsystem, "channel_uncorrectable_errors_total"),
+		"Total uncorrectable memory errors for this channel.",
+		[]string{"controller", "csrow", "channel", "dimm_label"}, nil,
 	)
 )
 
-// NewEdacCollector returns a new Collector exposing edac stats.
 func NewEdacCollector(logger *slog.Logger) (Collector, error) {
 	return &edacCollector{
 		logger: logger,
@@ -76,68 +78,107 @@ func (c *edacCollector) Update(ch chan<- prometheus.Metric) error {
 	if err != nil {
 		return err
 	}
+
 	for _, controller := range memControllers {
 		controllerMatch := edacMemControllerRE.FindStringSubmatch(controller)
 		if controllerMatch == nil {
 			return fmt.Errorf("controller string didn't match regexp: %s", controller)
 		}
+
 		controllerNumber := controllerMatch[1]
 
+		// Controller CE count
 		value, err := readUintFromFile(filepath.Join(controller, "ce_count"))
 		if err != nil {
 			return fmt.Errorf("couldn't get ce_count for controller %s: %w", controllerNumber, err)
 		}
-		ch <- prometheus.MustNewConstMetric(
-			edacCeCount, prometheus.CounterValue, float64(value), controllerNumber)
 
-		value, err = readUintFromFile(filepath.Join(controller, "ce_noinfo_count"))
-		if err != nil {
-			return fmt.Errorf("couldn't get ce_noinfo_count for controller %s: %w", controllerNumber, err)
-		}
 		ch <- prometheus.MustNewConstMetric(
-			edacCsRowCECount, prometheus.CounterValue, float64(value), controllerNumber, "unknown")
+			edacCeCount,
+			prometheus.CounterValue,
+			float64(value),
+			controllerNumber,
+		)
 
+		// Controller UE count
 		value, err = readUintFromFile(filepath.Join(controller, "ue_count"))
 		if err != nil {
 			return fmt.Errorf("couldn't get ue_count for controller %s: %w", controllerNumber, err)
 		}
-		ch <- prometheus.MustNewConstMetric(
-			edacUeCount, prometheus.CounterValue, float64(value), controllerNumber)
 
-		value, err = readUintFromFile(filepath.Join(controller, "ue_noinfo_count"))
-		if err != nil {
-			return fmt.Errorf("couldn't get ue_noinfo_count for controller %s: %w", controllerNumber, err)
-		}
 		ch <- prometheus.MustNewConstMetric(
-			edacCsRowUECount, prometheus.CounterValue, float64(value), controllerNumber, "unknown")
+			edacUeCount,
+			prometheus.CounterValue,
+			float64(value),
+			controllerNumber,
+		)
 
-		// For each controller, walk the csrow directories.
 		csrows, err := filepath.Glob(controller + "/csrow[0-9]*")
 		if err != nil {
 			return err
 		}
+
 		for _, csrow := range csrows {
 			csrowMatch := edacMemCsrowRE.FindStringSubmatch(csrow)
 			if csrowMatch == nil {
 				return fmt.Errorf("csrow string didn't match regexp: %s", csrow)
 			}
-			csrowNumber := csrowMatch[1]
 
-			value, err = readUintFromFile(filepath.Join(csrow, "ce_count"))
-			if err != nil {
-				return fmt.Errorf("couldn't get ce_count for controller/csrow %s/%s: %w", controllerNumber, csrowNumber, err)
-			}
-			ch <- prometheus.MustNewConstMetric(
-				edacCsRowCECount, prometheus.CounterValue, float64(value), controllerNumber, csrowNumber)
+			csrowNumber := csrowMatch[2]
 
-			value, err = readUintFromFile(filepath.Join(csrow, "ue_count"))
+			channelFiles, err := filepath.Glob(csrow + "/ch[0-9]*_ce_count")
 			if err != nil {
-				return fmt.Errorf("couldn't get ue_count for controller/csrow %s/%s: %w", controllerNumber, csrowNumber, err)
+				return err
 			}
-			ch <- prometheus.MustNewConstMetric(
-				edacCsRowUECount, prometheus.CounterValue, float64(value), controllerNumber, csrowNumber)
+
+			for _, chFile := range channelFiles {
+				match := regexp.MustCompile(`ch([0-9]+)_ce_count`).FindStringSubmatch(filepath.Base(chFile))
+				if match == nil {
+					continue
+				}
+
+				channelNumber := match[1]
+
+				label := fmt.Sprintf(
+					"mc%s_csrow%s_channel%s",
+					controllerNumber,
+					csrowNumber,
+					channelNumber,
+				)
+
+				value, err := readUintFromFile(chFile)
+				if err == nil {
+					ch <- prometheus.MustNewConstMetric(
+						edacChannelCECount,
+						prometheus.CounterValue,
+						float64(value),
+						controllerNumber,
+						csrowNumber,
+						channelNumber,
+						label,
+					)
+				}
+
+				ueFile := filepath.Join(
+					csrow,
+					fmt.Sprintf("ch%s_ue_count", channelNumber),
+				)
+
+				value, err = readUintFromFile(ueFile)
+				if err == nil {
+					ch <- prometheus.MustNewConstMetric(
+						edacChannelUECount,
+						prometheus.CounterValue,
+						float64(value),
+						controllerNumber,
+						csrowNumber,
+						channelNumber,
+						label,
+					)
+				}
+			}
 		}
 	}
 
-	return err
+	return nil
 }

--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -1331,17 +1331,21 @@ node_drbd_remote_pending{device="drbd1"} 12346
 # HELP node_drbd_remote_unacknowledged Number of requests received by the peer via the network connection, but that have not yet been answered.
 # TYPE node_drbd_remote_unacknowledged gauge
 node_drbd_remote_unacknowledged{device="drbd1"} 12347
+# HELP node_edac_channel_correctable_errors_total Total correctable memory errors for this channel.
+# TYPE node_edac_channel_correctable_errors_total counter
+node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 0
+node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="1",dimm_label="mc0_csrow1_channel0"} 0
+node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="0",dimm_label="mc0_csrow0_channel1"} 0
+node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="1",dimm_label="mc0_csrow1_channel1"} 0
+# HELP node_edac_channel_uncorrectable_errors_total Total uncorrectable memory errors for this channel.
+# TYPE node_edac_channel_uncorrectable_errors_total counter
+node_edac_channel_uncorrectable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 2
+node_edac_channel_uncorrectable_errors_total{channel="0",controller="0",csrow="1",dimm_label="mc0_csrow1_channel0"} 2
+node_edac_channel_uncorrectable_errors_total{channel="1",controller="0",csrow="0",dimm_label="mc0_csrow0_channel1"} 2
+node_edac_channel_uncorrectable_errors_total{channel="1",controller="0",csrow="1",dimm_label="mc0_csrow1_channel1"} 2
 # HELP node_edac_correctable_errors_total Total correctable memory errors.
 # TYPE node_edac_correctable_errors_total counter
 node_edac_correctable_errors_total{controller="0"} 1
-# HELP node_edac_csrow_correctable_errors_total Total correctable memory errors for this csrow.
-# TYPE node_edac_csrow_correctable_errors_total counter
-node_edac_csrow_correctable_errors_total{controller="0",csrow="0"} 3
-node_edac_csrow_correctable_errors_total{controller="0",csrow="unknown"} 2
-# HELP node_edac_csrow_uncorrectable_errors_total Total uncorrectable memory errors for this csrow.
-# TYPE node_edac_csrow_uncorrectable_errors_total counter
-node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="0"} 4
-node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="unknown"} 6
 # HELP node_edac_uncorrectable_errors_total Total uncorrectable memory errors.
 # TYPE node_edac_uncorrectable_errors_total counter
 node_edac_uncorrectable_errors_total{controller="0"} 5

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -1363,17 +1363,21 @@ node_drbd_remote_pending{device="drbd1"} 12346
 # HELP node_drbd_remote_unacknowledged Number of requests received by the peer via the network connection, but that have not yet been answered.
 # TYPE node_drbd_remote_unacknowledged gauge
 node_drbd_remote_unacknowledged{device="drbd1"} 12347
+# HELP node_edac_channel_correctable_errors_total Total correctable memory errors for this channel.
+# TYPE node_edac_channel_correctable_errors_total counter
+node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 0
+node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="1",dimm_label="mc0_csrow1_channel0"} 0
+node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="0",dimm_label="mc0_csrow0_channel1"} 0
+node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="1",dimm_label="mc0_csrow1_channel1"} 0
+# HELP node_edac_channel_uncorrectable_errors_total Total uncorrectable memory errors for this channel.
+# TYPE node_edac_channel_uncorrectable_errors_total counter
+node_edac_channel_uncorrectable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 2
+node_edac_channel_uncorrectable_errors_total{channel="0",controller="0",csrow="1",dimm_label="mc0_csrow1_channel0"} 2
+node_edac_channel_uncorrectable_errors_total{channel="1",controller="0",csrow="0",dimm_label="mc0_csrow0_channel1"} 2
+node_edac_channel_uncorrectable_errors_total{channel="1",controller="0",csrow="1",dimm_label="mc0_csrow1_channel1"} 2
 # HELP node_edac_correctable_errors_total Total correctable memory errors.
 # TYPE node_edac_correctable_errors_total counter
 node_edac_correctable_errors_total{controller="0"} 1
-# HELP node_edac_csrow_correctable_errors_total Total correctable memory errors for this csrow.
-# TYPE node_edac_csrow_correctable_errors_total counter
-node_edac_csrow_correctable_errors_total{controller="0",csrow="0"} 3
-node_edac_csrow_correctable_errors_total{controller="0",csrow="unknown"} 2
-# HELP node_edac_csrow_uncorrectable_errors_total Total uncorrectable memory errors for this csrow.
-# TYPE node_edac_csrow_uncorrectable_errors_total counter
-node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="0"} 4
-node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="unknown"} 6
 # HELP node_edac_uncorrectable_errors_total Total uncorrectable memory errors.
 # TYPE node_edac_uncorrectable_errors_total counter
 node_edac_uncorrectable_errors_total{controller="0"} 5

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -9174,9 +9174,52 @@ Mode: 644
 Directory: sys/devices/system/edac/mc/mc0/csrow0
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch0_ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/system/edac/mc/mc0/csrow1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch0_ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch1_ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch1_ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/csrow0/ce_count
 Lines: 1
 3
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch0_ue_count
+Lines: 1
+2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch0_ue_count
+Lines: 1
+2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch1_ue_count
+Lines: 1
+2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch1_ue_count
+Lines: 1
+2
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/csrow0/ue_count
@@ -9192,6 +9235,26 @@ Mode: 644
 Path: sys/devices/system/edac/mc/mc0/ue_noinfo_count
 Lines: 1
 6
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch0_dimm_label
+Lines: 1
+mc0csrow0channel0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch1_dimm_label
+Lines: 1
+mc0csrow0channel1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch0_dimm_label
+Lines: 1
+mc0csrow1channel0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch1_dimm_label
+Lines: 1
+mc0csrow1channel1
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/devices/system/node


### PR DESCRIPTION
```# HELP node_edac_channel_correctable_errors_total Total correctable memory errors for this channel.
# TYPE node_edac_channel_correctable_errors_total counter
node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 0
node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="1",dimm_label="mc0_csrow1_channel0"} 0
node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="2",dimm_label="mc0_csrow2_channel0"} 0
node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="3",dimm_label="mc0_csrow3_channel0"} 0
node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="0",dimm_label="mc0_csrow0_channel1"} 0
node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="1",dimm_label="mc0_csrow1_channel1"} 0
node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="2",dimm_label="mc0_csrow2_channel1"} 0
node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="3",dimm_label="mc0_csrow3_channel1"} 0
node_edac_channel_correctable_errors_total{channel="2",controller="0",csrow="0",dimm_label="mc0_csrow0_channel2"} 0
node_edac_channel_correctable_errors_total{channel="2",controller="0",csrow="1",dimm_label="mc0_csrow1_channel2"} 0
node_edac_channel_correctable_errors_total{channel="2",controller="0",csrow="2",dimm_label="mc0_csrow2_channel2"} 123
node_edac_channel_correctable_errors_total{channel="2",controller="0",csrow="3",dimm_label="mc0_csrow3_channel2"} 0
node_edac_channel_correctable_errors_total{channel="3",controller="0",csrow="0",dimm_label="mc0_csrow0_channel3"} 0
node_edac_channel_correctable_errors_total{channel="3",controller="0",csrow="1",dimm_label="mc0_csrow1_channel3"} 0
node_edac_channel_correctable_errors_total{channel="3",controller="0",csrow="2",dimm_label="mc0_csrow2_channel3"} 0
node_edac_channel_correctable_errors_total{channel="3",controller="0",csrow="3",dimm_label="mc0_csrow3_channel3"} 0
node_edac_channel_correctable_errors_total{channel="4",controller="0",csrow="0",dimm_label="mc0_csrow0_channel4"} 0
node_edac_channel_correctable_errors_total{channel="4",controller="0",csrow="1",dimm_label="mc0_csrow1_channel4"} 0
node_edac_channel_correctable_errors_total{channel="4",controller="0",csrow="2",dimm_label="mc0_csrow2_channel4"} 0
node_edac_channel_correctable_errors_total{channel="4",controller="0",csrow="3",dimm_label="mc0_csrow3_channel4"} 0
node_edac_channel_correctable_errors_total{channel="5",controller="0",csrow="0",dimm_label="mc0_csrow0_channel5"} 0
node_edac_channel_correctable_errors_total{channel="5",controller="0",csrow="1",dimm_label="mc0_csrow1_channel5"} 0
node_edac_channel_correctable_errors_total{channel="5",controller="0",csrow="2",dimm_label="mc0_csrow2_channel5"} 0
node_edac_channel_correctable_errors_total{channel="5",controller="0",csrow="3",dimm_label="mc0_csrow3_channel5"} 0
node_edac_channel_correctable_errors_total{channel="6",controller="0",csrow="0",dimm_label="mc0_csrow0_channel6"} 0
node_edac_channel_correctable_errors_total{channel="6",controller="0",csrow="1",dimm_label="mc0_csrow1_channel6"} 0
node_edac_channel_correctable_errors_total{channel="6",controller="0",csrow="2",dimm_label="mc0_csrow2_channel6"} 0
node_edac_channel_correctable_errors_total{channel="6",controller="0",csrow="3",dimm_label="mc0_csrow3_channel6"} 0
node_edac_channel_correctable_errors_total{channel="7",controller="0",csrow="0",dimm_label="mc0_csrow0_channel7"} 0
node_edac_channel_correctable_errors_total{channel="7",controller="0",csrow="1",dimm_label="mc0_csrow1_channel7"} 0
node_edac_channel_correctable_errors_total{channel="7",controller="0",csrow="2",dimm_label="mc0_csrow2_channel7"} 0
node_edac_channel_correctable_errors_total{channel="7",controller="0",csrow="3",dimm_label="mc0_csrow3_channel7"} 0
# HELP node_edac_correctable_errors_total Total correctable memory errors.
# TYPE node_edac_correctable_errors_total counter
node_edac_correctable_errors_total{controller="0"} 123
# HELP node_edac_uncorrectable_errors_total Total uncorrectable memory errors.
# TYPE node_edac_uncorrectable_errors_total counter
node_edac_uncorrectable_errors_total{controller="0"} 0