### PR TITLE
edac: Add DIMM/rank layer support

### DIFF
--- a/collector/edac_linux.go
+++ b/collector/edac_linux.go
@@ -34,6 +34,7 @@ var (
 	edacMemControllerRE = regexp.MustCompile(`.*devices/system/edac/mc/mc([0-9]*)`)
 	edacMemCsrowRE      = regexp.MustCompile(`.*devices/system/edac/mc/mc[0-9]*/csrow([0-9]*)`)
 	edacMemChannelRE    = regexp.MustCompile(`ch([0-9]+)_ce_count`)
+	edacMemDimmRE       = regexp.MustCompile(`^(?:dimm|rank)([0-9]+)$`)
 )
 
 type edacCollector struct {
@@ -74,6 +75,17 @@ var (
 		prometheus.BuildFQName(namespace, edacSubsystem, "channel_uncorrectable_errors_total"),
 		"Total uncorrectable memory errors for this channel.",
 		[]string{"controller", "csrow", "channel", "dimm_label"}, nil,
+	)
+	edacDimmCECount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, edacSubsystem, "dimm_correctable_errors_total"),
+		"Total correctable memory errors for this DIMM.",
+		[]string{"controller", "dimm", "dimm_label"}, nil,
+	)
+	edacDimmUECount = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, edacSubsystem, "dimm_uncorrectable_errors_total"),
+		"Total uncorrectable memory errors for this DIMM. Best effort: errors the "+
+			"controller cannot localize to a slot are counted in ue_noinfo_count instead.",
+		[]string{"controller", "dimm", "dimm_label"}, nil,
 	)
 )
 
@@ -137,10 +149,18 @@ func (c *edacCollector) Update(ch chan<- prometheus.Metric) error {
 		ch <- prometheus.MustNewConstMetric(
 			edacCsRowUECount, prometheus.CounterValue, float64(value), controllerNumber, "unknown")
 
-		// For each controller, walk the csrow directories.
+		// Controllers with no csrow* keep their per-location counters in the DIMM
+		// layer instead. csrow* wins where both exist: amd64_edac_mod repeats the
+		// same counts under rank*, so reading both would double-count.
 		csrows, err := filepath.Glob(controller + "/csrow[0-9]*")
 		if err != nil {
 			return err
+		}
+		if len(csrows) == 0 {
+			if err := c.updateDimms(ch, controller, controllerNumber); err != nil {
+				return err
+			}
+			continue
 		}
 		for _, csrow := range csrows {
 			csrowMatch := edacMemCsrowRE.FindStringSubmatch(csrow)
@@ -208,4 +228,67 @@ func (c *edacCollector) Update(ch chan<- prometheus.Metric) error {
 	}
 
 	return nil
+}
+
+// updateDimms reads the DIMM/MEM layer, spelled dimm* or rank* depending on the
+// driver. Only populated slots are registered, so the indices are sparse.
+func (c *edacCollector) updateDimms(ch chan<- prometheus.Metric, controller, controllerNumber string) error {
+	var dimms []string
+	for _, pattern := range []string{"/dimm[0-9]*", "/rank[0-9]*"} {
+		matches, err := filepath.Glob(controller + pattern)
+		if err != nil {
+			return err
+		}
+		dimms = append(dimms, matches...)
+	}
+
+	for _, dimm := range dimms {
+		match := edacMemDimmRE.FindStringSubmatch(filepath.Base(dimm))
+		if match == nil {
+			continue
+		}
+		dimmNumber := match[1]
+		label := edacDimmLabelFromDir(dimm)
+
+		value, err := readUintFromFile(filepath.Join(dimm, "dimm_ce_count"))
+		if err != nil {
+			c.logger.Debug("couldn't get dimm_ce_count", "controller", controllerNumber, "dimm", dimmNumber, "err", err)
+			continue
+		}
+		ch <- prometheus.MustNewConstMetric(
+			edacDimmCECount,
+			prometheus.CounterValue,
+			float64(value),
+			controllerNumber,
+			dimmNumber,
+			label,
+		)
+
+		value, err = readUintFromFile(filepath.Join(dimm, "dimm_ue_count"))
+		if err != nil {
+			c.logger.Debug("couldn't get dimm_ue_count", "controller", controllerNumber, "dimm", dimmNumber, "err", err)
+			continue
+		}
+		ch <- prometheus.MustNewConstMetric(
+			edacDimmUECount,
+			prometheus.CounterValue,
+			float64(value),
+			controllerNumber,
+			dimmNumber,
+			label,
+		)
+	}
+
+	return nil
+}
+
+// edacDimmLabelFromDir returns dimm_label verbatim. Unlike the csrow layer's
+// generated ch*_dimm_label, this one is supplied by the platform and names a
+// physical slot, so it is kept byte-identical to what dmidecode reports.
+func edacDimmLabelFromDir(dimm string) string {
+	labelBytes, err := os.ReadFile(filepath.Join(dimm, "dimm_label"))
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(string(labelBytes))
 }

--- a/collector/edac_linux_test.go
+++ b/collector/edac_linux_test.go
@@ -1,0 +1,139 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !noedac
+
+package collector
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// newTestEdacRegistry points the collector at the sysfs fixture tree and returns
+// a registry it has been registered against.
+func newTestEdacRegistry(t *testing.T) *prometheus.Registry {
+	t.Helper()
+
+	if _, err := kingpin.CommandLine.Parse([]string{
+		"--path.sysfs", "fixtures/sys",
+		"--collector.edac",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	c, err := NewEdacCollector(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(&testEdacCollector{ec: c})
+	return reg
+}
+
+// Fixture mc1 registers dimm0, dimm1 and dimm3 to cover sparse indices; mc2 uses
+// the rank* spelling and omits dimm_ue_count on rank1.
+func TestEdacDimmLayer(t *testing.T) {
+	reg := newTestEdacRegistry(t)
+
+	expected := `
+# HELP node_edac_dimm_correctable_errors_total Total correctable memory errors for this DIMM.
+# TYPE node_edac_dimm_correctable_errors_total counter
+node_edac_dimm_correctable_errors_total{controller="1",dimm="0",dimm_label="CPU_SrcID#0_MC#1_Chan#0_DIMM#0"} 100
+node_edac_dimm_correctable_errors_total{controller="1",dimm="1",dimm_label="CPU_SrcID#0_MC#1_Chan#1_DIMM#0"} 200
+node_edac_dimm_correctable_errors_total{controller="1",dimm="3",dimm_label="CPU_SrcID#0_MC#1_Chan#3_DIMM#0"} 300
+node_edac_dimm_correctable_errors_total{controller="2",dimm="0",dimm_label="PROC 1 DIMM 8"} 7
+node_edac_dimm_correctable_errors_total{controller="2",dimm="1",dimm_label="PROC 2 DIMM 10"} 9
+# HELP node_edac_dimm_uncorrectable_errors_total Total uncorrectable memory errors for this DIMM. Best effort: errors the controller cannot localize to a slot are counted in ue_noinfo_count instead.
+# TYPE node_edac_dimm_uncorrectable_errors_total counter
+node_edac_dimm_uncorrectable_errors_total{controller="1",dimm="0",dimm_label="CPU_SrcID#0_MC#1_Chan#0_DIMM#0"} 0
+node_edac_dimm_uncorrectable_errors_total{controller="1",dimm="1",dimm_label="CPU_SrcID#0_MC#1_Chan#1_DIMM#0"} 0
+node_edac_dimm_uncorrectable_errors_total{controller="1",dimm="3",dimm_label="CPU_SrcID#0_MC#1_Chan#3_DIMM#0"} 1
+node_edac_dimm_uncorrectable_errors_total{controller="2",dimm="0",dimm_label="PROC 1 DIMM 8"} 0
+`
+
+	if err := testutil.GatherAndCompare(reg, strings.NewReader(expected),
+		"node_edac_dimm_correctable_errors_total",
+		"node_edac_dimm_uncorrectable_errors_total",
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Fixture mc3 models amd64_edac_mod, where rank* repeats the csrow counts. Its
+// rank* dirs hold 999 so double-counting shows up loudly.
+func TestEdacCsrowTakesPriorityOverDimmLayer(t *testing.T) {
+	reg := newTestEdacRegistry(t)
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, family := range families {
+		if !strings.HasPrefix(family.GetName(), "node_edac_dimm_") {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "controller" && label.GetValue() == "3" {
+					t.Errorf("%s reported for controller 3, which exposes csrow* alongside rank*: "+
+						"the DIMM layer must be skipped there or counts are doubled (value %v, dimm_label %q)",
+						family.GetName(), metric.GetCounter().GetValue(), edacLabelValue(metric, "dimm_label"))
+				}
+			}
+		}
+	}
+}
+
+func edacLabelValue(metric *dto.Metric, name string) string {
+	for _, label := range metric.GetLabel() {
+		if label.GetName() == name {
+			return label.GetValue()
+		}
+	}
+	return ""
+}
+
+// testEdacCollector adapts the Collector interface for use with a registry.
+type testEdacCollector struct {
+	ec Collector
+}
+
+func (tc *testEdacCollector) Collect(ch chan<- prometheus.Metric) {
+	sink := make(chan prometheus.Metric)
+	go func() {
+		if err := tc.ec.Update(sink); err != nil {
+			panic(fmt.Errorf("failed to update collector: %s", err))
+		}
+		close(sink)
+	}()
+
+	for m := range sink {
+		ch <- m
+	}
+}
+
+func (tc *testEdacCollector) Describe(_ chan<- *prometheus.Desc) {
+	// No-op for testing.
+}

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -1400,6 +1400,7 @@ node_drbd_remote_unacknowledged{device="drbd1"} 12347
 node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 0
 node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="1",dimm_label="mc0_csrow1_channel0"} 0
 node_edac_channel_correctable_errors_total{channel="0",controller="0",csrow="2",dimm_label="mc0_csrow2_channel0"} 0
+node_edac_channel_correctable_errors_total{channel="0",controller="3",csrow="0",dimm_label="mc3_csrow0_channel0"} 3
 node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="0",dimm_label="mc0_csrow0_channel1"} 0
 node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="1",dimm_label="mc0_csrow1_channel1"} 0
 node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="2",dimm_label="mc0_csrow2_channel1"} 0
@@ -1407,26 +1408,54 @@ node_edac_channel_correctable_errors_total{channel="1",controller="0",csrow="2",
 # TYPE node_edac_channel_uncorrectable_errors_total counter
 node_edac_channel_uncorrectable_errors_total{channel="0",controller="0",csrow="0",dimm_label="mc0_csrow0_channel0"} 2
 node_edac_channel_uncorrectable_errors_total{channel="0",controller="0",csrow="1",dimm_label="mc0_csrow1_channel0"} 2
+node_edac_channel_uncorrectable_errors_total{channel="0",controller="3",csrow="0",dimm_label="mc3_csrow0_channel0"} 0
 node_edac_channel_uncorrectable_errors_total{channel="1",controller="0",csrow="0",dimm_label="mc0_csrow0_channel1"} 2
 node_edac_channel_uncorrectable_errors_total{channel="1",controller="0",csrow="1",dimm_label="mc0_csrow1_channel1"} 2
 # HELP node_edac_correctable_errors_total Total correctable memory errors.
 # TYPE node_edac_correctable_errors_total counter
 node_edac_correctable_errors_total{controller="0"} 1
+node_edac_correctable_errors_total{controller="1"} 10
+node_edac_correctable_errors_total{controller="2"} 5
+node_edac_correctable_errors_total{controller="3"} 3
 # HELP node_edac_csrow_correctable_errors_total Total correctable memory errors for this csrow.
 # TYPE node_edac_csrow_correctable_errors_total counter
 node_edac_csrow_correctable_errors_total{controller="0",csrow="0"} 3
 node_edac_csrow_correctable_errors_total{controller="0",csrow="1"} 0
 node_edac_csrow_correctable_errors_total{controller="0",csrow="2"} 0
 node_edac_csrow_correctable_errors_total{controller="0",csrow="unknown"} 2
+node_edac_csrow_correctable_errors_total{controller="1",csrow="unknown"} 1
+node_edac_csrow_correctable_errors_total{controller="2",csrow="unknown"} 0
+node_edac_csrow_correctable_errors_total{controller="3",csrow="0"} 3
+node_edac_csrow_correctable_errors_total{controller="3",csrow="unknown"} 0
 # HELP node_edac_csrow_uncorrectable_errors_total Total uncorrectable memory errors for this csrow.
 # TYPE node_edac_csrow_uncorrectable_errors_total counter
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="0"} 4
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="1"} 4
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="2"} 5
 node_edac_csrow_uncorrectable_errors_total{controller="0",csrow="unknown"} 6
+node_edac_csrow_uncorrectable_errors_total{controller="1",csrow="unknown"} 1
+node_edac_csrow_uncorrectable_errors_total{controller="2",csrow="unknown"} 0
+node_edac_csrow_uncorrectable_errors_total{controller="3",csrow="0"} 0
+node_edac_csrow_uncorrectable_errors_total{controller="3",csrow="unknown"} 0
+# HELP node_edac_dimm_correctable_errors_total Total correctable memory errors for this DIMM.
+# TYPE node_edac_dimm_correctable_errors_total counter
+node_edac_dimm_correctable_errors_total{controller="1",dimm="0",dimm_label="CPU_SrcID#0_MC#1_Chan#0_DIMM#0"} 100
+node_edac_dimm_correctable_errors_total{controller="1",dimm="1",dimm_label="CPU_SrcID#0_MC#1_Chan#1_DIMM#0"} 200
+node_edac_dimm_correctable_errors_total{controller="1",dimm="3",dimm_label="CPU_SrcID#0_MC#1_Chan#3_DIMM#0"} 300
+node_edac_dimm_correctable_errors_total{controller="2",dimm="0",dimm_label="PROC 1 DIMM 8"} 7
+node_edac_dimm_correctable_errors_total{controller="2",dimm="1",dimm_label="PROC 2 DIMM 10"} 9
+# HELP node_edac_dimm_uncorrectable_errors_total Total uncorrectable memory errors for this DIMM. Best effort: errors the controller cannot localize to a slot are counted in ue_noinfo_count instead.
+# TYPE node_edac_dimm_uncorrectable_errors_total counter
+node_edac_dimm_uncorrectable_errors_total{controller="1",dimm="0",dimm_label="CPU_SrcID#0_MC#1_Chan#0_DIMM#0"} 0
+node_edac_dimm_uncorrectable_errors_total{controller="1",dimm="1",dimm_label="CPU_SrcID#0_MC#1_Chan#1_DIMM#0"} 0
+node_edac_dimm_uncorrectable_errors_total{controller="1",dimm="3",dimm_label="CPU_SrcID#0_MC#1_Chan#3_DIMM#0"} 1
+node_edac_dimm_uncorrectable_errors_total{controller="2",dimm="0",dimm_label="PROC 1 DIMM 8"} 0
 # HELP node_edac_uncorrectable_errors_total Total uncorrectable memory errors.
 # TYPE node_edac_uncorrectable_errors_total counter
 node_edac_uncorrectable_errors_total{controller="0"} 5
+node_edac_uncorrectable_errors_total{controller="1"} 2
+node_edac_uncorrectable_errors_total{controller="2"} 0
+node_edac_uncorrectable_errors_total{controller="3"} 0
 # HELP node_entropy_available_bits Bits of available entropy.
 # TYPE node_entropy_available_bits gauge
 node_entropy_available_bits 1337

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -5,6 +5,108 @@ Mode: 755
 Directory: sys/block
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-5
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-5/dm
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-5/dm/name
+Lines: 1
+mpathAEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-5/dm/suspended
+Lines: 1
+0EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-5/dm/uuid
+Lines: 1
+mpath-3600508b1001c1234567890abcdef1234EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-5/size
+Lines: 1
+104857600EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-5/slaves
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-5/slaves/sdi
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-5/slaves/sdj
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-5/slaves/sdk
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-5/slaves/sdl
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-6
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-6/dm
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-6/dm/name
+Lines: 1
+mpathBEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-6/dm/suspended
+Lines: 1
+0EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-6/dm/uuid
+Lines: 1
+mpath-3600508b1001cabcdef4567890123456EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-6/size
+Lines: 1
+209715200EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-6/slaves
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-6/slaves/sdm
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-6/slaves/sdn
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-7
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/block/dm-7/dm
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-7/dm/name
+Lines: 1
+vg0-rootEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-7/dm/suspended
+Lines: 1
+0EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-7/dm/uuid
+Lines: 1
+LVM-abcdef1234567890abcdef1234567890EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/block/dm-7/size
+Lines: 1
+41943040EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/block/md0
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -826,108 +928,6 @@ Lines: 1
 none
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/block/dm-5
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/block/dm-5/dm
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/block/dm-5/dm/name
-Lines: 1
-mpathAEOF
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/block/dm-5/dm/suspended
-Lines: 1
-0EOF
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/block/dm-5/dm/uuid
-Lines: 1
-mpath-3600508b1001c1234567890abcdef1234EOF
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/block/dm-5/size
-Lines: 1
-104857600EOF
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/block/dm-5/slaves
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/block/dm-5/slaves/sdi
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/block/dm-5/slaves/sdj
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/block/dm-5/slaves/sdk
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/block/dm-5/slaves/sdl
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/block/dm-6
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/block/dm-6/dm
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/block/dm-6/dm/name
-Lines: 1
-mpathBEOF
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/block/dm-6/dm/suspended
-Lines: 1
-0EOF
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/block/dm-6/dm/uuid
-Lines: 1
-mpath-3600508b1001cabcdef4567890123456EOF
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/block/dm-6/size
-Lines: 1
-209715200EOF
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/block/dm-6/slaves
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/block/dm-6/slaves/sdm
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/block/dm-6/slaves/sdn
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/block/dm-7
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/block/dm-7/dm
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/block/dm-7/dm/name
-Lines: 1
-vg0-rootEOF
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/block/dm-7/dm/suspended
-Lines: 1
-0EOF
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/block/dm-7/dm/uuid
-Lines: 1
-LVM-abcdef1234567890abcdef1234567890EOF
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/block/dm-7/size
-Lines: 1
-41943040EOF
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/block/sdi
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1390,6 +1390,9 @@ SymlinkTo: ../../devices/platform/coretemp.0/hwmon/hwmon0
 Path: sys/class/hwmon/hwmon1
 SymlinkTo: ../../devices/platform/coretemp.1/hwmon/hwmon1
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/hwmon/hwmon10
+SymlinkTo: ../../devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon10
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/class/hwmon/hwmon2
 SymlinkTo: ../../devices/platform/applesmc.768/hwmon/hwmon2
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1483,9 +1486,6 @@ SymlinkTo: ../../devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon8
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/class/hwmon/hwmon9
 SymlinkTo: ../../devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon9
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/class/hwmon/hwmon10
-SymlinkTo: ../../devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon10
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/class/infiniband
 Mode: 755
@@ -2407,27 +2407,12 @@ Lines: 1
 Samsung SSD 970 PRO 512GB
 Mode: 444
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/class/nvme/nvme0/serial
-Lines: 1
-S680HF8N190894I
-Mode: 444
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/class/nvme/nvme0/state
-Lines: 1
-live
-Mode: 444
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/class/nvme/nvme0/nvme0n1
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/class/nvme/nvme0/nvme0n1/ana_state
 Lines: 1
 optimized
-Mode: 444
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/class/nvme/nvme0/nvme0n1/size
-Lines: 1
-3906250000
 Mode: 444
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/class/nvme/nvme0/nvme0n1/nuse
@@ -2442,6 +2427,21 @@ Path: sys/class/nvme/nvme0/nvme0n1/queue/logical_block_size
 Lines: 1
 4096
 Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme/nvme0/nvme0n1/size
+Lines: 1
+3906250000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme/nvme0/serial
+Lines: 1
+S680HF8N190894I
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/class/nvme/nvme0/state
+Lines: 1
+live
+Mode: 444
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/class/nvme-subsystem
 Mode: 755
@@ -8529,69 +8529,6 @@ Lines: 1
 2
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/devices/platform/soc
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/devices/platform/soc/18000000.wifi
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/devices/platform/soc/18000000.wifi/ieee80211
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon8
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon8/device
-SymlinkTo: ../..
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon8/name
-Lines: 1
-mt7996_phy0_0
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon8/temp1_input
-Lines: 1
-55000
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon9
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon9/device
-SymlinkTo: ../..
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon9/name
-Lines: 1
-mt7996_phy0_1
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon9/temp1_input
-Lines: 1
-56000
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon10
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon10/device
-SymlinkTo: ../..
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon10/name
-Lines: 1
-mt7996_phy0_2
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon10/temp1_input
-Lines: 1
-57000
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/devices/platform/bogus.0
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -9169,6 +9106,69 @@ Lines: 1
 0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/platform/soc
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/platform/soc/18000000.wifi
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/platform/soc/18000000.wifi/ieee80211
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon10
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon10/device
+SymlinkTo: ../..
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon10/name
+Lines: 1
+mt7996_phy0_2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon10/temp1_input
+Lines: 1
+57000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon8
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon8/device
+SymlinkTo: ../..
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon8/name
+Lines: 1
+mt7996_phy0_0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon8/temp1_input
+Lines: 1
+55000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon9
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon9/device
+SymlinkTo: ../..
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon9/name
+Lines: 1
+mt7996_phy0_1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/platform/soc/18000000.wifi/ieee80211/phy0/hwmon/hwmon9/temp1_input
+Lines: 1
+56000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/devices/system
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -9564,45 +9564,19 @@ Mode: 644
 Directory: sys/devices/system/edac/mc/mc0/csrow0
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow0/ce_count
+Lines: 1
+3
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/csrow0/ch0_ce_count
 Lines: 1
 0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/devices/system/edac/mc/mc0/csrow1
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow1/ch0_ce_count
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch0_dimm_label
 Lines: 1
-0
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: sys/devices/system/edac/mc/mc0/csrow2
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow2/ch0_ce_count
-Lines: 1
-0
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow0/ch1_ce_count
-Lines: 1
-0
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow1/ch1_ce_count
-Lines: 1
-0
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow2/ch1_ce_count
-Lines: 1
-0
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow0/ce_count
-Lines: 1
-3
+mc0csrow0channel0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/csrow0/ch0_ue_count
@@ -9610,9 +9584,14 @@ Lines: 1
 2
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow1/ch0_ue_count
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch1_ce_count
 Lines: 1
-2
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow0/ch1_dimm_label
+Lines: 1
+mc0csrow0channel1
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/csrow0/ch1_ue_count
@@ -9620,14 +9599,47 @@ Lines: 1
 2
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow1/ch1_ue_count
+Path: sys/devices/system/edac/mc/mc0/csrow0/ue_count
 Lines: 1
-2
+4
 Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/system/edac/mc/mc0/csrow1
+Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/csrow1/ce_count
 Lines: 1
 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch0_ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch0_dimm_label
+Lines: 1
+mc0csrow1channel0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch0_ue_count
+Lines: 1
+2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch1_ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch1_dimm_label
+Lines: 1
+mc0csrow1channel1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow1/ch1_ue_count
+Lines: 1
+2
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/csrow1/ue_count
@@ -9635,19 +9647,37 @@ Lines: 1
 4
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/system/edac/mc/mc0/csrow2
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/csrow2/ce_count
 Lines: 1
 0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow2/ch0_ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow2/ch0_dimm_label
+Lines: 1
+mc0csrow2channel0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow2/ch1_ce_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc0/csrow2/ch1_dimm_label
+Lines: 1
+mc0csrow2channel1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/csrow2/ue_count
 Lines: 1
 5
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow0/ue_count
-Lines: 1
-4
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/devices/system/edac/mc/mc0/ue_count
@@ -9660,34 +9690,222 @@ Lines: 1
 6
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow0/ch0_dimm_label
+Directory: sys/devices/system/edac/mc/mc1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc1/ce_count
 Lines: 1
-mc0csrow0channel0
+10
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow0/ch1_dimm_label
+Path: sys/devices/system/edac/mc/mc1/ce_noinfo_count
 Lines: 1
-mc0csrow0channel1
+1
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow1/ch0_dimm_label
+Directory: sys/devices/system/edac/mc/mc1/dimm0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc1/dimm0/dimm_ce_count
 Lines: 1
-mc0csrow1channel0
+100
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow1/ch1_dimm_label
+Path: sys/devices/system/edac/mc/mc1/dimm0/dimm_label
 Lines: 1
-mc0csrow1channel1
+CPU_SrcID#0_MC#1_Chan#0_DIMM#0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow2/ch0_dimm_label
+Path: sys/devices/system/edac/mc/mc1/dimm0/dimm_ue_count
 Lines: 1
-mc0csrow2channel0
+0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: sys/devices/system/edac/mc/mc0/csrow2/ch1_dimm_label
+Directory: sys/devices/system/edac/mc/mc1/dimm1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc1/dimm1/dimm_ce_count
 Lines: 1
-mc0csrow2channel1
+200
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc1/dimm1/dimm_label
+Lines: 1
+CPU_SrcID#0_MC#1_Chan#1_DIMM#0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc1/dimm1/dimm_ue_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/system/edac/mc/mc1/dimm3
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc1/dimm3/dimm_ce_count
+Lines: 1
+300
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc1/dimm3/dimm_label
+Lines: 1
+CPU_SrcID#0_MC#1_Chan#3_DIMM#0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc1/dimm3/dimm_ue_count
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc1/ue_count
+Lines: 1
+2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc1/ue_noinfo_count
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/system/edac/mc/mc2
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc2/ce_count
+Lines: 1
+5
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc2/ce_noinfo_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/system/edac/mc/mc2/rank0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc2/rank0/dimm_ce_count
+Lines: 1
+7
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc2/rank0/dimm_label
+Lines: 1
+PROC 1 DIMM 8
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc2/rank0/dimm_ue_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/system/edac/mc/mc2/rank1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc2/rank1/dimm_ce_count
+Lines: 1
+9
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc2/rank1/dimm_label
+Lines: 1
+PROC 2 DIMM 10
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc2/ue_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc2/ue_noinfo_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/system/edac/mc/mc3
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/ce_count
+Lines: 1
+3
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/ce_noinfo_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/system/edac/mc/mc3/csrow0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/csrow0/ce_count
+Lines: 1
+3
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/csrow0/ch0_ce_count
+Lines: 1
+3
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/csrow0/ch0_dimm_label
+Lines: 1
+mc#3csrow#0channel#0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/csrow0/ch0_ue_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/csrow0/ue_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/system/edac/mc/mc3/rank0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/rank0/dimm_ce_count
+Lines: 1
+999
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/rank0/dimm_label
+Lines: 1
+mc#3csrow#0channel#0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/rank0/dimm_ue_count
+Lines: 1
+999
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/system/edac/mc/mc3/rank1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/rank1/dimm_ce_count
+Lines: 1
+999
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/rank1/dimm_label
+Lines: 1
+mc#3csrow#0channel#1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/rank1/dimm_ue_count
+Lines: 1
+999
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/ue_count
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/devices/system/edac/mc/mc3/ue_noinfo_count
+Lines: 1
+0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/devices/system/node


### PR DESCRIPTION
Draft implementation of #3722, opened early for feedback on shape rather than as a finished proposal — there are open questions at the bottom I'd rather settle before polishing.

## The gap

`edac` reads only `mc*/csrow*/chN`. Controllers driven by `sb_edac`, `skx_edac` or `i10nm_edac` register in the DIMM/MEM layer and expose **no `csrow*` directories at all**, so on that hardware the collector emits controller totals plus `csrow="unknown"` and nothing else — the counts are right, the attribution is absent. #3720 added per-channel metrics but reads only the csrow layer, so it is empty there.

Across a 55-host fleet of modern Intel hardware, **100% report `csrow="unknown"` and nothing else** — zero non-`unknown` csrow values over a 24h window. On one host the DIMM layer identified a specific failing pair of slots carrying hundreds of millions of correctable errors that the controller-level counter could not attribute.

## What this does

Per controller: if `csrow*` exists, nothing changes. Otherwise walk `(dimm|rank)[0-9]*` and emit

```
node_edac_dimm_correctable_errors_total{controller,dimm,dimm_label}
node_edac_dimm_uncorrectable_errors_total{controller,dimm,dimm_label}
```

Controller-level and `*_noinfo` series are untouched.

## csrow takes priority — thanks @arunsrini3082

The original issue assumed the two layouts were mutually exclusive. They are not: on `amd64_edac_mod` a controller exposes `csrow*` **and** `rank*` together, and the `rank*` directories repeat the csrow counts under EDAC-generated labels. Reading both double-counts. So the rule is a priority order, not a branch — `csrow*` is authoritative and the DIMM layer is a fallback only when it is absent.

Corroborated by two independent reporters on #3730: @saj on EPYC Rome / `amd64_edac`, and @hoffie on HPE ProLiant DL38x Gen10/Gen11.

## `dimm_label` is emitted verbatim

Deliberately not passed through `edacDimmLabel()`. Two reasons.

CONTRIBUTING.md's Collector Implementation Guidelines say metrics "should not get transformed in a way that is hardware specific" and that a value should be exposed "as it is and not keep a mapping in code to make this human readable." The DIMM layer's `dimm_label` is a platform-supplied slot name, and stripping characters from it breaks equality with the kernel value and with what `dmidecode` prints for the same slot — the correlation you need to physically identify a DIMM for replacement.

Second, `edacDimmLabel()`'s transforms are specific to the csrow layer's dialect:

```go
label = strings.ReplaceAll(label, "#", "")
label = strings.ReplaceAll(label, "csrow", "_csrow")
label = strings.ReplaceAll(label, "channel", "_channel")
```

The last two fire only on the synthetic form — `mc#0csrow#0channel#0` becomes `mc0_csrow0_channel0` — which is precisely the `rank*` dialect the priority rule skips. On a platform label like `CPU_SrcID#0_MC#1_Chan#0_DIMM#0` neither matches (`Chan` is not `channel`). Three distinct dialects showed up across the fleet, which one fixed transform can't normalize:

| driver | label |
|---|---|
| `sb_edac` | `CPU_SrcID#0_Ha#0_Chan#N_DIMM#0` |
| `skx_edac` / `i10nm_edac` | `CPU_SrcID#0_MC#N_Chan#N_DIMM#0` |
| vendor BIOS | `PROC 1 DIMM 8` — spaces, no `#` at all |

Worth noting every `dimm_label` in the current `e2e-output.txt` reads `mc0_csrow0_channel0`, so the synthetic dialect is the only one the transform has ever been exercised against.

## Uncorrectable errors are best effort

EDAC increments a per-DIMM counter only when it can localize the error to a slot; otherwise it goes to the controller's `ce_noinfo_count` / `ue_noinfo_count`. Correctable errors localize reliably. Uncorrectable ones frequently do not — `edac_mc.c` notes:

> On FB-DIMM memory controllers, for uncorrected errors, it is common to have only the MC channel and the MC dimm (also called "branch") but the channel is not known, as the memory is arranged in pairs, where each memory belongs to a separate channel within the same branch.

So `dimm_ue_count` often reads 0 even when UEs occurred. It is still exposed, documented as best effort in the metric help, and the controller-level and `*_noinfo` series remain authoritative for totals — which is why this change adds to them rather than replacing them.

## Fixtures and tests

Three new controllers in `sys.ttar`:

- `mc1` — Intel DIMM-model, indices `dimm0`/`dimm1`/`dimm3`. Only populated slots register on real hardware (observed `0,1,3,4,6,7,9,10`), so indices are sparse and must be globbed rather than counted.
- `mc2` — the same layer spelled `rank*`, with vendor BIOS labels containing spaces, and `rank1` missing `dimm_ue_count` to cover the partial case.
- `mc3` — `csrow*` and `rank*` coexisting, with the `rank*` counters set to `999` so that reading both layers would be immediately visible.

**The `mc3` fixture is hand-built from the directory listing @arunsrini3082 posted in #3722, not captured from AMD hardware — I don't have any.** Corrections very welcome. The assertion it encodes is structural (`rank*` skipped when `csrow*` is present) so it doesn't depend on label content, but I'd rather someone with an EPYC box confirmed the shape.

This adds `collector/edac_linux_test.go`, the collector's first unit tests. The e2e golden file already covers the metric output, so the test earns its place on what the golden file can't express: `TestEdacCsrowTakesPriorityOverDimmLayer` names the double-count failure and prints the offending value. Verified in both directions — removing the priority guard makes it fail with the `999`s.

## Cardinality

The DIMM layer adds one series pair per *populated* slot, replaces nothing, and only appears on hardware that reports no per-slot data at all today. Flagging it because @hoffie raised the opt-in question about the channel metrics on #3730 — happy to put this behind a flag if you'd prefer.

## Open questions

1. **Naming.** `node_edac_dimm_*` here, parallel to `node_edac_csrow_*` and `node_edac_channel_*`. A common family across both layouts was discussed on #3722 and dropped, partly on timing and partly because a csrow/channel isn't a DIMM. Happy to be redirected.
2. **`dimm_label` normalization.** I've argued for verbatim above, but this is really a ruling for you to make, and I'd like it documented either way so the next layout someone adds doesn't have to guess.
3. **Opt-in or default?** As above.

Unrelated one-line fix in the same file, if it's useful to take first: #3759.
