### PR TITLE
textfile: support UTF-8 metric and label names

### DIFF
--- a/collector/textfile.go
+++ b/collector/textfile.go
@@ -293,7 +293,7 @@ func (c *textFileCollector) processFile(dir, name string) (*time.Time, map[strin
 	}
 	defer f.Close()
 
-	parser := expfmt.NewTextParser(model.LegacyValidation)
+	parser := expfmt.NewTextParser(model.UTF8Validation)
 	families, err := parser.TextToMetricFamilies(f)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse textfile data from %q: %w", path, err)

--- a/collector/textfile_test.go
+++ b/collector/textfile_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -155,4 +156,38 @@ func TestTextfileCollector(t *testing.T) {
 			t.Fatalf("%d.%q want:\n\n%s\n\ngot:\n\n%s", i, test.paths, string(want), got)
 		}
 	}
+}
+
+func TestTextfileCollectorSupportsUTF8Names(t *testing.T) {
+	dir := t.TempDir()
+	const input = `# HELP "my.dotted.metric" A metric with UTF-8 compatible names.
+# TYPE "my.dotted.metric" gauge
+{"my.dotted.metric", "error.message"="Not Found"} 1
+`
+	if err := os.WriteFile(filepath.Join(dir, "test.prom"), []byte(input), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &textFileCollector{
+		paths:  []string{dir},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collectorAdapter{c})
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather textfile with UTF-8 names: %v", err)
+	}
+
+	for _, family := range families {
+		if family.GetName() != "my.dotted.metric" {
+			continue
+		}
+		if got := family.Metric[0].Label[0].GetName(); got != "error.message" {
+			t.Fatalf("expected dotted label name, got %q", got)
+		}
+		return
+	}
+	t.Fatalf("expected dotted metric name, got %v", families)
 }


### PR DESCRIPTION
## Summary

Since #3405 updated `prometheus/common` to v0.66.1 and adapted the textfile parser to its explicit validation API, the parser has used `LegacyValidation`. This rejects quoted metric and label names that are valid under the current UTF-8 exposition format, including names containing dots.

Use `UTF8Validation` when parsing textfile input and add a regression test covering dotted metric and label names.

Legacy-compatible input remains accepted. The HTTP handler continues to use `promhttp`'s existing name-escaping negotiation for scraper compatibility.

## Testing

- `go test ./collector -run '^TestTextfileCollector(SupportsUTF8Names)?$' -count=1`
- `go test -short ./...`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 make lint`
- `make test` with Go 1.26 on Linux

Fixes #3700.

cc @SuperQ
