### PR TITLE
collector/filesystem: fix readonly false positives under ro rootfs bind mount

### DIFF
--- a/collector/filesystem_common.go
+++ b/collector/filesystem_common.go
@@ -81,6 +81,10 @@ type filesystemCollector struct {
 
 type filesystemLabels struct {
 	device, mountPoint, fsType, mountOptions, superOptions, deviceError, major, minor string
+	// hostMount is true when the mount point was found below the configured
+	// --path.rootfs prefix, i.e. it is a host mount observed from within a
+	// container through a bind mount of the host root.
+	hostMount bool
 }
 
 type filesystemStats struct {

--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -130,6 +130,7 @@ func (c *filesystemCollector) processStat(labels filesystemLabels) filesystemSta
 	// twice, with different options (metrics would be recorded multiple times).
 	labels.mountOptions = ""
 	labels.superOptions = ""
+	labels.hostMount = false
 
 	if err != nil {
 		labels.deviceError = err.Error()
@@ -208,15 +209,18 @@ func parseFilesystemLabels(mountInfo []*procfs.MountInfo) ([]filesystemLabels, e
 		mount.MountPoint = strings.ReplaceAll(mount.MountPoint, "\\040", " ")
 		mount.MountPoint = strings.ReplaceAll(mount.MountPoint, "\\011", "\t")
 
+		mountPoint := rootfsStripPrefix(mount.MountPoint)
+
 		filesystems = append(filesystems, filesystemLabels{
 			device:       strings.ToValidUTF8(mount.Source, "�"),
-			mountPoint:   strings.ToValidUTF8(rootfsStripPrefix(mount.MountPoint), "�"),
+			mountPoint:   strings.ToValidUTF8(mountPoint, "�"),
 			fsType:       strings.ToValidUTF8(mount.FSType, "�"),
 			mountOptions: mountOptionsString(mount.Options),
 			superOptions: mountOptionsString(mount.SuperOptions),
 			major:        strconv.Itoa(major),
 			minor:        strconv.Itoa(minor),
 			deviceError:  "",
+			hostMount:    mountPoint != mount.MountPoint,
 		})
 	}
 
@@ -227,14 +231,26 @@ func parseFilesystemLabels(mountInfo []*procfs.MountInfo) ([]filesystemLabels, e
 // if either mount or super options contain "ro" or the superblock contains "emergency_ro",
 // the filesystem is read-only
 func isFilesystemReadOnly(labels filesystemLabels) bool {
-	mountOptions := strings.Split(labels.mountOptions, ",")
 	superOptions := strings.Split(labels.superOptions, ",")
 
-	if slices.Contains(mountOptions, "ro") || slices.Contains(superOptions, "ro") || slices.Contains(superOptions, "emergency_ro") {
+	// Super options are shared across mount namespaces: "ro" or
+	// "emergency_ro" there means the filesystem itself is read-only.
+	if slices.Contains(superOptions, "ro") || slices.Contains(superOptions, "emergency_ro") {
 		return true
 	}
 
-	return false
+	// For mount points below --path.rootfs the per-mount options describe the
+	// exporter's own view of the host mounts. With the recommended
+	// containerized deployment the host root is bind-mounted read-only into
+	// the container (`-v /:/host:ro,rslave`), so every host mount carries a
+	// per-mount "ro" flag in the exporter's mount namespace even though the
+	// filesystem is writable on the host. Ignore per-mount options for those
+	// mount points to avoid false positives (issue #3755).
+	if labels.hostMount {
+		return false
+	}
+
+	return slices.Contains(strings.Split(labels.mountOptions, ","), "ro")
 }
 
 func mountOptionsString(m map[string]string) string {

--- a/collector/filesystem_linux_test.go
+++ b/collector/filesystem_linux_test.go
@@ -117,6 +117,32 @@ func Test_isFilesystemReadOnly(t *testing.T) {
 				superOptions: "emergency_ro",
 			}, expected: true,
 		},
+		// Host mount observed through a read-only bind mount of the host
+		// root (`-v /:/host:ro,rslave`): the per-mount "ro" belongs to the
+		// exporter's mount namespace, the filesystem itself is writable.
+		"/host/volume6": {
+			labels: filesystemLabels{
+				mountOptions: "ro,relatime",
+				superOptions: "rw,errors=remount-ro",
+				hostMount:    true,
+			}, expected: false,
+		},
+		// Host filesystem that really is read-only on the superblock level.
+		"/host/volume7": {
+			labels: filesystemLabels{
+				mountOptions: "ro,relatime",
+				superOptions: "ro",
+				hostMount:    true,
+			}, expected: true,
+		},
+		// Host ext4 filesystem after an emergency remount-ro (Linux 6.15+).
+		"/host/volume8": {
+			labels: filesystemLabels{
+				mountOptions: "ro,relatime",
+				superOptions: "rw,emergency_ro",
+				hostMount:    true,
+			}, expected: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -285,6 +311,49 @@ func TestMountOptionsStringReadOnlyDetection(t *testing.T) {
 					tt, got, tt.wantReadOnly, labels.mountOptions, labels.superOptions)
 			}
 		})
+	}
+}
+
+func TestPathRootfsReadOnly(t *testing.T) {
+	if _, err := kingpin.CommandLine.Parse([]string{"--path.procfs", "./fixtures_bindmount_ro/proc", "--path.rootfs", "/host"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The fixture mimics the recommended containerized deployment with the
+	// host root bind-mounted read-only (`-v /:/host:ro,rslave`): every mount
+	// below /host carries a per-mount "ro" flag in the exporter's mount
+	// namespace, regardless of the state of the host filesystem (issue #3755).
+	expected := map[string]bool{
+		// Writable on the host, per-mount "ro" only comes from the bind mount.
+		"/":         false,
+		"/var/data": false,
+		// Read-only on the superblock level, must still be reported.
+		"/mnt/backup": true,
+		// ext4 emergency remount-ro (Linux 6.15+), must still be reported.
+		"/mnt/flaky": true,
+		// Mounts of the exporter's own container keep the per-mount semantics.
+		"/run/lock":           false,
+		"/textfile_collector": true,
+	}
+
+	filesystems, err := mountPointDetails(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(filesystems) != len(expected) {
+		t.Errorf("Expected %d mount points, got %d", len(expected), len(filesystems))
+	}
+
+	for _, fs := range filesystems {
+		want, ok := expected[fs.mountPoint]
+		if !ok {
+			t.Errorf("Got unexpected mount point %s", fs.mountPoint)
+			continue
+		}
+		if got := isFilesystemReadOnly(fs); got != want {
+			t.Errorf("Expected readonly=%t for mount point %s, got %t", want, fs.mountPoint, got)
+		}
 	}
 }
 

--- a/collector/fixtures_bindmount_ro/proc/1/mountinfo
+++ b/collector/fixtures_bindmount_ro/proc/1/mountinfo
@@ -1,0 +1,6 @@
+29 1 259:0 / /host ro,relatime shared:1 - ext4 /dev/nvme1n0 rw
+30 1 260:0 / /host/var/data ro,relatime shared:2 - ext4 /dev/mapper/data--vg0-data--lv--0 rw
+31 1 261:0 / /host/mnt/backup ro,relatime shared:3 - ext4 /dev/sdb1 ro
+32 1 262:0 / /host/mnt/flaky ro,relatime shared:4 - ext4 /dev/sdc1 rw,emergency_ro
+33 28 0:27 / /run/lock rw,nosuid,nodev,noexec,relatime shared:6 - tmpfs tmpfs rw,size=5120k,inode64
+34 1 263:0 / /textfile_collector ro,relatime shared:7 - ext4 /dev/sdd1 rw


### PR DESCRIPTION
Fixes #3755

### The regression

After upgrading from 1.11.x to 1.12.0/1.12.1, `node_filesystem_readonly` reports `1` for host filesystems that are clearly writable, when node_exporter runs in the recommended containerized deployment (`-v /:/host:ro,rslave` + `--path.rootfs=/host`).

### Root cause

`isFilesystemReadOnly()` (introduced for #3157/#3484) considers a filesystem read-only when either the per-mount options (mountinfo field 6) or the super options (last mountinfo field) contain `ro`:

- **v1.11.x**: `mountOptionsString()` concatenated the options map **without separators** (e.g. `ro,relatime` became `rorelatime`), so `strings.Split(opts, ",")` could never match `ro` alongside other options. The per-mount check was effectively dead — that hid this problem (while also causing #3484).
- **v1.12.0**: 65902fa (#3659) fixed the missing comma separator, so the per-mount `ro` check actually started matching.

In the recommended containerized deployment the host root is bind-mounted read-only into the container. On current Docker (25.0+/API 1.44+, kernel >= 5.12) `ro` bind mounts are recursively read-only, so **every host mount propagated via `rslave` carries a per-mount `ro` flag in the exporter's mount namespace** — even though the filesystems are writable on the host. Unless the container also runs with `--pid=host` (in which case `/proc/1/mountinfo` provides the host's view), the exporter reads its own namespace's mountinfo and now reports `readonly 1` for every host filesystem. That is exactly the reporter's setup in #3755, and the same false positive was previously observed with the statfs-based detection in #2506.

The per-mount `ro` seen through `--path.rootfs` describes the exporter's *own view* of the host mounts (an artifact of the deployment), not the state of the host filesystem.

### The fix

For mount points below the configured `--path.rootfs` prefix, only consider the **super options** for the read-only decision. The superblock is shared across mount namespaces, so `ro`/`emergency_ro` there reliably reflects the state of the host filesystem regardless of how the exporter observes it:

- Host filesystems observed through a read-only bind mount are no longer falsely reported (`superOptions=rw`, per-mount `ro` ignored) — fixes the regression.
- Truly read-only filesystems are still reported: superblock `ro` (e.g. `mount -o ro`, or an ext4 emergency remount triggered by `errors=remount-ro`) and `emergency_ro` (Linux 6.15+, #3717) are honored for host mounts.
- Deployments without a rootfs prefix (bare metal, or containers with `--pid=host` where mountinfo is read from the host's PID 1) are unchanged: the per-mount `ro` semantics from #3484 (read-only bind mounts of a writable device) are preserved.

### Tests

- New fixture `collector/fixtures_bindmount_ro/` mirrors the reporter's environment as seen from the container's mount namespace: `/host` and `/host/var/data` with per-mount `ro` but superblock `rw` (must be `0`), plus a superblock-`ro` mount and an `emergency_ro` mount under `/host` (must stay `1`), and a `ro` bind mount of the container itself outside the rootfs prefix (must stay `1`, #3484 semantics).
- `TestPathRootfsReadOnly` runs `mountPointDetails` + `isFilesystemReadOnly` against that fixture. It fails on current master (`/` and `/var/data` are reported read-only) and passes with this change.
- New `hostMount` cases in `Test_isFilesystemReadOnly` cover the unit-level behavior.

Verified locally with `GOOS=linux go build`, `GOOS=linux go vet` and `GOOS=linux go test -c` (development on a non-Linux host — the Linux test suite runs in CI).
