### PR TITLE
infiniband: Add port_info metric with link_layer label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## master / unreleased
 
 * [CHANGE]
-* [FEATURE]
+* [FEATURE] infiniband: Add `port_info` metric with `link_layer` label
 * [ENHANCEMENT]
 * [BUGFIX]
 

--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -1729,6 +1729,11 @@ node_infiniband_port_discards_transmitted_total{device="mlx4_0",port="1"} 5
 # HELP node_infiniband_port_errors_received_total Number of packets containing an error that were received on this port
 # TYPE node_infiniband_port_errors_received_total counter
 node_infiniband_port_errors_received_total{device="mlx4_0",port="1"} 0
+# HELP node_infiniband_port_info Non-numeric per-port data from /sys/class/infiniband/<device>/ports/<port>, value is always 1.
+# TYPE node_infiniband_port_info gauge
+node_infiniband_port_info{device="i40iw0",link_layer="Ethernet",port="1"} 1
+node_infiniband_port_info{device="mlx4_0",link_layer="InfiniBand",port="1"} 1
+node_infiniband_port_info{device="mlx4_0",link_layer="InfiniBand",port="2"} 1
 # HELP node_infiniband_port_packets_received_total Number of packets received on all VLs by this port (including errors)
 # TYPE node_infiniband_port_packets_received_total counter
 node_infiniband_port_packets_received_total{device="mlx4_0",port="1"} 6.825908347e+09

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -1761,6 +1761,11 @@ node_infiniband_port_discards_transmitted_total{device="mlx4_0",port="1"} 5
 # HELP node_infiniband_port_errors_received_total Number of packets containing an error that were received on this port
 # TYPE node_infiniband_port_errors_received_total counter
 node_infiniband_port_errors_received_total{device="mlx4_0",port="1"} 0
+# HELP node_infiniband_port_info Non-numeric per-port data from /sys/class/infiniband/<device>/ports/<port>, value is always 1.
+# TYPE node_infiniband_port_info gauge
+node_infiniband_port_info{device="i40iw0",link_layer="Ethernet",port="1"} 1
+node_infiniband_port_info{device="mlx4_0",link_layer="InfiniBand",port="1"} 1
+node_infiniband_port_info{device="mlx4_0",link_layer="InfiniBand",port="2"} 1
 # HELP node_infiniband_port_packets_received_total Number of packets received on all VLs by this port (including errors)
 # TYPE node_infiniband_port_packets_received_total counter
 node_infiniband_port_packets_received_total{device="mlx4_0",port="1"} 6.825908347e+09

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -1416,7 +1416,7 @@ Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/class/infiniband/i40iw0/ports/1/link_layer
 Lines: 1
-InfiniBand
+Ethernet
 Mode: 664
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/class/infiniband/i40iw0/ports/1/phys_state

--- a/collector/infiniband_linux.go
+++ b/collector/infiniband_linux.go
@@ -165,6 +165,14 @@ func (c *infinibandCollector) Update(ch chan<- prometheus.Metric) error {
 		for _, port := range device.Ports {
 			portStr := strconv.FormatUint(uint64(port.Port), 10)
 
+			portInfoDesc := prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, c.subsystem, "port_info"),
+				"Non-numeric per-port data from /sys/class/infiniband/<device>/ports/<port>, value is always 1.",
+				[]string{"device", "port", "link_layer"},
+				nil,
+			)
+			ch <- prometheus.MustNewConstMetric(portInfoDesc, prometheus.GaugeValue, 1.0, port.Name, portStr, port.LinkLayer)
+
 			c.pushMetric(ch, "state_id", uint64(port.StateID), port.Name, portStr, prometheus.GaugeValue)
 			c.pushMetric(ch, "physical_state_id", uint64(port.PhysStateID), port.Name, portStr, prometheus.GaugeValue)
 			c.pushMetric(ch, "rate_bytes_per_second", port.Rate, port.Name, portStr, prometheus.GaugeValue)


### PR DESCRIPTION
## Summary

Adds `node_infiniband_port_info{device, port, link_layer}` (value always `1`), surfacing `/sys/class/infiniband/<dev>/ports/<port>/link_layer` ("InfiniBand" or "Ethernet") as a new per-port info metric.

## Rationale

Modern Mellanox/NVIDIA NICs (ConnectX-6/7, BlueField, B200 platforms) routinely present some ports in Ethernet link layer (RoCE / generic Ethernet) while others run pure InfiniBand. Both modes appear under `/sys/class/infiniband/*` and currently emit indistinguishable `node_infiniband_*` series, so operators running mixed fleets cannot scope alerts (`link_downed_total`, `link_error_recovery_total`, etc.) to a specific layer.

`link_layer` is already parsed by `prometheus/procfs/sysfs` into `InfiniBandPort.LinkLayer` — this change is purely additive in the collector.

## Design choice

A per-port **info metric** (sibling of the existing device-scoped `node_infiniband_info`) rather than adding `link_layer` as a label on every existing per-port metric. Non-breaking — existing series unchanged — joinable in PromQL via:

```promql
rate(node_infiniband_link_downed_total[5m])
  * on(device, port) group_left(link_layer) node_infiniband_port_info
```

Per-port info (not extending the device-level `node_infiniband_info`) because a single mlx5_* device can have port 1 in InfiniBand and port 2 in Ethernet — link layer is a port-level property.

## Testing

End-to-end fixtures updated to exercise both `link_layer` values:
- `i40iw0/ports/1/link_layer` flipped to `"Ethernet"` (iWARP runs over Ethernet by definition)
- `mlx4_0/ports/{1,2}/link_layer` remain `"InfiniBand"`

`make test` and `./end-to-end-test.sh` pass.

cc @SuperQ @discordianfish