### PR TITLE
filesystem: support ext4 super block emergency_ro flag

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -226,9 +226,13 @@ func parseFilesystemLabels(mountInfo []*procfs.MountInfo) ([]filesystemLabels, e
 }
 
 // see https://github.com/prometheus/node_exporter/issues/3157#issuecomment-2422761187
-// if either mount or super options contain "ro" the filesystem is read-only
+// if either mount or super options contain "ro" or the superblock contains "emergency_ro",
+// the filesystem is read-only
 func isFilesystemReadOnly(labels filesystemLabels) bool {
-	if slices.Contains(strings.Split(labels.mountOptions, ","), "ro") || slices.Contains(strings.Split(labels.superOptions, ","), "ro") {
+	mountOptions := strings.Split(labels.mountOptions, ",")
+	superOptions := strings.Split(labels.superOptions, ",")
+
+	if slices.Contains(mountOptions, "ro") || slices.Contains(superOptions, "ro") || slices.Contains(superOptions, "emergency_ro") {
 		return true
 	}
 

--- a/collector/filesystem_linux_test.go
+++ b/collector/filesystem_linux_test.go
@@ -81,6 +81,12 @@ func Test_isFilesystemReadOnly(t *testing.T) {
 				superOptions: "ro,nodev",
 			}, expected: true,
 		},
+		"/media/volume5": {
+			labels: filesystemLabels{
+				mountOptions: "rw,user_id=1000,group_id=1000",
+				superOptions: "emergency_ro",
+			}, expected: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Since Linux 6.15, the ext4 superblock exposes the 'emergency_ro' flag when 'errors=remount-ro' has been triggered. The 'ro' flag is no longer set on the super block in this case since Linux 6.12.

reference:
- https://github.com/torvalds/linux/commit/6b76715d5e41f
- https://github.com/torvalds/linux/commit/d3476f3dad4ad

This commit will allow reporting an ext4 filesystem as read-only, for Linux 6.15+. Hosts with a version between 6.12 and 6.15 or with a backport of the 6.12 fix will still report an 'emergency_ro' filesystem as read-write.

This was tested manually with a 6.18.x Kernel using a 'flakey' device mapper overlay for fault injection.