### PR TITLE
zfs: fix dataset name parsing

### DIFF
--- a/collector/zfs_linux.go
+++ b/collector/zfs_linux.go
@@ -315,7 +315,8 @@ func (c *zfsCollector) parsePoolObjsetFile(reader io.Reader, zpoolPath string, h
 			zpoolPathElements := strings.Split(zpoolPath, "/")
 			pathLen := len(zpoolPathElements)
 			zpoolName = zpoolPathElements[pathLen-2]
-			datasetName = line[strings.Index(line, parts[2]):]
+			dataStart := strings.Index(line, parts[1]) + len(parts[1])
+			datasetName = strings.TrimSpace(line[dataStart:])
 			continue
 		}
 

--- a/collector/zfs_linux_test.go
+++ b/collector/zfs_linux_test.go
@@ -18,6 +18,7 @@ package collector
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -360,6 +361,22 @@ func TestZpoolObjsetParsingWithSpace(t *testing.T) {
 		if !handlerCalled {
 			t.Fatalf("Zpool parsing handler was not called for '%s'", test.path)
 		}
+	}
+}
+
+func TestZpoolObjsetParsingDatasetInFieldName(t *testing.T) {
+	const input = "name type data\ndataset_name 7 data\nnwritten 4 1\n"
+
+	c := zfsCollector{}
+	var datasetName string
+	err := c.parsePoolObjsetFile(strings.NewReader(input), "/proc/spl/kstat/zfs/data/objset-1", func(_ string, dataset string, _ zfsSysctl, _ uint64) {
+		datasetName = dataset
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if datasetName != "data" {
+		t.Fatalf("Incorrectly parsed dataset name: expected: %q, got: %q", "data", datasetName)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Parse the ZFS objset dataset value after the kstat type column instead of searching the full line for the value.
- Preserve repeated spaces inside valid dataset names.
- Add regression coverage for a root dataset whose name also occurs in `dataset_name`.

This prevents root pool names such as `data` from being exported as `dataset_name 7 data`.

## Testing

- `make` in Linux Go 1.26 container
- `go test -race ./...`
- `GOARCH=amd64 go test ./collector -run '^TestZpoolObjsetParsing' -count=1`
- `GOARCH=386 go test -c ./collector`
- `govulncheck ./...`

Fixes #3761

@SuperQ, please review.