### PR TITLE
cpufreq_linux: fix race with cpu_linux collector for node_cpu_frequency_hertz metric

### DIFF
--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -219,18 +219,13 @@ func (c *cpuCollector) updateInfo(ch chan<- prometheus.Metric) error {
 			cpu.CacheSize)
 	}
 
-	cpuFreqEnabled, ok := collectorState["cpufreq"]
-	if !ok || cpuFreqEnabled == nil {
-		c.logger.Debug("cpufreq key missing or nil value in collectorState map")
-	} else if *cpuFreqEnabled {
-		for _, cpu := range info {
-			ch <- prometheus.MustNewConstMetric(c.cpuFrequencyHz,
-				prometheus.GaugeValue,
-				cpu.CPUMHz*1e6,
-				cpu.PhysicalID,
-				cpu.CoreID,
-				strconv.Itoa(int(cpu.Processor)))
-		}
+	for _, cpu := range info {
+		ch <- prometheus.MustNewConstMetric(c.cpuFrequencyHz,
+			prometheus.GaugeValue,
+			cpu.CPUMHz*1e6,
+			cpu.PhysicalID,
+			cpu.CoreID,
+			strconv.Itoa(int(cpu.Processor)))
 	}
 
 	if len(info) != 0 {

--- a/collector/cpufreq_linux.go
+++ b/collector/cpufreq_linux.go
@@ -53,10 +53,21 @@ func (c *cpuFreqCollector) Update(ch chan<- prometheus.Metric) error {
 		return err
 	}
 
+	// The current frequency metric is also provided by the cpuinfo-based collector.
+	// If that collector is enabled and set to provide frequency information,
+	// we skip this metric here (otherwise the two collectors would race for it)
+	cpuCollectorEnabled, ok := collectorState["cpu"]
+	skipCurrentFreq := false
+	if !ok || cpuCollectorEnabled == nil {
+		c.logger.Debug("cpu key missing or nil value in collectorState map")
+	} else {
+		skipCurrentFreq = *cpuCollectorEnabled && *enableCPUInfo
+	}
+
 	// sysfs cpufreq values are kHz, thus multiply by 1000 to export base units (hz).
 	// See https://www.kernel.org/doc/Documentation/cpu-freq/user-guide.txt
 	for _, stats := range cpuFreqs {
-		if stats.CpuinfoCurrentFrequency != nil {
+		if stats.CpuinfoCurrentFrequency != nil && !skipCurrentFreq {
 			ch <- prometheus.MustNewConstMetric(
 				cpuFreqHertzDesc,
 				prometheus.GaugeValue,


### PR DESCRIPTION
Hi,

the cpu_linux and cpufreq_linux collectors seem to fight for the `node_cpu_frequency_hertz` metric. It's a bit messy, but here is how that came to be, I think:

933b1c1 introduced the `node_cpu_frequency_hertz` metric in the cpu_linux collector. Since that name was also used by the cpufreq_linux collector, a check was added to not export that metrics from the cpu collector if the cpufreq collector is enabled.

In https://github.com/prometheus/node_exporter/pull/3318 that logic was then inverted for reasons that I don't quite get. The author of that PR states that this is necessary to get that metric exported at all when both cpu and cpufreq are enabled. My guess is that they had a configuration where the cpufreq collector failed (e.g., due to permission errors when reading the corresponding sysfs files). Forcing the cpu exporter to then also export that metric of course "fixes" the issue, but in cases where it *doesn't* fail, you get the metric exported twice. It seems that leads to a timing-sensitive race condition between the two collectors (hence that strange dependency on the number of cores) and finally to the error message I described in #3689.

Now, someone opened https://github.com/prometheus/node_exporter/pull/3749 to fix this by just reverting 933b1c1.[^1] I don't think that is a good solution as then someone else will likely run into the confusing situation again where both collectors are enabled, but the metric is missing. Since unprivileged reading of /proc/cpuinfo seems to be more reliable, I would instead suggest to flip the check and silence the cpufreq collector if the cpu collector is already collecting `node_cpu_frequency_hertz`. That way you also always get the more detailed version of the metric if it is collected.

[^1]: A kind of *sloppy* solution if you will.

Fixes #3689
