### PR TITLE
Add workflow to approve CI runs

### DIFF
--- a/.github/workflows/approve-workflows.yml
+++ b/.github/workflows/approve-workflows.yml
@@ -1,0 +1,24 @@
+---
+name: Approve pending workflows
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: read-all
+
+jobs:
+  approve:
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/workflow-approve' &&
+      github.repository_owner == 'prometheus'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: prometheus/promci/approve_workflows@370e8c15dcec50043cbe66f2f34633d9efc0a190
+        with:
+          github_token: ${{ github.token }}

--- a/.github/workflows/approve-workflows.yml
+++ b/.github/workflows/approve-workflows.yml
@@ -19,6 +19,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: prometheus/promci/approve_workflows@370e8c15dcec50043cbe66f2f34633d9efc0a190
+      - uses: prometheus/promci/approve_workflows@370e8c15dcec50043cbe66f2f34633d9efc0a190 # v0.9.0
         with:
           github_token: ${{ github.token }}


### PR DESCRIPTION
Add a CI workflow that allows folks with `triage` access to approve CI runs, overriding the GitHub default behavior, which requires at least `write` access to approve CI runs.