### PR TITLE
fix(e2e): resolve the Darwin fixture path on bash 3.2

### DIFF
--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -279,7 +279,10 @@ generated_metrics="${tmpdir}/e2e-output.txt"
 for os in freebsd openbsd netbsd solaris dragonfly darwin; do
   if [ "${GOHOSTOS}" = "${os}" ]; then
     generated_metrics="${tmpdir}/e2e-output-${GOHOSTOS}.txt"
-    fixture_metrics="${fixture_metrics::-4}-${GOHOSTOS}.txt"
+    # Not "${fixture_metrics::-4}": a negative length needs bash 4.2, and macOS
+    # still ships bash 3.2, where the expansion fails and the Linux fixture is
+    # used instead.
+    fixture_metrics="${fixture_metrics%.txt}-${GOHOSTOS}.txt"
   fi
 done
 
@@ -390,6 +393,7 @@ non_deterministic_metrics=$(cat << METRICS
   node_network_receive_bytes_total
   node_network_receive_multicast_total
   node_network_transmit_multicast_total
+  node_thermal_temperature_celsius
   node_zfs_abdstats_linear_count_total
   node_zfs_abdstats_linear_data_bytes
   node_zfs_abdstats_scatter_chunk_waste_bytes

--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -279,9 +279,6 @@ generated_metrics="${tmpdir}/e2e-output.txt"
 for os in freebsd openbsd netbsd solaris dragonfly darwin; do
   if [ "${GOHOSTOS}" = "${os}" ]; then
     generated_metrics="${tmpdir}/e2e-output-${GOHOSTOS}.txt"
-    # Not "${fixture_metrics::-4}": a negative length needs bash 4.2, and macOS
-    # still ships bash 3.2, where the expansion fails and the Linux fixture is
-    # used instead.
     fixture_metrics="${fixture_metrics%.txt}-${GOHOSTOS}.txt"
   fi
 done


### PR DESCRIPTION
Split out of #3767 as requested.

Two fixes to `end-to-end-test.sh`, both about running the suite on a Darwin host.

**The Darwin fixture path is not resolved on bash 3.2**

```sh
fixture_metrics="${fixture_metrics::-4}-${GOHOSTOS}.txt"
```

A negative substring length needs bash 4.2. macOS still ships bash 3.2, where that expansion fails:

```
$ /bin/bash -c 'v=collector/fixtures/e2e-output.txt; echo "${v::-4}"'
/bin/bash: -4: substring expression < 0
```

`generated_metrics` on the line above uses plain interpolation and is resolved correctly, so the generated file is the Darwin one while `fixture_metrics` still points at the Linux fixture. Running `./end-to-end-test.sh -u` on a Mac therefore overwrites `collector/fixtures/e2e-output.txt` with Darwin output — in my case rewriting 5330 lines of it before I noticed.

`${fixture_metrics%.txt}` is equivalent and works on both. Verified under bash 3.2.57 and 5.3.15, and both still pass `bash -n`.

**`node_thermal_temperature_celsius` is per-machine**

Its sensor names and its values both depend on the hardware, so anyone regenerating the Darwin fixture on a real Mac gets the whole sensor list as a diff rather than the intended change. It is stripped along with the other non-deterministic metrics now.

This makes no difference in CI, which reports no thermal sensors at all — it only matters when the suite is run on real hardware, which is exactly what the `-u` instructions ask for.

Unrelated and left alone: the `sed -i /pattern/d` calls in that same loop need an extension argument on BSD sed, so the stripping aborts on stock macOS. It behaves the same way on master, so it is not something this PR introduces.
