### PR TITLE
collector/cpu: avoid frequency_hertz clash with cpufreq

### DIFF
--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -219,10 +219,13 @@ func (c *cpuCollector) updateInfo(ch chan<- prometheus.Metric) error {
 			cpu.CacheSize)
 	}
 
+	// Avoid clashing with the cpufreq collector, which exports the same
+	// metric name with a different help string and label set. Only use
+	// /proc/cpuinfo when cpufreq is disabled.
 	cpuFreqEnabled, ok := collectorState["cpufreq"]
 	if !ok || cpuFreqEnabled == nil {
 		c.logger.Debug("cpufreq key missing or nil value in collectorState map")
-	} else if *cpuFreqEnabled {
+	} else if !*cpuFreqEnabled {
 		for _, cpu := range info {
 			ch <- prometheus.MustNewConstMetric(c.cpuFrequencyHz,
 				prometheus.GaugeValue,

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -902,16 +902,6 @@ node_cpu_flag_info{flag="aes"} 1
 node_cpu_flag_info{flag="avx"} 1
 node_cpu_flag_info{flag="avx2"} 1
 node_cpu_flag_info{flag="constant_tsc"} 1
-# HELP node_cpu_frequency_hertz CPU frequency in hertz from /proc/cpuinfo.
-# TYPE node_cpu_frequency_hertz gauge
-node_cpu_frequency_hertz{core="0",cpu="0",package="0"} 7.99998e+08
-node_cpu_frequency_hertz{core="0",cpu="4",package="0"} 7.99989e+08
-node_cpu_frequency_hertz{core="1",cpu="1",package="0"} 8.00037e+08
-node_cpu_frequency_hertz{core="1",cpu="5",package="0"} 8.00083e+08
-node_cpu_frequency_hertz{core="2",cpu="2",package="0"} 8.0001e+08
-node_cpu_frequency_hertz{core="2",cpu="6",package="0"} 8.00017e+08
-node_cpu_frequency_hertz{core="3",cpu="3",package="0"} 8.00028e+08
-node_cpu_frequency_hertz{core="3",cpu="7",package="0"} 8.0003e+08
 # HELP node_cpu_guest_seconds_total Seconds the CPUs spent in guests (VMs) for each mode.
 # TYPE node_cpu_guest_seconds_total counter
 node_cpu_guest_seconds_total{cpu="0",mode="nice"} 0.01


### PR DESCRIPTION
## What

`node_cpu_frequency_hertz` was being emitted from both the cpu.info path (`/proc/cpuinfo`) and the cpufreq collector, with different help strings and label sets. On hosts where both sources actually produce samples (often large-core machines), Prometheus gather fails:

```
collected metric node_cpu_frequency_hertz ... has help "Current CPU thread frequency in hertz." but should have "CPU frequency in hertz from /proc/cpuinfo."
```

## Why

#3318 flipped the guard so cpu.info always emitted frequency while cpufreq was enabled. That restored the metric in some setups, but made the two collectors share a metric name they cannot share.

## Fix

Only export `/proc/cpuinfo` frequency when the cpufreq collector is disabled. When cpufreq is on, it owns `node_cpu_frequency_hertz`.

Updated the e2e fixture accordingly (those samples only appeared because of the broken dual export; the fixture has no `cpuinfo_cur_freq` for the cpufreq path).

## Test

```
go test ./collector/ -count=1 -short
go build .
```

Fixes #3689