### PR TITLE
filesystem: prevent panic on mount points with non-UTF-8 names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * [CHANGE]
 * [FEATURE]
 * [ENHANCEMENT]
-* [BUGFIX]
+* [BUGFIX] filesystem: Prevent panic on mount points with non-UTF-8 names #3
 
 ## 1.10.2 / 2025-10-25
 

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -212,9 +212,9 @@ func parseFilesystemLabels(mountInfo []*procfs.MountInfo) ([]filesystemLabels, e
 		mount.MountPoint = strings.ReplaceAll(mount.MountPoint, "\\011", "\t")
 
 		filesystems = append(filesystems, filesystemLabels{
-			device:       mount.Source,
-			mountPoint:   rootfsStripPrefix(mount.MountPoint),
-			fsType:       mount.FSType,
+			device:       strings.ToValidUTF8(mount.Source, "�"),
+			mountPoint:   strings.ToValidUTF8(rootfsStripPrefix(mount.MountPoint), "�"),
+			fsType:       strings.ToValidUTF8(mount.FSType, "�"),
 			mountOptions: mountOptionsString(mount.Options),
 			superOptions: mountOptionsString(mount.SuperOptions),
 			major:        strconv.Itoa(major),

--- a/collector/filesystem_linux_test.go
+++ b/collector/filesystem_linux_test.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/alecthomas/kingpin/v2"
 
@@ -46,6 +47,35 @@ func Test_parseFilesystemLabelsError(t *testing.T) {
 				t.Fatal("expected an error, but none occurred")
 			}
 		})
+	}
+}
+
+func Test_parseFilesystemLabelsSanitizesInvalidUTF8(t *testing.T) {
+	in := []*procfs.MountInfo{
+		{
+			MajorMinorVer: "0:0",
+			Source:        "/dev/sd\xe9",
+			MountPoint:    "/mnt/cass\xe9",
+			FSType:        "ext\xe9",
+		},
+	}
+
+	got, err := parseFilesystemLabels(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 filesystem, got %d", len(got))
+	}
+
+	for name, value := range map[string]string{
+		"device":     got[0].device,
+		"mountPoint": got[0].mountPoint,
+		"fsType":     got[0].fsType,
+	} {
+		if !utf8.ValidString(value) {
+			t.Errorf("expected %s to be valid UTF-8, got %q", name, value)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

On Linux, mount paths are byte strings and are *usually* — but not always — valid UTF-8. When a filesystem is mounted on a path containing non-UTF-8 bytes, the filesystem collector passes that value straight to `prometheus.MustNewConstMetric` as a label value, which panics (Prometheus label values must be valid UTF-8). This crashes the whole scrape:

```
panic: label value "/mnt/cass\xe9" is not valid UTF-8
github.com/prometheus/client_golang/prometheus.MustNewConstMetric(...)
github.com/prometheus/node_exporter/collector.(*filesystemCollector).Update(...)
```

## Fix

Sanitize the `device`, `mountPoint` and `fsType` labels with `strings.ToValidUTF8(..., "�")` in `parseFilesystemLabels`. This mirrors the approach already used elsewhere in the tree (hwmon, dmi, netclass, powersupply collectors and `collector/utils`), so invalid bytes are replaced with the Unicode replacement character instead of taking the exporter down.

A unit test covering non-UTF-8 `device`/`mountPoint`/`fsType` input is included.

Fixes #3662

## Reproduce

```
fallocate -l 32m /root/disk.dd
mkfs -t ext2 /root/disk.dd
mount --mkdir /root/disk.dd /mnt/cass$'\xe9'
./node_exporter &
curl http://localhost:9100/metrics
```