### PR TITLE
fix(collector): handle EINVAL errors from thermal_zone gracefully

### DIFF
--- a/collector/thermal_zone_linux.go
+++ b/collector/thermal_zone_linux.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"syscall"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs/sysfs"
@@ -71,7 +72,7 @@ func NewThermalZoneCollector(logger *slog.Logger) (Collector, error) {
 func (c *thermalZoneCollector) Update(ch chan<- prometheus.Metric) error {
 	thermalZones, err := c.fs.ClassThermalZoneStats()
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrInvalid) {
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrInvalid) || errors.Is(err, syscall.EINVAL) {
 			c.logger.Debug("Could not read thermal zone stats", "err", err)
 			return ErrNoData
 		}


### PR DESCRIPTION
## Summary
Fixes #2980 - When running node_exporter in Docker on some embedded devices, reading thermal_zone temp files can return `EINVAL` (invalid argument) errors. These were previously not handled, causing the entire thermal_zone collector to fail with an error instead of gracefully returning `ErrNoData`.

## Changes
- `collector/thermal_zone_linux.go`: Added `syscall.EINVAL` to the list of handled errors that result in `ErrNoData` instead of propagating as a fatal collector error

## Test plan
- [x] `go build ./collector/` succeeds