### PR TITLE
edac: Fix optional csrow ue_count collection

### DIFF
--- a/collector/edac_linux.go
+++ b/collector/edac_linux.go
@@ -190,18 +190,19 @@ func (c *edacCollector) Update(ch chan<- prometheus.Metric) error {
 				)
 
 				value, err = readUintFromFile(filepath.Join(csrow, "ch"+channelNumber+"_ue_count"))
-				if err != nil {
-					return fmt.Errorf("couldn't get ue_count for controller/csrow/channel %s/%s/%s: %w", controllerNumber, csrowNumber, channelNumber, err)
+				if err == nil {
+					ch <- prometheus.MustNewConstMetric(
+						edacChannelUECount,
+						prometheus.CounterValue,
+						float64(value),
+						controllerNumber,
+						csrowNumber,
+						channelNumber,
+						label,
+					)
+				} else {
+					c.logger.Debug("couldn't get ue_count for controller/csrow/channel %s/%s/%s: %w", controllerNumber, csrowNumber, channelNumber, err)
 				}
-				ch <- prometheus.MustNewConstMetric(
-					edacChannelUECount,
-					prometheus.CounterValue,
-					float64(value),
-					controllerNumber,
-					csrowNumber,
-					channelNumber,
-					label,
-				)
 			}
 		}
 	}

--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -1367,8 +1367,10 @@ node_drbd_remote_unacknowledged{device="drbd1"} 12347
 # TYPE node_edac_channel_correctable_errors_total counter
 node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 0
 node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="1",dimm_label="mc0_csrow1_channel0"} 0
+node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="2",dimm_label="mc0_csrow2_channel0"} 0
 node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="0",dimm_label="mc0_csrow0_channel1"} 0
 node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="1",dimm_label="mc0_csrow1_channel1"} 0
+node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="2",dimm_label="mc0_csrow2_channel1"} 0
 # HELP node_edac_channel_uncorrectable_errors_total Total uncorrectable memory errors for this channel.
 # TYPE node_edac_channel_uncorrectable_errors_total counter
 node_edac_channel_uncorrectable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 2
@@ -1382,11 +1384,13 @@ node_edac_correctable_errors_total{controller="0"} 1
 # TYPE node_edac_csrow_correctable_errors_total counter
 node_edac_csrow_correctable_errors_total{controller="0",csrow="0"} 3
 node_edac_csrow_correctable_errors_total{controller="0",csrow="1"} 0
+node_edac_csrow_correctable_errors_total{controller="0",csrow="2"} 0
 node_edac_csrow_correctable_errors_total{controller="0",csrow="unknown"} 2
 # HELP node_edac_csrow_uncorrectable_errors_total Total uncorrectable memory errors for this csrow.
 # TYPE node_edac_csrow_uncorrectable_errors_total counter
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="0"} 4
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="1"} 4
+node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="2"} 5
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="unknown"} 6
 # HELP node_edac_uncorrectable_errors_total Total uncorrectable memory errors.
 # TYPE node_edac_uncorrectable_errors_total counter

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -1399,8 +1399,10 @@ node_drbd_remote_unacknowledged{device="drbd1"} 12347
 # TYPE node_edac_channel_correctable_errors_total counter
 node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 0
 node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="1",dimm_label="mc0_csrow1_channel0"} 0
+node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="2",dimm_label="mc0_csrow2_channel0"} 0
 node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="0",dimm_label="mc0_csrow0_channel1"} 0
 node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="1",dimm_label="mc0_csrow1_channel1"} 0
+node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="2",dimm_label="mc0_csrow2_channel1"} 0
 # HELP node_edac_channel_uncorrectable_errors_total Total uncorrectable memory errors for this channel.
 # TYPE node_edac_channel_uncorrectable_errors_total counter
 node_edac_channel_uncorrectable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 2
@@ -1414,11 +1416,13 @@ node_edac_correctable_errors_total{controller="0"} 1
 # TYPE node_edac_csrow_correctable_errors_total counter
 node_edac_csrow_correctable_errors_total{controller="0",csrow="0"} 3
 node_edac_csrow_correctable_errors_total{controller="0",csrow="1"} 0
+node_edac_csrow_correctable_errors_total{controller="0",csrow="2"} 0
 node_edac_csrow_correctable_errors_total{controller="0",csrow="unknown"} 2
 # HELP node_edac_csrow_uncorrectable_errors_total Total uncorrectable memory errors for this csrow.
 # TYPE node_edac_csrow_uncorrectable_errors_total counter
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="0"} 4
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="1"} 4
+node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="2"} 5
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="unknown"} 6
 # HELP node_edac_uncorrectable_errors_total Total uncorrectable memory errors.
 # TYPE node_edac_uncorrectable_errors_total counter

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -9572,12 +9572,25 @@ Lines: 1
 0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/system/edac/mc/mc0/csrow2
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow2/ch0_ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/csrow0/ch1_ce_count
 Lines: 1
 0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/csrow1/ch1_ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow2/ch1_ce_count
 Lines: 1
 0
 Mode: 644
@@ -9617,6 +9630,16 @@ Lines: 1
 4
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow2/ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow2/ue_count
+Lines: 1
+5
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/csrow0/ue_count
 Lines: 1
 4
@@ -9650,6 +9673,16 @@ Mode: 644
 Path: sys/devices/system/edac/mc/mc0/csrow1/ch1_dimm_label
 Lines: 1
 mc0csrow1channel1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow2/ch0_dimm_label
+Lines: 1
+mc0csrow2channel0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow2/ch1_dimm_label
+Lines: 1
+mc0csrow2channel1
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/devices/system/node


### PR DESCRIPTION
PR #3720 introduced the node_edac_channel_uncorrectable_errors_total metric.

It depends on the per-channel ue_count file (e.g. ch0_ue_count). This isn't always available. Therefore, only log a debug message if it's missing and keep the existing collector working.

Validated on ProLiant DL380 Gen10 hardware -- ERROR message disappears, `node_scrape_collector_success{collector="edac"}` is `1` again.

Note: The sys.ttar changes are hand-crafted because `make update_fixtures` generated a sys.ttar file with a different order, making it hard to review. Maybe I'm missing something?

Fixes #3730.