### PR TITLE
ksmd: add general_profit metric

### DIFF
--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -1990,6 +1990,9 @@ node_kernel_hung_tasks_total 42
 # HELP node_ksmd_full_scans_total ksmd 'full_scans' file.
 # TYPE node_ksmd_full_scans_total counter
 node_ksmd_full_scans_total 323
+# HELP node_ksmd_general_profit_bytes ksmd 'general_profit' file.
+# TYPE node_ksmd_general_profit_bytes gauge
+node_ksmd_general_profit_bytes 1.04448e+06
 # HELP node_ksmd_merge_across_nodes ksmd 'merge_across_nodes' file.
 # TYPE node_ksmd_merge_across_nodes gauge
 node_ksmd_merge_across_nodes 1

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -2022,6 +2022,9 @@ node_kernel_hung_tasks_total 42
 # HELP node_ksmd_full_scans_total ksmd 'full_scans' file.
 # TYPE node_ksmd_full_scans_total counter
 node_ksmd_full_scans_total 323
+# HELP node_ksmd_general_profit_bytes ksmd 'general_profit' file.
+# TYPE node_ksmd_general_profit_bytes gauge
+node_ksmd_general_profit_bytes 1.04448e+06
 # HELP node_ksmd_merge_across_nodes ksmd 'merge_across_nodes' file.
 # TYPE node_ksmd_merge_across_nodes gauge
 node_ksmd_merge_across_nodes 1

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -11960,6 +11960,11 @@ Lines: 1
 323
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/kernel/mm/ksm/general_profit
+Lines: 1
+1044480
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: sys/kernel/mm/ksm/merge_across_nodes
 Lines: 1
 1

--- a/collector/ksmd_linux.go
+++ b/collector/ksmd_linux.go
@@ -16,16 +16,19 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
-	ksmdFiles = []string{"full_scans", "merge_across_nodes", "pages_shared", "pages_sharing",
-		"pages_to_scan", "pages_unshared", "pages_volatile", "run", "sleep_millisecs"}
+	ksmdFiles = []string{"full_scans", "general_profit", "merge_across_nodes", "pages_shared",
+		"pages_sharing", "pages_to_scan", "pages_unshared", "pages_volatile", "run",
+		"sleep_millisecs"}
 )
 
 type ksmdCollector struct {
@@ -41,6 +44,8 @@ func getCanonicalMetricName(filename string) string {
 	switch filename {
 	case "full_scans":
 		return filename + "_total"
+	case "general_profit":
+		return "general_profit_bytes"
 	case "sleep_millisecs":
 		return "sleep_seconds"
 	default:
@@ -66,6 +71,10 @@ func (c *ksmdCollector) Update(ch chan<- prometheus.Metric) error {
 	for _, n := range ksmdFiles {
 		val, err := readUintFromFile(sysFilePath(filepath.Join("kernel/mm/ksm", n)))
 		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				c.logger.Debug("ksmd file not found, skipping", "file", n)
+				continue
+			}
 			return err
 		}
 


### PR DESCRIPTION
Expose /sys/kernel/mm/ksm/general_profit as node_ksmd_general_profit_bytes. 
This file (reports the net memory saved by KSM after subtracting the overhead of rmap_item tracking structures.
A negative value means KSM is consuming more memory than it saves. This is the single most useful KSM metric for operators deciding whether KSM is worthwhile on a given workload.

`general_profit` is available since Linux kernel 6.4 upstream, or CentOS Stream 9.
Since it may not exist on older kernels, also make the collector gracefully skip any missing sysfs file instead of failing the entire scrape.
