### PR TITLE
collector: add reusable runtime wrapper

### DIFF
--- a/collector/runtime.go
+++ b/collector/runtime.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"log/slog"
+	"sort"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus/node_exporter/config"
+)
+
+// Runtime represents a single exporter runtime instance built from a reusable
+// Config.
+type Runtime struct {
+	collector *NodeCollector
+}
+
+func NewRuntime(cfg config.Config, logger *slog.Logger) (*Runtime, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	if cfg.CollectorDisableDefaults {
+		DisableDefaultCollectors()
+	}
+
+	nodeCollector, err := NewNodeCollector(logger, cfg.EnabledCollectors...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Runtime{collector: nodeCollector}, nil
+}
+
+func (r *Runtime) Collectors() []prometheus.Collector {
+	return []prometheus.Collector{r.collector}
+}
+
+func (r *Runtime) Registry() (*prometheus.Registry, error) {
+	registry := prometheus.NewRegistry()
+	for _, c := range r.Collectors() {
+		if err := registry.Register(c); err != nil {
+			return nil, err
+		}
+	}
+	return registry, nil
+}
+
+func (r *Runtime) EnabledCollectors() []string {
+	enabled := make([]string, 0, len(r.collector.Collectors))
+	for name := range r.collector.Collectors {
+		enabled = append(enabled, name)
+	}
+	sort.Strings(enabled)
+	return enabled
+}

--- a/collector/runtime_test.go
+++ b/collector/runtime_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/prometheus/node_exporter/config"
+)
+
+func TestNewRuntimeCollectors(t *testing.T) {
+	runtime, err := NewRuntime(config.NewConfigWithDefaults(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if got, want := len(runtime.Collectors()), 1; got != want {
+		t.Errorf("Expected: %d, Got: %d", want, got)
+	}
+
+	if got := len(runtime.EnabledCollectors()); got == 0 {
+		t.Fatal("expected at least one enabled collector")
+	}
+}
+
+func TestNewRuntimeValidateConfig(t *testing.T) {
+	cfg := config.NewConfigWithDefaults()
+	cfg.RuntimeGoMaxProcs = 0
+
+	if _, err := NewRuntime(cfg, slog.New(slog.NewTextHandler(io.Discard, nil))); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestRuntimeRegistry(t *testing.T) {
+	runtime, err := NewRuntime(config.NewConfigWithDefaults(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	registry, err := runtime.Registry()
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if got := len(metrics); got == 0 {
+		t.Fatal("expected gathered metrics, got none")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,54 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "fmt"
+
+const (
+	DefaultWebTelemetryPath  = "/metrics"
+	DefaultWebMaxRequests    = 40
+	DefaultRuntimeGoMaxProcs = 1
+)
+
+// Config contains the user-facing configuration currently adapted by the
+// node_exporter binary into the reusable runtime and HTTP handler layers.
+type Config struct {
+	WebTelemetryPath          string
+	WebDisableExporterMetrics bool
+	WebMaxRequests            int
+	CollectorDisableDefaults  bool
+	RuntimeGoMaxProcs         int
+	EnabledCollectors         []string
+}
+
+func NewConfigWithDefaults() Config {
+	return Config{
+		WebTelemetryPath:  DefaultWebTelemetryPath,
+		WebMaxRequests:    DefaultWebMaxRequests,
+		RuntimeGoMaxProcs: DefaultRuntimeGoMaxProcs,
+	}
+}
+
+func (c Config) Validate() error {
+	if c.WebTelemetryPath == "" {
+		return fmt.Errorf("web telemetry path must not be empty")
+	}
+	if c.WebMaxRequests < 0 {
+		return fmt.Errorf("web max requests must be greater than or equal to zero")
+	}
+	if c.RuntimeGoMaxProcs <= 0 {
+		return fmt.Errorf("runtime gomaxprocs must be greater than zero")
+	}
+	return nil
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "testing"
+
+func TestNewConfigWithDefaults(t *testing.T) {
+	cfg := NewConfigWithDefaults()
+
+	if got, want := cfg.WebTelemetryPath, DefaultWebTelemetryPath; got != want {
+		t.Errorf("Expected: %q, Got: %q", want, got)
+	}
+	if got, want := cfg.WebMaxRequests, DefaultWebMaxRequests; got != want {
+		t.Errorf("Expected: %d, Got: %d", want, got)
+	}
+	if got, want := cfg.RuntimeGoMaxProcs, DefaultRuntimeGoMaxProcs; got != want {
+		t.Errorf("Expected: %d, Got: %d", want, got)
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	cfg := NewConfigWithDefaults()
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestConfigValidateRequiresTelemetryPath(t *testing.T) {
+	cfg := NewConfigWithDefaults()
+	cfg.WebTelemetryPath = ""
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestConfigValidateRejectsNegativeMaxRequests(t *testing.T) {
+	cfg := NewConfigWithDefaults()
+	cfg.WebMaxRequests = -1
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestConfigValidateRejectsNonPositiveGoMaxProcs(t *testing.T) {
+	cfg := NewConfigWithDefaults()
+	cfg.RuntimeGoMaxProcs = 0
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
This continues the incremental refactor to make `node_exporter` easier to embed outside the standalone binary.
The broader goal is to support ongoing work to make Prometheus exporters embeddable inside the Prometheus OpenTelemetry Collector distribution as native receivers, without requiring each exporter to be rewritten as an OpenTelemetry component.
This PR builds on the reusable config package by adding a runtime layer that downstream callers can construct directly from config, independent of CLI parsing and HTTP serving.
Specifically, this PR:
- adds `collector.Runtime` as a reusable wrapper around `NodeCollector`
- validates reusable config at runtime construction time
- exposes embeddable APIs for:
  - collector access via `Collectors()`
  - registry creation via `Registry()`
  - enabled collector discovery via `EnabledCollectors()`
- adds unit tests covering runtime construction, validation, and registry gathering
## Why
Today, `node_exporter` collector construction is tied closely to the binary wiring. Introducing a reusable runtime layer is a small but important step toward separating:
- binary concerns such as flags, HTTP serving, and process setup
- reusable exporter concerns such as config validation, collector construction, and metric registry assembly
This does not make `node_exporter` fully embeddable yet. In particular, collector-specific process-global configuration and state still need follow-up refactors. The intent here is to establish a reusable runtime API that future changes can build on.
## Stack
This PR is part of a stacked series:
- depends on https://github.com/prometheus/node_exporter/pull/3660
Only the runtime layer is intended to be reviewed here; the CLI wiring changes will come in a follow-up PR.
