### PR TITLE
Fixup end-to-end test

### DIFF
--- a/collector/fixtures/e2e-output-freebsd.txt
+++ b/collector/fixtures/e2e-output-freebsd.txt
@@ -99,9 +99,6 @@ node_memory_swap_in_bytes_total 0
 # HELP node_memory_swap_out_bytes_total Bytes paged out to swap devices
 # TYPE node_memory_swap_out_bytes_total counter
 node_memory_swap_out_bytes_total 0
-# HELP node_memory_swap_size_bytes Total swap memory size
-# TYPE node_memory_swap_size_bytes gauge
-node_memory_swap_size_bytes 1.073741824e+09
 # HELP node_memory_swap_used_bytes Currently allocated swap
 # TYPE node_memory_swap_used_bytes gauge
 node_memory_swap_used_bytes 0

--- a/collector/fixtures/e2e-output-netbsd.txt
+++ b/collector/fixtures/e2e-output-netbsd.txt
@@ -58,9 +58,6 @@
 # TYPE go_threads gauge
 # HELP node_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which node_exporter was built, and the goos and goarch for the build.
 # TYPE node_exporter_build_info gauge
-# HELP node_memory_swap_size_bytes Memory information field swap_size_bytes.
-# TYPE node_memory_swap_size_bytes gauge
-node_memory_swap_size_bytes 6.442426368e+09
 # HELP node_memory_swap_used_bytes Memory information field swap_used_bytes.
 # TYPE node_memory_swap_used_bytes gauge
 node_memory_swap_used_bytes 0

--- a/collector/fixtures/e2e-output-openbsd.txt
+++ b/collector/fixtures/e2e-output-openbsd.txt
@@ -93,9 +93,6 @@ node_buddyinfo_blocks{node="0",size="9",zone="DMA32"} 0
 node_buddyinfo_blocks{node="0",size="9",zone="Normal"} 0
 # HELP node_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which node_exporter was built, and the goos and goarch for the build.
 # TYPE node_exporter_build_info gauge
-# HELP node_memory_swap_size_bytes Memory information field swap_size_bytes.
-# TYPE node_memory_swap_size_bytes gauge
-node_memory_swap_size_bytes 6.693941248e+09
 # HELP node_memory_swap_used_bytes Memory information field swap_used_bytes.
 # TYPE node_memory_swap_used_bytes gauge
 node_memory_swap_used_bytes 0

--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -365,6 +365,7 @@ non_deterministic_metrics=$(cat << METRICS
   node_memory_size_bytes
   node_memory_swapped_in_bytes_total
   node_memory_swapped_out_bytes_total
+  node_memory_swap_size_bytes
   node_memory_wired_bytes
   node_netstat_tcp_receive_packets_total
   node_netstat_tcp_transmit_packets_total


### PR DESCRIPTION
Add `node_memory_swap_size_bytes` to non-deterministic metrics for the OpenBSD tests.