### PR TITLE
collector: scope collector runtime state

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -49,12 +49,20 @@ const (
 )
 
 var (
-	factories              = make(map[string]func(logger *slog.Logger) (Collector, error))
-	initiatedCollectorsMtx = sync.Mutex{}
-	initiatedCollectors    = make(map[string]Collector)
-	collectorState         = make(map[string]*bool)
-	forcedCollectors       = map[string]bool{} // collectors which have been explicitly enabled or disabled
+	factories        = make(map[string]func(logger *slog.Logger) (Collector, error))
+	collectorState   = make(map[string]*bool)
+	forcedCollectors = map[string]bool{} // collectors which have been explicitly enabled or disabled
 )
+
+type collectorRuntimeState struct {
+	enabled    map[string]bool
+	collectors map[string]Collector
+	mtx        sync.Mutex
+}
+
+type runtimeConfiguredCollector interface {
+	configureRuntimeState(*collectorRuntimeState)
+}
 
 func registerCollector(collector string, isDefaultEnabled bool, factory func(logger *slog.Logger) (Collector, error)) {
 	var helpDefaultState string
@@ -80,13 +88,20 @@ type NodeCollector struct {
 	logger     *slog.Logger
 }
 
-// DisableDefaultCollectors sets the collector state to false for all collectors which
-// have not been explicitly enabled on the command line.
-func DisableDefaultCollectors() {
-	for c := range collectorState {
-		if _, ok := forcedCollectors[c]; !ok {
-			*collectorState[c] = false
+func newCollectorRuntimeState(disableDefaultCollectors bool) *collectorRuntimeState {
+	enabled := make(map[string]bool, len(collectorState))
+	for collector, state := range collectorState {
+		enabled[collector] = *state
+		if disableDefaultCollectors {
+			if _, ok := forcedCollectors[collector]; !ok {
+				enabled[collector] = false
+			}
 		}
+	}
+
+	return &collectorRuntimeState{
+		enabled:    enabled,
+		collectors: make(map[string]Collector),
 	}
 }
 
@@ -103,37 +118,44 @@ func collectorFlagAction(collector string) func(ctx *kingpin.ParseContext) error
 }
 
 // NewNodeCollector creates a new NodeCollector.
-func NewNodeCollector(logger *slog.Logger, filters ...string) (*NodeCollector, error) {
+func (s *collectorRuntimeState) NewNodeCollector(logger *slog.Logger, filters ...string) (*NodeCollector, error) {
 	f := make(map[string]bool)
 	for _, filter := range filters {
-		enabled, exist := collectorState[filter]
+		enabled, exist := s.enabled[filter]
 		if !exist {
 			return nil, fmt.Errorf("missing collector: %s", filter)
 		}
-		if !*enabled {
+		if !enabled {
 			return nil, fmt.Errorf("disabled collector: %s", filter)
 		}
 		f[filter] = true
 	}
 	collectors := make(map[string]Collector)
-	initiatedCollectorsMtx.Lock()
-	defer initiatedCollectorsMtx.Unlock()
-	for key, enabled := range collectorState {
-		if !*enabled || (len(f) > 0 && !f[key]) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	for key, enabled := range s.enabled {
+		if !enabled || (len(f) > 0 && !f[key]) {
 			continue
 		}
-		if collector, ok := initiatedCollectors[key]; ok {
+		if collector, ok := s.collectors[key]; ok {
 			collectors[key] = collector
 		} else {
 			collector, err := factories[key](logger.With("collector", key))
 			if err != nil {
 				return nil, err
 			}
+			s.configureCollector(collector)
 			collectors[key] = collector
-			initiatedCollectors[key] = collector
+			s.collectors[key] = collector
 		}
 	}
 	return &NodeCollector{Collectors: collectors, logger: logger}, nil
+}
+
+func (s *collectorRuntimeState) configureCollector(collector Collector) {
+	if configuredCollector, ok := collector.(runtimeConfiguredCollector); ok {
+		configuredCollector.configureRuntimeState(s)
+	}
 }
 
 // Describe implements the prometheus.Collector interface.

--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -50,6 +50,7 @@ type cpuCollector struct {
 	cpuStats           map[int64]procfs.CPUStat
 	cpuStatsMutex      sync.Mutex
 	isolatedCpus       []uint16
+	cpuFreqEnabled     bool
 
 	cpuFlagsIncludeRegexp *regexp.Regexp
 	cpuBugsIncludeRegexp  *regexp.Regexp
@@ -150,6 +151,10 @@ func NewCPUCollector(logger *slog.Logger) (Collector, error) {
 	return c, nil
 }
 
+func (c *cpuCollector) configureRuntimeState(state *collectorRuntimeState) {
+	c.cpuFreqEnabled = state.enabled["cpufreq"]
+}
+
 func (c *cpuCollector) compileIncludeFlags(flagsIncludeFlag, bugsIncludeFlag *string) error {
 	if (*flagsIncludeFlag != "" || *bugsIncludeFlag != "") && !*enableCPUInfo {
 		*enableCPUInfo = true
@@ -219,10 +224,7 @@ func (c *cpuCollector) updateInfo(ch chan<- prometheus.Metric) error {
 			cpu.CacheSize)
 	}
 
-	cpuFreqEnabled, ok := collectorState["cpufreq"]
-	if !ok || cpuFreqEnabled == nil {
-		c.logger.Debug("cpufreq key missing or nil value in collectorState map")
-	} else if *cpuFreqEnabled {
+	if c.cpuFreqEnabled {
 		for _, cpu := range info {
 			ch <- prometheus.MustNewConstMetric(c.cpuFrequencyHz,
 				prometheus.GaugeValue,

--- a/collector/runtime.go
+++ b/collector/runtime.go
@@ -25,7 +25,9 @@ import (
 // Runtime represents a single exporter runtime instance built from a reusable
 // Config.
 type Runtime struct {
+	state     *collectorRuntimeState
 	collector *NodeCollector
+	logger    *slog.Logger
 }
 
 func NewRuntime(cfg config.Config, logger *slog.Logger) (*Runtime, error) {
@@ -33,16 +35,27 @@ func NewRuntime(cfg config.Config, logger *slog.Logger) (*Runtime, error) {
 		return nil, err
 	}
 
-	if cfg.CollectorDisableDefaults {
-		DisableDefaultCollectors()
-	}
+	state := newCollectorRuntimeState(cfg.CollectorDisableDefaults)
 
-	nodeCollector, err := NewNodeCollector(logger, cfg.EnabledCollectors...)
+	return newRuntime(state, logger, cfg.EnabledCollectors)
+}
+
+func newRuntime(state *collectorRuntimeState, logger *slog.Logger, enabledCollectors []string) (*Runtime, error) {
+	nodeCollector, err := state.NewNodeCollector(logger, enabledCollectors...)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Runtime{collector: nodeCollector}, nil
+	return &Runtime{state: state, collector: nodeCollector, logger: logger}, nil
+}
+
+func (r *Runtime) Filtered(enabledCollectors ...string) (*Runtime, error) {
+	filtered, err := newRuntime(r.state, r.logger, enabledCollectors)
+	if err != nil {
+		return nil, err
+	}
+
+	return filtered, nil
 }
 
 func (r *Runtime) Collectors() []prometheus.Collector {

--- a/collector/runtime.go
+++ b/collector/runtime.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"log/slog"
+	"sort"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus/node_exporter/config"
+)
+
+// Runtime represents a single exporter runtime instance built from a reusable
+// Config.
+type Runtime struct {
+	collector *NodeCollector
+}
+
+func NewRuntime(cfg config.Config, logger *slog.Logger) (*Runtime, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	if cfg.CollectorDisableDefaults {
+		DisableDefaultCollectors()
+	}
+
+	nodeCollector, err := NewNodeCollector(logger, cfg.EnabledCollectors...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Runtime{collector: nodeCollector}, nil
+}
+
+func (r *Runtime) Collectors() []prometheus.Collector {
+	return []prometheus.Collector{r.collector}
+}
+
+func (r *Runtime) Registry() (*prometheus.Registry, error) {
+	registry := prometheus.NewRegistry()
+	for _, c := range r.Collectors() {
+		if err := registry.Register(c); err != nil {
+			return nil, err
+		}
+	}
+	return registry, nil
+}
+
+func (r *Runtime) EnabledCollectors() []string {
+	enabled := make([]string, 0, len(r.collector.Collectors))
+	for name := range r.collector.Collectors {
+		enabled = append(enabled, name)
+	}
+	sort.Strings(enabled)
+	return enabled
+}

--- a/collector/runtime_test.go
+++ b/collector/runtime_test.go
@@ -64,3 +64,56 @@ func TestRuntimeRegistry(t *testing.T) {
 		t.Fatal("expected gathered metrics, got none")
 	}
 }
+
+func TestNewRuntimeDisableDefaultsDoesNotMutateGlobalCollectorState(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	disabledDefaultsCfg := config.NewConfigWithDefaults()
+	disabledDefaultsCfg.CollectorDisableDefaults = true
+
+	if _, err := NewRuntime(disabledDefaultsCfg, logger); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	runtime, err := NewRuntime(config.NewConfigWithDefaults(), logger)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if got := len(runtime.EnabledCollectors()); got == 0 {
+		t.Fatal("expected enabled collectors after constructing runtime with defaults")
+	}
+}
+
+func TestRuntimeFilteredUsesBaseCollectorState(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	originalCPUEnabled := *collectorState["cpu"]
+	_, originalCPUForced := forcedCollectors["cpu"]
+	*collectorState["cpu"] = true
+	forcedCollectors["cpu"] = true
+	t.Cleanup(func() {
+		*collectorState["cpu"] = originalCPUEnabled
+		if originalCPUForced {
+			forcedCollectors["cpu"] = true
+		} else {
+			delete(forcedCollectors, "cpu")
+		}
+	})
+
+	cfg := config.NewConfigWithDefaults()
+	cfg.CollectorDisableDefaults = true
+	cfg.EnabledCollectors = []string{"cpu"}
+
+	runtime, err := NewRuntime(cfg, logger)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if _, err := runtime.Filtered("cpu"); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if _, err := runtime.Filtered("meminfo"); err == nil {
+		t.Fatal("expected error for collector disabled in base runtime")
+	}
+}

--- a/collector/runtime_test.go
+++ b/collector/runtime_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/prometheus/node_exporter/config"
+)
+
+func TestNewRuntimeCollectors(t *testing.T) {
+	runtime, err := NewRuntime(config.NewConfigWithDefaults(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if got, want := len(runtime.Collectors()), 1; got != want {
+		t.Errorf("Expected: %d, Got: %d", want, got)
+	}
+
+	if got := len(runtime.EnabledCollectors()); got == 0 {
+		t.Fatal("expected at least one enabled collector")
+	}
+}
+
+func TestNewRuntimeValidateConfig(t *testing.T) {
+	cfg := config.NewConfigWithDefaults()
+	cfg.RuntimeGoMaxProcs = 0
+
+	if _, err := NewRuntime(cfg, slog.New(slog.NewTextHandler(io.Discard, nil))); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestRuntimeRegistry(t *testing.T) {
+	runtime, err := NewRuntime(config.NewConfigWithDefaults(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	registry, err := runtime.Registry()
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if got := len(metrics); got == 0 {
+		t.Fatal("expected gathered metrics, got none")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,54 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "fmt"
+
+const (
+	DefaultWebTelemetryPath  = "/metrics"
+	DefaultWebMaxRequests    = 40
+	DefaultRuntimeGoMaxProcs = 1
+)
+
+// Config contains the user-facing configuration currently adapted by the
+// node_exporter binary into the reusable runtime and HTTP handler layers.
+type Config struct {
+	WebTelemetryPath          string
+	WebDisableExporterMetrics bool
+	WebMaxRequests            int
+	CollectorDisableDefaults  bool
+	RuntimeGoMaxProcs         int
+	EnabledCollectors         []string
+}
+
+func NewConfigWithDefaults() Config {
+	return Config{
+		WebTelemetryPath:  DefaultWebTelemetryPath,
+		WebMaxRequests:    DefaultWebMaxRequests,
+		RuntimeGoMaxProcs: DefaultRuntimeGoMaxProcs,
+	}
+}
+
+func (c Config) Validate() error {
+	if c.WebTelemetryPath == "" {
+		return fmt.Errorf("web telemetry path must not be empty")
+	}
+	if c.WebMaxRequests < 0 {
+		return fmt.Errorf("web max requests must be greater than or equal to zero")
+	}
+	if c.RuntimeGoMaxProcs <= 0 {
+		return fmt.Errorf("runtime gomaxprocs must be greater than zero")
+	}
+	return nil
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "testing"
+
+func TestNewConfigWithDefaults(t *testing.T) {
+	cfg := NewConfigWithDefaults()
+
+	if got, want := cfg.WebTelemetryPath, DefaultWebTelemetryPath; got != want {
+		t.Errorf("Expected: %q, Got: %q", want, got)
+	}
+	if got, want := cfg.WebMaxRequests, DefaultWebMaxRequests; got != want {
+		t.Errorf("Expected: %d, Got: %d", want, got)
+	}
+	if got, want := cfg.RuntimeGoMaxProcs, DefaultRuntimeGoMaxProcs; got != want {
+		t.Errorf("Expected: %d, Got: %d", want, got)
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	cfg := NewConfigWithDefaults()
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestConfigValidateRequiresTelemetryPath(t *testing.T) {
+	cfg := NewConfigWithDefaults()
+	cfg.WebTelemetryPath = ""
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestConfigValidateRejectsNegativeMaxRequests(t *testing.T) {
+	cfg := NewConfigWithDefaults()
+	cfg.WebMaxRequests = -1
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestConfigValidateRejectsNonPositiveGoMaxProcs(t *testing.T) {
+	cfg := NewConfigWithDefaults()
+	cfg.RuntimeGoMaxProcs = 0
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -137,9 +137,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *handler) innerHandler(filters ...string) (http.Handler, error) {
 	runtime := h.runtime
 	if len(filters) > 0 {
-		cfg := h.cfg
-		cfg.EnabledCollectors = filters
-		r, err := collector.NewRuntime(cfg, h.logger)
+		r, err := h.runtime.Filtered(filters...)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't create collector runtime: %w", err)
 		}

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -22,7 +22,7 @@ import (
 	"os/user"
 	"runtime"
 	"slices"
-	"sort"
+	"strconv"
 
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/common/promslog/flag"
@@ -37,6 +37,7 @@ import (
 	"github.com/prometheus/exporter-toolkit/web/kingpinflag"
 
 	"github.com/prometheus/node_exporter/collector"
+	"github.com/prometheus/node_exporter/config"
 )
 
 // handler wraps an unfiltered http.Handler but uses a filtered handler,
@@ -44,6 +45,8 @@ import (
 // newHandler.
 type handler struct {
 	unfilteredHandler http.Handler
+	cfg               config.Config
+	runtime           *collector.Runtime
 	// enabledCollectors list is used for logging and filtering
 	enabledCollectors []string
 	// exporterMetricsRegistry is a separate registry for the metrics about
@@ -54,11 +57,18 @@ type handler struct {
 	logger                  *slog.Logger
 }
 
-func newHandler(includeExporterMetrics bool, maxRequests int, logger *slog.Logger) *handler {
+func newHandler(cfg config.Config, logger *slog.Logger) (*handler, error) {
+	runtime, err := collector.NewRuntime(cfg, logger)
+	if err != nil {
+		return nil, err
+	}
+
 	h := &handler{
+		cfg:                     cfg,
+		runtime:                 runtime,
 		exporterMetricsRegistry: prometheus.NewRegistry(),
-		includeExporterMetrics:  includeExporterMetrics,
-		maxRequests:             maxRequests,
+		includeExporterMetrics:  !cfg.WebDisableExporterMetrics,
+		maxRequests:             cfg.WebMaxRequests,
 		logger:                  logger,
 	}
 	if h.includeExporterMetrics {
@@ -67,12 +77,12 @@ func newHandler(includeExporterMetrics bool, maxRequests int, logger *slog.Logge
 			promcollectors.NewGoCollector(),
 		)
 	}
-	if innerHandler, err := h.innerHandler(); err != nil {
-		panic(fmt.Sprintf("Couldn't create metrics handler: %s", err))
-	} else {
-		h.unfilteredHandler = innerHandler
+	innerHandler, err := h.innerHandler()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create metrics handler: %w", err)
 	}
-	return h
+	h.unfilteredHandler = innerHandler
+	return h, nil
 }
 
 // ServeHTTP implements http.Handler.
@@ -125,29 +135,32 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // (in which case it will log all the collectors enabled via command-line
 // flags).
 func (h *handler) innerHandler(filters ...string) (http.Handler, error) {
-	nc, err := collector.NewNodeCollector(h.logger, filters...)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't create collector: %s", err)
+	runtime := h.runtime
+	if len(filters) > 0 {
+		cfg := h.cfg
+		cfg.EnabledCollectors = filters
+		r, err := collector.NewRuntime(cfg, h.logger)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't create collector runtime: %w", err)
+		}
+		runtime = r
 	}
 
 	// Only log the creation of an unfiltered handler, which should happen
 	// only once upon startup.
 	if len(filters) == 0 {
 		h.logger.Info("Enabled collectors")
-		for n := range nc.Collectors {
-			h.enabledCollectors = append(h.enabledCollectors, n)
-		}
-		sort.Strings(h.enabledCollectors)
+		h.enabledCollectors = runtime.EnabledCollectors()
 		for _, c := range h.enabledCollectors {
 			h.logger.Info(c)
 		}
 	}
 
-	r := prometheus.NewRegistry()
-	r.MustRegister(versioncollector.NewCollector("node_exporter"))
-	if err := r.Register(nc); err != nil {
-		return nil, fmt.Errorf("couldn't register node collector: %s", err)
+	r, err := runtime.Registry()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create collector registry: %w", err)
 	}
+	r.MustRegister(versioncollector.NewCollector("node_exporter"))
 
 	var handler http.Handler
 	if h.includeExporterMetrics {
@@ -184,7 +197,7 @@ func main() {
 		metricsPath = kingpin.Flag(
 			"web.telemetry-path",
 			"Path under which to expose metrics.",
-		).Default("/metrics").String()
+		).Default(config.DefaultWebTelemetryPath).String()
 		disableExporterMetrics = kingpin.Flag(
 			"web.disable-exporter-metrics",
 			"Exclude metrics about the exporter itself (promhttp_*, process_*, go_*).",
@@ -192,14 +205,14 @@ func main() {
 		maxRequests = kingpin.Flag(
 			"web.max-requests",
 			"Maximum number of parallel scrape requests. Use 0 to disable.",
-		).Default("40").Int()
+		).Default(strconv.Itoa(config.DefaultWebMaxRequests)).Int()
 		disableDefaultCollectors = kingpin.Flag(
 			"collector.disable-defaults",
 			"Set all collectors to disabled by default.",
 		).Default("false").Bool()
 		maxProcs = kingpin.Flag(
 			"runtime.gomaxprocs", "The target number of CPUs Go will run on (GOMAXPROCS)",
-		).Envar("GOMAXPROCS").Default("1").Int()
+		).Envar("GOMAXPROCS").Default(strconv.Itoa(config.DefaultRuntimeGoMaxProcs)).Int()
 		toolkitFlags = kingpinflag.AddFlags(kingpin.CommandLine, ":9100")
 	)
 
@@ -211,26 +224,40 @@ func main() {
 	kingpin.Parse()
 	logger := promslog.New(promslogConfig)
 
-	if *disableDefaultCollectors {
-		collector.DisableDefaultCollectors()
+	cfg := config.NewConfigWithDefaults()
+	cfg.WebTelemetryPath = *metricsPath
+	cfg.WebDisableExporterMetrics = *disableExporterMetrics
+	cfg.WebMaxRequests = *maxRequests
+	cfg.CollectorDisableDefaults = *disableDefaultCollectors
+	cfg.RuntimeGoMaxProcs = *maxProcs
+	if err := cfg.Validate(); err != nil {
+		logger.Error(err.Error())
+		os.Exit(1)
 	}
+
 	logger.Info("Starting node_exporter", "version", version.Info())
 	logger.Info("Build context", "build_context", version.BuildContext())
 	if user, err := user.Current(); err == nil && user.Uid == "0" {
 		logger.Warn("Node Exporter is running as root user. This exporter is designed to run as unprivileged user, root is not required.")
 	}
-	runtime.GOMAXPROCS(*maxProcs)
+	runtime.GOMAXPROCS(cfg.RuntimeGoMaxProcs)
 	logger.Debug("Go MAXPROCS", "procs", runtime.GOMAXPROCS(0))
 
-	http.Handle(*metricsPath, newHandler(!*disableExporterMetrics, *maxRequests, logger))
-	if *metricsPath != "/" {
+	handler, err := newHandler(cfg, logger)
+	if err != nil {
+		logger.Error(err.Error())
+		os.Exit(1)
+	}
+
+	http.Handle(cfg.WebTelemetryPath, handler)
+	if cfg.WebTelemetryPath != "/" {
 		landingConfig := web.LandingConfig{
 			Name:        "Node Exporter",
 			Description: "Prometheus Node Exporter",
 			Version:     version.Info(),
 			Links: []web.LandingLinks{
 				{
-					Address: *metricsPath,
+					Address: cfg.WebTelemetryPath,
 					Text:    "Metrics",
 				},
 			},


### PR DESCRIPTION
## Summary
This continues the incremental refactor to make `node_exporter` easier to embed outside the standalone binary.
The broader goal is to support ongoing work to make Prometheus exporters embeddable inside the Prometheus OpenTelemetry Collector distribution as native receivers, without requiring each exporter to be rewritten as an OpenTelemetry component.

This PR builds on the previous config, runtime, and CLI wiring PRs by moving collector runtime state off shared process-global mutation and into runtime-owned state.

Specifically, this PR:
- snapshots effective collector enablement into per-runtime state
- moves lazy collector instantiation and caching behind that runtime-owned state
- derives filtered runtimes from the base runtime instead of rebuilding from global collector flags
- removes the CPU collector's direct dependency on the global collector enablement map for `cpufreq`-related behavior
- adds tests covering runtime-local collector state and filtered runtime behavior

## Why
The goal of this change is to make collector setup more instance-scoped and less dependent on mutable process-global state.
Before this change, runtime construction could mutate global collector enablement, and collector instances were cached globally across the process. That made it harder to reason about independent runtime instances and made filtered handler construction depend on shared global state.
After this change, collector enablement is resolved once into runtime-local state, collector instances are cached within that runtime state, and derived filtered runtimes reuse the base runtime's effective collector configuration.
This is still not the end of the embeddability work. Many individual collectors still read configuration directly from package-global CLI flags. The intent of this PR is to narrow the shared runtime state surface and make the current runtime model more explicit and reusable.

## Stack
This PR is part of a stacked series:
- depends on https://github.com/prometheus/node_exporter/pull/3660
- depends on https://github.com/prometheus/node_exporter/pull/3661
- depends on https://github.com/prometheus/node_exporter/pull/3663

The earlier PRs introduced reusable config, runtime, and binary wiring layers. This PR pushes the remaining runtime behavior further away from shared process-global mutation.