### PR TITLE
qdisc: expose fq throttled events as node_qdisc_throttled_total

### DIFF
--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -3702,6 +3702,10 @@ node_qdisc_packets_total{device="wlan0",kind="fq"} 42
 # TYPE node_qdisc_requeues_total counter
 node_qdisc_requeues_total{device="eth0",kind="pfifo_fast"} 2
 node_qdisc_requeues_total{device="wlan0",kind="fq"} 1
+# HELP node_qdisc_throttled_total Number of times the qdisc has been throttled to enforce pacing (fq).
+# TYPE node_qdisc_throttled_total counter
+node_qdisc_throttled_total{device="eth0",kind="pfifo_fast"} 0
+node_qdisc_throttled_total{device="wlan0",kind="fq"} 3
 # HELP node_rapl_core_joules_total Current RAPL core value in joules
 # TYPE node_rapl_core_joules_total counter
 node_rapl_core_joules_total{index="0",path="collector/fixtures/sys/class/powercap/intel-rapl:0:0"} 118821.284256

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -3734,6 +3734,10 @@ node_qdisc_packets_total{device="wlan0",kind="fq"} 42
 # TYPE node_qdisc_requeues_total counter
 node_qdisc_requeues_total{device="eth0",kind="pfifo_fast"} 2
 node_qdisc_requeues_total{device="wlan0",kind="fq"} 1
+# HELP node_qdisc_throttled_total Number of times the qdisc has been throttled to enforce pacing (fq).
+# TYPE node_qdisc_throttled_total counter
+node_qdisc_throttled_total{device="eth0",kind="pfifo_fast"} 0
+node_qdisc_throttled_total{device="wlan0",kind="fq"} 3
 # HELP node_rapl_core_joules_total Current RAPL core value in joules
 # TYPE node_rapl_core_joules_total counter
 node_rapl_core_joules_total{index="0",path="collector/fixtures/sys/class/powercap/intel-rapl:0:0"} 118821.284256

--- a/collector/fixtures/qdisc/results.json
+++ b/collector/fixtures/qdisc/results.json
@@ -5,7 +5,8 @@
         "Packets": 42,
         "Requeues": 1,
         "Kind": "fq",
-        "Drops": 1
+        "Drops": 1,
+        "Throttled": 3
     },
     {
         "IfaceName": "eth0",

--- a/collector/qdisc_linux.go
+++ b/collector/qdisc_linux.go
@@ -35,6 +35,7 @@ type qdiscStatCollector struct {
 	drops        typedDesc
 	requeues     typedDesc
 	overlimits   typedDesc
+	throttled    typedDesc
 	qlength      typedDesc
 	backlog      typedDesc
 }
@@ -101,6 +102,11 @@ func NewQdiscStatCollector(logger *slog.Logger) (Collector, error) {
 			"Number of overlimit packets.",
 			[]string{"device", "kind"}, nil,
 		), prometheus.CounterValue},
+		throttled: typedDesc{prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "qdisc", "throttled_total"),
+			"Number of times the qdisc has been throttled to enforce pacing (fq).",
+			[]string{"device", "kind"}, nil,
+		), prometheus.CounterValue},
 		qlength: typedDesc{prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "qdisc", "current_queue_length"),
 			"Number of packets currently in queue to be sent.",
@@ -159,6 +165,7 @@ func (c *qdiscStatCollector) Update(ch chan<- prometheus.Metric) error {
 		ch <- c.drops.mustNewConstMetric(float64(msg.Drops), msg.IfaceName, msg.Kind)
 		ch <- c.requeues.mustNewConstMetric(float64(msg.Requeues), msg.IfaceName, msg.Kind)
 		ch <- c.overlimits.mustNewConstMetric(float64(msg.Overlimits), msg.IfaceName, msg.Kind)
+		ch <- c.throttled.mustNewConstMetric(float64(msg.Throttled), msg.IfaceName, msg.Kind)
 		ch <- c.qlength.mustNewConstMetric(float64(msg.Qlen), msg.IfaceName, msg.Kind)
 		ch <- c.backlog.mustNewConstMetric(float64(msg.Backlog), msg.IfaceName, msg.Kind)
 	}


### PR DESCRIPTION
This adds `node_qdisc_throttled_total` (counter, `device`/`kind` labels) to the qdisc collector, sourced from `QdiscInfo.Throttled`.

The ema/qdisc library has parsed the fq qdisc's extended stats (`Throttled`, among others) since ema/qdisc@e2e5ae4 (2017-05-24) — merged one day after #580 introduced this collector — but the field was never wired into a metric. This follows the same pattern as #1732, which wired the library's backlog/qlen fields through.

Use case: with `fq` used for egress pacing (`maxrate`), this counter shows whether and how often pacing actually engages — packets are delayed rather than dropped, so none of the existing drop/overlimit metrics capture it. For non-fq qdiscs the value is 0, consistent with the collector's uniform metric emission.

Testing: fixtures updated (`results.json`, `e2e-output.txt`, `e2e-64k-page-output.txt`); verified by running the exporter with `--collector.qdisc.fixtures` and confirming the new series alongside unchanged existing ones.

cc @SuperQ