### PR TITLE
feat: expose sysfs_device label for network, nvme, and infiniband

### DIFF
--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -1711,8 +1711,8 @@ node_hwmon_temp_max_celsius{chip="platform_coretemp_1",sensor="temp4"} 84
 node_hwmon_temp_max_celsius{chip="platform_coretemp_1",sensor="temp5"} 84
 # HELP node_infiniband_info Non-numeric data from /sys/class/infiniband/<device>, value is always 1.
 # TYPE node_infiniband_info gauge
-node_infiniband_info{board_id="I40IW Board ID",device="i40iw0",firmware_version="0.2",hca_type="I40IW"} 1
-node_infiniband_info{board_id="SM_1141000001000",device="mlx4_0",firmware_version="2.31.5050",hca_type="MT4099"} 1
+node_infiniband_info{board_id="I40IW Board ID",device="i40iw0",firmware_version="0.2",hca_type="I40IW",sysfs_device=""} 1
+node_infiniband_info{board_id="SM_1141000001000",device="mlx4_0",firmware_version="2.31.5050",hca_type="MT4099",sysfs_device=""} 1
 # HELP node_infiniband_legacy_data_received_bytes_total Number of data octets received on all links
 # TYPE node_infiniband_legacy_data_received_bytes_total counter
 node_infiniband_legacy_data_received_bytes_total{device="mlx4_0",port="1"} 1.8527668e+07
@@ -3141,8 +3141,8 @@ node_network_iface_link_mode{device="bond0"} 1
 node_network_iface_link_mode{device="eth0"} 1
 # HELP node_network_info Non-numeric data from /sys/class/net/<iface>, value is always 1.
 # TYPE node_network_info gauge
-node_network_info{address="01:01:01:01:01:01",adminstate="up",broadcast="ff:ff:ff:ff:ff:ff",device="bond0",duplex="full",ifalias="",operstate="up"} 1
-node_network_info{address="01:01:01:01:01:01",adminstate="up",broadcast="ff:ff:ff:ff:ff:ff",device="eth0",duplex="full",ifalias="",operstate="up"} 1
+node_network_info{address="01:01:01:01:01:01",adminstate="up",broadcast="ff:ff:ff:ff:ff:ff",device="bond0",duplex="full",ifalias="",operstate="up",sysfs_device=""} 1
+node_network_info{address="01:01:01:01:01:01",adminstate="up",broadcast="ff:ff:ff:ff:ff:ff",device="eth0",duplex="full",ifalias="",operstate="up",sysfs_device=""} 1
 # HELP node_network_mtu_bytes Network device property: mtu_bytes
 # TYPE node_network_mtu_bytes gauge
 node_network_mtu_bytes{device="bond0"} 1500
@@ -3484,7 +3484,7 @@ node_nfsd_server_rpcs_total 18628
 node_nfsd_server_threads 8
 # HELP node_nvme_info Non-numeric data from /sys/class/nvme/<device>, value is always 1.
 # TYPE node_nvme_info gauge
-node_nvme_info{cntlid="1997",device="nvme0",firmware_revision="1B2QEXP7",model="Samsung SSD 970 PRO 512GB",serial="S680HF8N190894I",state="live"} 1
+node_nvme_info{cntlid="1997",device="nvme0",firmware_revision="1B2QEXP7",model="Samsung SSD 970 PRO 512GB",serial="S680HF8N190894I",state="live",sysfs_device=""} 1
 # HELP node_nvme_namespace_capacity_bytes Capacity of the NVMe namespace in bytes. Computed as namespace_size * namespace_logical_block_size
 # TYPE node_nvme_namespace_capacity_bytes gauge
 node_nvme_namespace_capacity_bytes{device="nvme0",nsid="1"} 1.6e+13

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -1743,8 +1743,8 @@ node_hwmon_temp_max_celsius{chip="platform_coretemp_1",sensor="temp4"} 84
 node_hwmon_temp_max_celsius{chip="platform_coretemp_1",sensor="temp5"} 84
 # HELP node_infiniband_info Non-numeric data from /sys/class/infiniband/<device>, value is always 1.
 # TYPE node_infiniband_info gauge
-node_infiniband_info{board_id="I40IW Board ID",device="i40iw0",firmware_version="0.2",hca_type="I40IW"} 1
-node_infiniband_info{board_id="SM_1141000001000",device="mlx4_0",firmware_version="2.31.5050",hca_type="MT4099"} 1
+node_infiniband_info{board_id="I40IW Board ID",device="i40iw0",firmware_version="0.2",hca_type="I40IW",sysfs_device=""} 1
+node_infiniband_info{board_id="SM_1141000001000",device="mlx4_0",firmware_version="2.31.5050",hca_type="MT4099",sysfs_device=""} 1
 # HELP node_infiniband_legacy_data_received_bytes_total Number of data octets received on all links
 # TYPE node_infiniband_legacy_data_received_bytes_total counter
 node_infiniband_legacy_data_received_bytes_total{device="mlx4_0",port="1"} 1.8527668e+07
@@ -3173,8 +3173,8 @@ node_network_iface_link_mode{device="bond0"} 1
 node_network_iface_link_mode{device="eth0"} 1
 # HELP node_network_info Non-numeric data from /sys/class/net/<iface>, value is always 1.
 # TYPE node_network_info gauge
-node_network_info{address="01:01:01:01:01:01",adminstate="up",broadcast="ff:ff:ff:ff:ff:ff",device="bond0",duplex="full",ifalias="",operstate="up"} 1
-node_network_info{address="01:01:01:01:01:01",adminstate="up",broadcast="ff:ff:ff:ff:ff:ff",device="eth0",duplex="full",ifalias="",operstate="up"} 1
+node_network_info{address="01:01:01:01:01:01",adminstate="up",broadcast="ff:ff:ff:ff:ff:ff",device="bond0",duplex="full",ifalias="",operstate="up",sysfs_device=""} 1
+node_network_info{address="01:01:01:01:01:01",adminstate="up",broadcast="ff:ff:ff:ff:ff:ff",device="eth0",duplex="full",ifalias="",operstate="up",sysfs_device=""} 1
 # HELP node_network_mtu_bytes Network device property: mtu_bytes
 # TYPE node_network_mtu_bytes gauge
 node_network_mtu_bytes{device="bond0"} 1500
@@ -3516,7 +3516,7 @@ node_nfsd_server_rpcs_total 18628
 node_nfsd_server_threads 8
 # HELP node_nvme_info Non-numeric data from /sys/class/nvme/<device>, value is always 1.
 # TYPE node_nvme_info gauge
-node_nvme_info{cntlid="1997",device="nvme0",firmware_revision="1B2QEXP7",model="Samsung SSD 970 PRO 512GB",serial="S680HF8N190894I",state="live"} 1
+node_nvme_info{cntlid="1997",device="nvme0",firmware_revision="1B2QEXP7",model="Samsung SSD 970 PRO 512GB",serial="S680HF8N190894I",state="live",sysfs_device=""} 1
 # HELP node_nvme_namespace_capacity_bytes Capacity of the NVMe namespace in bytes. Computed as namespace_size * namespace_logical_block_size
 # TYPE node_nvme_namespace_capacity_bytes gauge
 node_nvme_namespace_capacity_bytes{device="nvme0",nsid="1"} 1.6e+13

--- a/collector/helper.go
+++ b/collector/helper.go
@@ -15,10 +15,21 @@ package collector
 
 import (
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 )
+
+// sysfsDevice returns the base name of the symlink target of /sys/class/<class>/<device>/device
+func sysfsDevice(class, device string) string {
+	path := sysFilePath(filepath.Join("class", class, device, "device"))
+	symlink, err := os.Readlink(path)
+	if err != nil {
+		return ""
+	}
+	return filepath.Base(symlink)
+}
 
 func readUintFromFile(path string) (uint64, error) {
 	data, err := os.ReadFile(path)

--- a/collector/infiniband_linux.go
+++ b/collector/infiniband_linux.go
@@ -175,11 +175,11 @@ func (c *infinibandCollector) Update(ch chan<- prometheus.Metric) error {
 		infoDesc := prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, c.subsystem, "info"),
 			"Non-numeric data from /sys/class/infiniband/<device>, value is always 1.",
-			[]string{"device", "board_id", "firmware_version", "hca_type"},
+			[]string{"device", "board_id", "firmware_version", "hca_type", "sysfs_device"},
 			nil,
 		)
 		infoValue := 1.0
-		ch <- prometheus.MustNewConstMetric(infoDesc, prometheus.GaugeValue, infoValue, device.Name, device.BoardID, device.FirmwareVersion, device.HCAType)
+		ch <- prometheus.MustNewConstMetric(infoDesc, prometheus.GaugeValue, infoValue, device.Name, device.BoardID, device.FirmwareVersion, device.HCAType, sysfsDevice("infiniband", device.Name))
 
 		for _, port := range device.Ports {
 			portStr := strconv.FormatUint(uint64(port.Port), 10)

--- a/collector/netclass_linux.go
+++ b/collector/netclass_linux.go
@@ -97,12 +97,12 @@ func (c *netClassCollector) netClassSysfsUpdate(ch chan<- prometheus.Metric) err
 		infoDesc := prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, c.subsystem, "info"),
 			"Non-numeric data from /sys/class/net/<iface>, value is always 1.",
-			[]string{"device", "address", "broadcast", "duplex", "operstate", "adminstate", "ifalias"},
+			[]string{"device", "address", "broadcast", "duplex", "operstate", "adminstate", "ifalias", "sysfs_device"},
 			nil,
 		)
 		infoValue := 1.0
 
-		ch <- prometheus.MustNewConstMetric(infoDesc, prometheus.GaugeValue, infoValue, ifaceInfo.Name, ifaceInfo.Address, ifaceInfo.Broadcast, ifaceInfo.Duplex, ifaceInfo.OperState, getAdminState(ifaceInfo.Flags), ifaceInfo.IfAlias)
+		ch <- prometheus.MustNewConstMetric(infoDesc, prometheus.GaugeValue, infoValue, ifaceInfo.Name, ifaceInfo.Address, ifaceInfo.Broadcast, ifaceInfo.Duplex, ifaceInfo.OperState, getAdminState(ifaceInfo.Flags), ifaceInfo.IfAlias, sysfsDevice("net", ifaceInfo.Name))
 
 		pushMetric(ch, c.getFieldDesc("address_assign_type"), ifaceInfo.AddrAssignType, prometheus.GaugeValue, ifaceInfo.Name)
 		pushMetric(ch, c.getFieldDesc("carrier"), ifaceInfo.Carrier, prometheus.GaugeValue, ifaceInfo.Name)

--- a/collector/nvme_linux.go
+++ b/collector/nvme_linux.go
@@ -38,7 +38,7 @@ var (
 	nvmeInfo = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "nvme", "info"),
 		"Non-numeric data from /sys/class/nvme/<device>, value is always 1.",
-		[]string{"device", "firmware_revision", "model", "serial", "state", "cntlid"},
+		[]string{"device", "firmware_revision", "model", "serial", "state", "cntlid", "sysfs_device"},
 		nil,
 	)
 	nvmeNamespaceInfo = prometheus.NewDesc(
@@ -106,6 +106,7 @@ func (c *nvmeCollector) Update(ch chan<- prometheus.Metric) error {
 			device.Serial,
 			device.State,
 			device.ControllerID,
+			sysfsDevice("nvme", device.Name),
 		)
 
 		// Export namespace-level metrics


### PR DESCRIPTION
This PR implements the feature requested in #3721 by introducing a new `sysfs_device` label to the following info metrics:
- `node_network_info`
- `node_nvme_info`
- `node_infiniband_info`

**What changed:**
- Added a `sysfsDevice` helper to dynamically resolve the symlink target of `/sys/class/<class>/<device>/device`.
- Injected the underlying hardware address (e.g., PCI BDF `0000:00:1f.3`) into the metrics as a new label `sysfs_device`.
- Updated `e2e-output.txt` and `e2e-64k-page-output.txt` fixtures to reflect the new label format.

**Why this is needed:**
As detailed in #3721, when a physical hardware issue occurs (e.g., NIC or cable failure), operators need a reliable way to map the affected logical interface directly to its physical PCI/Hardware location on the chassis. Exposing the `sysfs_device` label makes it seamless to identify the physical BDF location for maintenance or part replacements.

Closes #3721
