### PR TITLE
mixins: rename Grafana dashboard titles for consistency

### DIFF
--- a/docs/node-mixin/config.libsonnet
+++ b/docs/node-mixin/config.libsonnet
@@ -4,7 +4,7 @@
 
     // Select the metrics coming from the node exporter. Note that all
     // the selected metrics are shown stacked on top of each other in
-    // the 'USE Method / Cluster' dashboard. Consider disabling that
+    // the 'Utilization and Saturation / Cluster' dashboard. Consider disabling that
     // dashboard if mixing up all those metrics in the same dashboard
     // doesn't make sense (e.g. because they are coming from different
     // clusters).

--- a/docs/node-mixin/dashboards/use.libsonnet
+++ b/docs/node-mixin/dashboards/use.libsonnet
@@ -118,7 +118,7 @@ local diskSpaceUtilisation =
   grafanaDashboards+:: {
                          'node-rsrc-use.json':
                            dashboard.new(
-                             '%sUSE Method / Node' % $._config.dashboardNamePrefix,
+                             '%sUtilization and Saturation / Node' % $._config.dashboardNamePrefix,
                            )
                            + dashboard.time.withFrom('now-1h')
                            + dashboard.withTags($._config.dashboardTags)
@@ -189,7 +189,7 @@ local diskSpaceUtilisation =
                            ),
                          'node-cluster-rsrc-use.json':
                            dashboard.new(
-                             '%sUSE Method / Cluster' % $._config.dashboardNamePrefix,
+                             '%sUtilization and Saturation / Cluster' % $._config.dashboardNamePrefix,
                            )
                            + dashboard.time.withFrom('now-1h')
                            + dashboard.withTags($._config.dashboardTags)
@@ -318,7 +318,7 @@ local diskSpaceUtilisation =
                        if $._config.showMultiCluster then {
                          'node-multicluster-rsrc-use.json':
                            dashboard.new(
-                             '%sUSE Method / Multi-cluster' % $._config.dashboardNamePrefix,
+                             '%sUtilization and Saturation / Multi-cluster' % $._config.dashboardNamePrefix,
                            )
                            + dashboard.time.withFrom('now-1h')
                            + dashboard.withTags($._config.dashboardTags)

--- a/docs/node-mixin/lib/prom-mixin.libsonnet
+++ b/docs/node-mixin/lib/prom-mixin.libsonnet
@@ -497,7 +497,7 @@ local tableTransformation = table.queryOptions.transformation;
 
     dashboard: if platform == 'Linux' then
       dashboard.new(
-        '%sNodes' % config.dashboardNamePrefix,
+        '%sNode' % config.dashboardNamePrefix,
       )
       + dashboard.time.withFrom('now-1h')
       + dashboard.withTags(config.dashboardTags)


### PR DESCRIPTION
## What

Rename node-mixin Grafana dashboard titles for consistency and clarity:

| Before | After |
|--------|--------|
| Node Exporter / **Nodes** | Node Exporter / **Node** |
| Node Exporter / **USE Method / Node** | Node Exporter / **Utilization and Saturation / Node** |
| Node Exporter / **USE Method / Cluster** | Node Exporter / **Utilization and Saturation / Cluster** |
| Node Exporter / **USE Method / Multi-cluster** | Node Exporter / **Utilization and Saturation / Multi-cluster** |

## Why

Per #1828 and discussion there:

- **Nodes** is a single-node dashboard (same scope as the former USE Method / Node) — use singular **Node**.
- **USE Method** is not self-explanatory; these dashboards also have no Errors panels, so **Utilization and Saturation** is a better name than spelling out full USE.
- Keep the Node / Cluster / Multi-cluster hierarchy; only the prefix and pluralization change.

Dashboard UIDs and JSON filenames are unchanged, so existing links by UID keep working. Display titles in the Grafana UI will update on next import/provision.

## Test

Docs/jsonnet only — no Go changes.

Fixes #1828