### PR TITLE
chore(mixin): update NodeNetworkTransmitErrs/NodeNetworkReceiveErrs descriptions

### DIFF
--- a/docs/node-mixin/alerts/alerts.libsonnet
+++ b/docs/node-mixin/alerts/alerts.libsonnet
@@ -167,7 +167,7 @@
             },
             annotations: {
               summary: 'Network interface is reporting many receive errors.',
-              description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} receive errors in the last two minutes.',
+              description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.2f" $value }} receive errors in the last two minutes.',
             },
           },
           {
@@ -181,7 +181,7 @@
             },
             annotations: {
               summary: 'Network interface is reporting many transmit errors.',
-              description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} transmit errors in the last two minutes.',
+              description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.2f" $value }} transmit errors in the last two minutes.',
             },
           },
           {


### PR DESCRIPTION
Previous descriptions could lead to confusing alert description like:
```
Description
myhost interface tap8cf786dc-d2 has encountered 0 transmit errors in the last two minutes
```
if the latest value is < 0.5