### PR TITLE
edac: Add per-channel error metrics with DIMM labels

### DIFF
--- a/collector/edac_linux.go
+++ b/collector/edac_linux.go
@@ -18,8 +18,10 @@ package collector
 import (
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -31,6 +33,7 @@ const (
 var (
 	edacMemControllerRE = regexp.MustCompile(`.*devices/system/edac/mc/mc([0-9]*)`)
 	edacMemCsrowRE      = regexp.MustCompile(`.*devices/system/edac/mc/mc[0-9]*/csrow([0-9]*)`)
+	edacMemChannelRE    = regexp.MustCompile(`ch([0-9]+)_ce_count`)
 )
 
 type edacCollector struct {
@@ -62,6 +65,16 @@ var (
 		"Total uncorrectable memory errors for this csrow.",
 		[]string{"controller", "csrow"}, nil,
 	)
+	edacChannelCECount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, edacSubsystem, "channel_correctable_errors_total"),
+		"Total correctable memory errors for this channel.",
+		[]string{"controller", "csrow", "channel", "dimm_label"}, nil,
+	)
+	edacChannelUECount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, edacSubsystem, "channel_uncorrectable_errors_total"),
+		"Total uncorrectable memory errors for this channel.",
+		[]string{"controller", "csrow", "channel", "dimm_label"}, nil,
+	)
 )
 
 // NewEdacCollector returns a new Collector exposing edac stats.
@@ -69,6 +82,19 @@ func NewEdacCollector(logger *slog.Logger) (Collector, error) {
 	return &edacCollector{
 		logger: logger,
 	}, nil
+}
+
+func edacDimmLabel(csrow, channel string) string {
+	label := "unknown"
+	labelBytes, err := os.ReadFile(filepath.Join(csrow, "ch"+channel+"_dimm_label"))
+	if err != nil {
+		return label
+	}
+	label = strings.TrimSpace(string(labelBytes))
+	label = strings.ReplaceAll(label, "#", "")
+	label = strings.ReplaceAll(label, "csrow", "_csrow")
+	label = strings.ReplaceAll(label, "channel", "_channel")
+	return label
 }
 
 func (c *edacCollector) Update(ch chan<- prometheus.Metric) error {
@@ -136,8 +162,49 @@ func (c *edacCollector) Update(ch chan<- prometheus.Metric) error {
 			}
 			ch <- prometheus.MustNewConstMetric(
 				edacCsRowUECount, prometheus.CounterValue, float64(value), controllerNumber, csrowNumber)
+
+			channelFiles, err := filepath.Glob(csrow + "/ch*_ce_count")
+			if err != nil {
+				return err
+			}
+			for _, chFile := range channelFiles {
+				match := edacMemChannelRE.FindStringSubmatch(filepath.Base(chFile))
+				if match == nil {
+					continue
+				}
+				channelNumber := match[1]
+				label := edacDimmLabel(csrow, channelNumber)
+
+				value, err = readUintFromFile(chFile)
+				if err != nil {
+					return fmt.Errorf("couldn't get ce_count for controller/csrow/channel %s/%s/%s: %w", controllerNumber, csrowNumber, channelNumber, err)
+				}
+				ch <- prometheus.MustNewConstMetric(
+					edacChannelCECount,
+					prometheus.CounterValue,
+					float64(value),
+					controllerNumber,
+					csrowNumber,
+					channelNumber,
+					label,
+				)
+
+				value, err = readUintFromFile(filepath.Join(csrow, "ch"+channelNumber+"_ue_count"))
+				if err != nil {
+					return fmt.Errorf("couldn't get ue_count for controller/csrow/channel %s/%s/%s: %w", controllerNumber, csrowNumber, channelNumber, err)
+				}
+				ch <- prometheus.MustNewConstMetric(
+					edacChannelUECount,
+					prometheus.CounterValue,
+					float64(value),
+					controllerNumber,
+					csrowNumber,
+					channelNumber,
+					label,
+				)
+			}
 		}
 	}
 
-	return err
+	return nil
 }

--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -1363,16 +1363,30 @@ node_drbd_remote_pending{device="drbd1"} 12346
 # HELP node_drbd_remote_unacknowledged Number of requests received by the peer via the network connection, but that have not yet been answered.
 # TYPE node_drbd_remote_unacknowledged gauge
 node_drbd_remote_unacknowledged{device="drbd1"} 12347
+# HELP node_edac_channel_correctable_errors_total Total correctable memory errors for this channel.
+# TYPE node_edac_channel_correctable_errors_total counter
+node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 0
+node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="1",dimm_label="mc0_csrow1_channel0"} 0
+node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="0",dimm_label="mc0_csrow0_channel1"} 0
+node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="1",dimm_label="mc0_csrow1_channel1"} 0
+# HELP node_edac_channel_uncorrectable_errors_total Total uncorrectable memory errors for this channel.
+# TYPE node_edac_channel_uncorrectable_errors_total counter
+node_edac_channel_uncorrectable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 2
+node_edac_channel_uncorrectable_errors_total{channel="0",controller="0",csrow="1",dimm_label="mc0_csrow1_channel0"} 2
+node_edac_channel_uncorrectable_errors_total{channel="1",controller="0",csrow="0",dimm_label="mc0_csrow0_channel1"} 2
+node_edac_channel_uncorrectable_errors_total{channel="1",controller="0",csrow="1",dimm_label="mc0_csrow1_channel1"} 2
 # HELP node_edac_correctable_errors_total Total correctable memory errors.
 # TYPE node_edac_correctable_errors_total counter
 node_edac_correctable_errors_total{controller="0"} 1
 # HELP node_edac_csrow_correctable_errors_total Total correctable memory errors for this csrow.
 # TYPE node_edac_csrow_correctable_errors_total counter
 node_edac_csrow_correctable_errors_total{controller="0",csrow="0"} 3
+node_edac_csrow_correctable_errors_total{controller="0",csrow="1"} 0
 node_edac_csrow_correctable_errors_total{controller="0",csrow="unknown"} 2
 # HELP node_edac_csrow_uncorrectable_errors_total Total uncorrectable memory errors for this csrow.
 # TYPE node_edac_csrow_uncorrectable_errors_total counter
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="0"} 4
+node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="1"} 4
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="unknown"} 6
 # HELP node_edac_uncorrectable_errors_total Total uncorrectable memory errors.
 # TYPE node_edac_uncorrectable_errors_total counter

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -1395,16 +1395,30 @@ node_drbd_remote_pending{device="drbd1"} 12346
 # HELP node_drbd_remote_unacknowledged Number of requests received by the peer via the network connection, but that have not yet been answered.
 # TYPE node_drbd_remote_unacknowledged gauge
 node_drbd_remote_unacknowledged{device="drbd1"} 12347
+# HELP node_edac_channel_correctable_errors_total Total correctable memory errors for this channel.
+# TYPE node_edac_channel_correctable_errors_total counter
+node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 0
+node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="1",dimm_label="mc0_csrow1_channel0"} 0
+node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="0",dimm_label="mc0_csrow0_channel1"} 0
+node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="1",dimm_label="mc0_csrow1_channel1"} 0
+# HELP node_edac_channel_uncorrectable_errors_total Total uncorrectable memory errors for this channel.
+# TYPE node_edac_channel_uncorrectable_errors_total counter
+node_edac_channel_uncorrectable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 2
+node_edac_channel_uncorrectable_errors_total{channel="0",controller="0",csrow="1",dimm_label="mc0_csrow1_channel0"} 2
+node_edac_channel_uncorrectable_errors_total{channel="1",controller="0",csrow="0",dimm_label="mc0_csrow0_channel1"} 2
+node_edac_channel_uncorrectable_errors_total{channel="1",controller="0",csrow="1",dimm_label="mc0_csrow1_channel1"} 2
 # HELP node_edac_correctable_errors_total Total correctable memory errors.
 # TYPE node_edac_correctable_errors_total counter
 node_edac_correctable_errors_total{controller="0"} 1
 # HELP node_edac_csrow_correctable_errors_total Total correctable memory errors for this csrow.
 # TYPE node_edac_csrow_correctable_errors_total counter
 node_edac_csrow_correctable_errors_total{controller="0",csrow="0"} 3
+node_edac_csrow_correctable_errors_total{controller="0",csrow="1"} 0
 node_edac_csrow_correctable_errors_total{controller="0",csrow="unknown"} 2
 # HELP node_edac_csrow_uncorrectable_errors_total Total uncorrectable memory errors for this csrow.
 # TYPE node_edac_csrow_uncorrectable_errors_total counter
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="0"} 4
+node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="1"} 4
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="unknown"} 6
 # HELP node_edac_uncorrectable_errors_total Total uncorrectable memory errors.
 # TYPE node_edac_uncorrectable_errors_total counter

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -9443,9 +9443,62 @@ Mode: 644
 Directory: sys/devices/system/edac/mc/mc0/csrow0
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch0_ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/system/edac/mc/mc0/csrow1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch0_ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch1_ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch1_ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/csrow0/ce_count
 Lines: 1
 3
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch0_ue_count
+Lines: 1
+2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch0_ue_count
+Lines: 1
+2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch1_ue_count
+Lines: 1
+2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch1_ue_count
+Lines: 1
+2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ue_count
+Lines: 1
+4
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/csrow0/ue_count
@@ -9461,6 +9514,26 @@ Mode: 644
 Path: sys/devices/system/edac/mc/mc0/ue_noinfo_count
 Lines: 1
 6
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch0_dimm_label
+Lines: 1
+mc0csrow0channel0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch1_dimm_label
+Lines: 1
+mc0csrow0channel1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch0_dimm_label
+Lines: 1
+mc0csrow1channel0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch1_dimm_label
+Lines: 1
+mc0csrow1channel1
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/devices/system/node


### PR DESCRIPTION
## Summary

Continues #3571. Original author @Manognagrandhi moved off our team; I'm taking this forward from my fork with fixes to get the change merge-ready.

Adds per-channel correctable/uncorrectable EDAC counters with `controller`, `csrow`, `channel`, and `dimm_label` labels, while preserving existing controller- and csrow-level metrics.

Example output:
```text
node_edac_channel_correctable_errors_total{channel="2",controller="0",csrow="2",dimm_label="mc0_csrow2_channel2"} 123
node_edac_correctable_errors_total{controller="0"} 123