### PR TITLE
docs: fix qdisk -> qdisc collector and flag names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ hwmon | chip | --collector.hwmon.chip-include | --collector.hwmon.chip-exclude
 hwmon | sensor | --collector.hwmon.sensor-include | --collector.hwmon.sensor-exclude
 interrupts | name | --collector.interrupts.name-include | --collector.interrupts.name-exclude
 netdev | device | --collector.netdev.device-include | --collector.netdev.device-exclude
-qdisk | device | --collector.qdisk.device-include | --collector.qdisk.device-exclude
+qdisc | device | --collector.qdisc.device-include | --collector.qdisc.device-exclude
 slabinfo | slab-names | --collector.slabinfo.slabs-include | --collector.slabinfo.slabs-exclude
 sysctl | all | --collector.sysctl.include | N/A
 systemd | unit | --collector.systemd.unit-include | --collector.systemd.unit-exclude


### PR DESCRIPTION
The Include/Exclude flags table documents the `qdisk` collector and `--collector.qdisk.device-(include|exclude)` flags. Those are the deprecated/hidden spellings (removed in 2.0.0); the active collector and flags are `qdisc`. The collector list further down already uses `qdisc`, so this row was inconsistent.
