### PR TITLE
infiniband: Add device filtering flags to the collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## master / unreleased
 
 * [CHANGE]
-* [FEATURE]
+* [FEATURE] Add device filtering to the infiniband collector #3694
 * [ENHANCEMENT]
 * [BUGFIX]
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ filesystem | fs-types | --collector.filesystem.fs-types-include | --collector.fi
 filesystem | mount-points | --collector.filesystem.mount-points-include | --collector.filesystem.mount-points-exclude
 hwmon | chip | --collector.hwmon.chip-include | --collector.hwmon.chip-exclude
 hwmon | sensor | --collector.hwmon.sensor-include | --collector.hwmon.sensor-exclude
+infiniband | device | --collector.infiniband.device-include | --collector.infiniband.device-exclude
 interrupts | name | --collector.interrupts.name-include | --collector.interrupts.name-exclude
 netdev | device | --collector.netdev.device-include | --collector.netdev.device-exclude
 qdisk | device | --collector.qdisk.device-include | --collector.qdisk.device-exclude

--- a/collector/infiniband_linux.go
+++ b/collector/infiniband_linux.go
@@ -22,15 +22,22 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs/sysfs"
 )
 
+var (
+	infinibandDeviceInclude = kingpin.Flag("collector.infiniband.device-include", "Regexp of infiniband devices to include (mutually exclusive to device-exclude).").String()
+	infinibandDeviceExclude = kingpin.Flag("collector.infiniband.device-exclude", "Regexp of infiniband devices to exclude (mutually exclusive to device-include).").String()
+)
+
 type infinibandCollector struct {
-	fs          sysfs.FS
-	metricDescs map[string]*prometheus.Desc
-	logger      *slog.Logger
-	subsystem   string
+	fs           sysfs.FS
+	metricDescs  map[string]*prometheus.Desc
+	logger       *slog.Logger
+	subsystem    string
+	deviceFilter deviceFilter
 }
 
 func init() {
@@ -129,6 +136,14 @@ func NewInfiniBandCollector(logger *slog.Logger) (Collector, error) {
 		)
 	}
 
+	if *infinibandDeviceInclude != "" {
+		i.logger.Info("Parsed flag --collector.infiniband.device-include", "flag", *infinibandDeviceInclude)
+	}
+	if *infinibandDeviceExclude != "" {
+		i.logger.Info("Parsed flag --collector.infiniband.device-exclude", "flag", *infinibandDeviceExclude)
+	}
+	i.deviceFilter = newDeviceFilter(*infinibandDeviceExclude, *infinibandDeviceInclude)
+
 	return &i, nil
 }
 
@@ -153,6 +168,10 @@ func (c *infinibandCollector) Update(ch chan<- prometheus.Metric) error {
 	}
 
 	for _, device := range devices {
+		if c.deviceFilter.ignored(device.Name) {
+			continue
+		}
+
 		infoDesc := prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, c.subsystem, "info"),
 			"Non-numeric data from /sys/class/infiniband/<device>, value is always 1.",


### PR DESCRIPTION
Closes #3583

Adds `--collector.infiniband.device-include` and `--collector.infiniband.device-exclude` flags to the infiniband collector, so operators can scrape a subset of infiniband devices.

This follows the established `deviceFilter` pattern already used by the **arp, ethtool, diskstats and netdev** collectors: two mutually-exclusive include/exclude regexp flags, a `deviceFilter` field on the collector, and a `c.deviceFilter.ignored(device.Name)` skip at the top of the `Update` device loop. The filter logic itself is covered by `collector/device_filter_test.go`.

Defaults are unchanged — with neither flag set, all devices are scraped as before.

Verified: `GOOS=linux go build/vet ./collector/` and the collector test binary compile cleanly; gofmt clean; DCO signed.
