### PR TITLE
tls: Add collector for /proc/net/tls_stat kernel TLS statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ sysctl | Expose sysctl values from `/proc/sys`. Use `--collector.sysctl.include(
 swap | Expose swap information from `/proc/swaps`. | Linux
 systemd | Exposes service and system status from [systemd](http://www.freedesktop.org/wiki/Software/systemd/). | Linux
 tcpstat | Exposes TCP connection status information from `/proc/net/tcp` and `/proc/net/tcp6`. (Warning: the current version has potential performance issues in high load situations.) | Linux
+tls | Exposes kernel TLS statistics from `/proc/net/tls_stat`. | Linux
 wifi | Exposes WiFi device and station statistics. | Linux
 xfrm | Exposes statistics from `/proc/net/xfrm_stat` | Linux
 zoneinfo | Exposes NUMA memory zone metrics. | Linux

--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -3779,6 +3779,7 @@ node_scrape_collector_success{collector="tapestats"} 1
 node_scrape_collector_success{collector="textfile"} 1
 node_scrape_collector_success{collector="thermal_zone"} 1
 node_scrape_collector_success{collector="time"} 1
+node_scrape_collector_success{collector="tls"} 1
 node_scrape_collector_success{collector="udp_queues"} 1
 node_scrape_collector_success{collector="vmstat"} 1
 node_scrape_collector_success{collector="watchdog"} 1
@@ -4030,6 +4031,42 @@ node_time_clocksource_current_info{clocksource="tsc",device="0"} 1
 # TYPE node_time_seconds gauge
 # HELP node_time_zone_offset_seconds System time zone offset in seconds.
 # TYPE node_time_zone_offset_seconds gauge
+# HELP node_tls_curr_rx_device Number of RX sessions currently installed where NIC handles cryptography.
+# TYPE node_tls_curr_rx_device gauge
+node_tls_curr_rx_device 4
+# HELP node_tls_curr_rx_sw Number of RX sessions currently installed where host handles cryptography.
+# TYPE node_tls_curr_rx_sw gauge
+node_tls_curr_rx_sw 2
+# HELP node_tls_curr_tx_device Number of TX sessions currently installed where NIC handles cryptography.
+# TYPE node_tls_curr_tx_device gauge
+node_tls_curr_tx_device 3
+# HELP node_tls_curr_tx_sw Number of TX sessions currently installed where host handles cryptography.
+# TYPE node_tls_curr_tx_sw gauge
+node_tls_curr_tx_sw 1
+# HELP node_tls_decrypt_error_total Number of record decryption failures, e.g. due to incorrect authentication tags.
+# TYPE node_tls_decrypt_error_total counter
+node_tls_decrypt_error_total 9
+# HELP node_tls_decrypt_retry_total Number of retried record decryption attempts.
+# TYPE node_tls_decrypt_retry_total counter
+node_tls_decrypt_retry_total 11
+# HELP node_tls_rx_device_resync_total Number of RX resyncs sent to NICs handling cryptography.
+# TYPE node_tls_rx_device_resync_total counter
+node_tls_rx_device_resync_total 10
+# HELP node_tls_rx_device_total Number of RX sessions opened with NIC cryptography.
+# TYPE node_tls_rx_device_total counter
+node_tls_rx_device_total 8
+# HELP node_tls_rx_nopad_violation_total Number of RX no-pad violations.
+# TYPE node_tls_rx_nopad_violation_total counter
+node_tls_rx_nopad_violation_total 12
+# HELP node_tls_rx_sw_total Number of RX sessions opened with host cryptography.
+# TYPE node_tls_rx_sw_total counter
+node_tls_rx_sw_total 6
+# HELP node_tls_tx_device_total Number of TX sessions opened with NIC cryptography.
+# TYPE node_tls_tx_device_total counter
+node_tls_tx_device_total 7
+# HELP node_tls_tx_sw_total Number of TX sessions opened with host cryptography.
+# TYPE node_tls_tx_sw_total counter
+node_tls_tx_sw_total 5
 # HELP node_udp_queues Number of allocated memory in the kernel for UDP datagrams in bytes.
 # TYPE node_udp_queues gauge
 node_udp_queues{ip="v4",queue="rx"} 0

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -3801,6 +3801,7 @@ node_scrape_collector_success{collector="tapestats"} 1
 node_scrape_collector_success{collector="textfile"} 1
 node_scrape_collector_success{collector="thermal_zone"} 1
 node_scrape_collector_success{collector="time"} 1
+node_scrape_collector_success{collector="tls"} 1
 node_scrape_collector_success{collector="udp_queues"} 1
 node_scrape_collector_success{collector="vmstat"} 1
 node_scrape_collector_success{collector="watchdog"} 1
@@ -4052,6 +4053,42 @@ node_time_clocksource_current_info{clocksource="tsc",device="0"} 1
 # TYPE node_time_seconds gauge
 # HELP node_time_zone_offset_seconds System time zone offset in seconds.
 # TYPE node_time_zone_offset_seconds gauge
+# HELP node_tls_curr_rx_device Number of RX sessions currently installed where NIC handles cryptography.
+# TYPE node_tls_curr_rx_device gauge
+node_tls_curr_rx_device 4
+# HELP node_tls_curr_rx_sw Number of RX sessions currently installed where host handles cryptography.
+# TYPE node_tls_curr_rx_sw gauge
+node_tls_curr_rx_sw 2
+# HELP node_tls_curr_tx_device Number of TX sessions currently installed where NIC handles cryptography.
+# TYPE node_tls_curr_tx_device gauge
+node_tls_curr_tx_device 3
+# HELP node_tls_curr_tx_sw Number of TX sessions currently installed where host handles cryptography.
+# TYPE node_tls_curr_tx_sw gauge
+node_tls_curr_tx_sw 1
+# HELP node_tls_decrypt_error_total Number of record decryption failures, e.g. due to incorrect authentication tags.
+# TYPE node_tls_decrypt_error_total counter
+node_tls_decrypt_error_total 9
+# HELP node_tls_decrypt_retry_total Number of retried record decryption attempts.
+# TYPE node_tls_decrypt_retry_total counter
+node_tls_decrypt_retry_total 11
+# HELP node_tls_rx_device_resync_total Number of RX resyncs sent to NICs handling cryptography.
+# TYPE node_tls_rx_device_resync_total counter
+node_tls_rx_device_resync_total 10
+# HELP node_tls_rx_device_total Number of RX sessions opened with NIC cryptography.
+# TYPE node_tls_rx_device_total counter
+node_tls_rx_device_total 8
+# HELP node_tls_rx_nopad_violation_total Number of RX no-pad violations.
+# TYPE node_tls_rx_nopad_violation_total counter
+node_tls_rx_nopad_violation_total 12
+# HELP node_tls_rx_sw_total Number of RX sessions opened with host cryptography.
+# TYPE node_tls_rx_sw_total counter
+node_tls_rx_sw_total 6
+# HELP node_tls_tx_device_total Number of TX sessions opened with NIC cryptography.
+# TYPE node_tls_tx_device_total counter
+node_tls_tx_device_total 7
+# HELP node_tls_tx_sw_total Number of TX sessions opened with host cryptography.
+# TYPE node_tls_tx_sw_total counter
+node_tls_tx_sw_total 5
 # HELP node_udp_queues Number of allocated memory in the kernel for UDP datagrams in bytes.
 # TYPE node_udp_queues gauge
 node_udp_queues{ip="v4",queue="rx"} 0

--- a/collector/fixtures/proc/net/tls_stat
+++ b/collector/fixtures/proc/net/tls_stat
@@ -1,0 +1,12 @@
+TlsCurrTxSw                     	1
+TlsCurrRxSw                     	2
+TlsCurrTxDevice                 	3
+TlsCurrRxDevice                 	4
+TlsTxSw                         	5
+TlsRxSw                         	6
+TlsTxDevice                     	7
+TlsRxDevice                     	8
+TlsDecryptError                 	9
+TlsRxDeviceResync               	10
+TlsDecryptRetry                 	11
+TlsRxNoPadViolation             	12

--- a/collector/tls_linux.go
+++ b/collector/tls_linux.go
@@ -1,0 +1,148 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !notls
+
+package collector
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/procfs"
+)
+
+const tlsSubsystem = "tls"
+
+type tlsStatDesc struct {
+	typedDesc
+	value func(stat *procfs.TLSStat) float64
+}
+
+type tlsCollector struct {
+	descs  []tlsStatDesc
+	fs     procfs.FS
+	logger *slog.Logger
+}
+
+func init() {
+	registerCollector("tls", defaultDisabled, NewTLSCollector)
+}
+
+// NewTLSCollector returns a new Collector exposing kernel TLS statistics
+// from /proc/net/tls_stat, disabled by default.
+func NewTLSCollector(logger *slog.Logger) (Collector, error) {
+	fs, err := procfs.NewFS(*procPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open procfs: %w", err)
+	}
+
+	return &tlsCollector{
+		descs: []tlsStatDesc{
+			{
+				typedDesc: newTLSTypedDesc("curr_tx_sw", prometheus.GaugeValue,
+					"Number of TX sessions currently installed where host handles cryptography."),
+				value: func(stat *procfs.TLSStat) float64 { return float64(stat.TLSCurrTxSw) },
+			},
+			{
+				typedDesc: newTLSTypedDesc("curr_rx_sw", prometheus.GaugeValue,
+					"Number of RX sessions currently installed where host handles cryptography."),
+				value: func(stat *procfs.TLSStat) float64 { return float64(stat.TLSCurrRxSw) },
+			},
+			{
+				typedDesc: newTLSTypedDesc("curr_tx_device", prometheus.GaugeValue,
+					"Number of TX sessions currently installed where NIC handles cryptography."),
+				value: func(stat *procfs.TLSStat) float64 { return float64(stat.TLSCurrTxDevice) },
+			},
+			{
+				typedDesc: newTLSTypedDesc("curr_rx_device", prometheus.GaugeValue,
+					"Number of RX sessions currently installed where NIC handles cryptography."),
+				value: func(stat *procfs.TLSStat) float64 { return float64(stat.TLSCurrRxDevice) },
+			},
+			{
+				typedDesc: newTLSTypedDesc("tx_sw_total", prometheus.CounterValue,
+					"Number of TX sessions opened with host cryptography."),
+				value: func(stat *procfs.TLSStat) float64 { return float64(stat.TLSTxSw) },
+			},
+			{
+				typedDesc: newTLSTypedDesc("rx_sw_total", prometheus.CounterValue,
+					"Number of RX sessions opened with host cryptography."),
+				value: func(stat *procfs.TLSStat) float64 { return float64(stat.TLSRxSw) },
+			},
+			{
+				typedDesc: newTLSTypedDesc("tx_device_total", prometheus.CounterValue,
+					"Number of TX sessions opened with NIC cryptography."),
+				value: func(stat *procfs.TLSStat) float64 { return float64(stat.TLSTxDevice) },
+			},
+			{
+				typedDesc: newTLSTypedDesc("rx_device_total", prometheus.CounterValue,
+					"Number of RX sessions opened with NIC cryptography."),
+				value: func(stat *procfs.TLSStat) float64 { return float64(stat.TLSRxDevice) },
+			},
+			{
+				typedDesc: newTLSTypedDesc("decrypt_error_total", prometheus.CounterValue,
+					"Number of record decryption failures, e.g. due to incorrect authentication tags."),
+				value: func(stat *procfs.TLSStat) float64 { return float64(stat.TLSDecryptError) },
+			},
+			{
+				typedDesc: newTLSTypedDesc("rx_device_resync_total", prometheus.CounterValue,
+					"Number of RX resyncs sent to NICs handling cryptography."),
+				value: func(stat *procfs.TLSStat) float64 { return float64(stat.TLSRxDeviceResync) },
+			},
+			{
+				typedDesc: newTLSTypedDesc("decrypt_retry_total", prometheus.CounterValue,
+					"Number of retried record decryption attempts."),
+				value: func(stat *procfs.TLSStat) float64 { return float64(stat.TLSDecryptRetry) },
+			},
+			{
+				typedDesc: newTLSTypedDesc("rx_nopad_violation_total", prometheus.CounterValue,
+					"Number of RX no-pad violations."),
+				value: func(stat *procfs.TLSStat) float64 { return float64(stat.TLSRxNoPadViolation) },
+			},
+		},
+		fs:     fs,
+		logger: logger,
+	}, nil
+}
+
+func newTLSTypedDesc(name string, valueType prometheus.ValueType, help string) typedDesc {
+	return typedDesc{
+		desc: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, tlsSubsystem, name),
+			help,
+			nil, nil,
+		),
+		valueType: valueType,
+	}
+}
+
+func (c *tlsCollector) Update(ch chan<- prometheus.Metric) error {
+	stats, err := c.fs.NewTLSStat()
+	if err != nil {
+		// The file only exists while the kernel TLS module is loaded.
+		if errors.Is(err, os.ErrNotExist) {
+			c.logger.Debug("TLS statistics unavailable", "err", err)
+			return ErrNoData
+		}
+		return fmt.Errorf("failed to get TLS statistics: %w", err)
+	}
+
+	for _, statDesc := range c.descs {
+		ch <- statDesc.mustNewConstMetric(statDesc.value(&stats))
+	}
+
+	return nil
+}

--- a/collector/tls_linux_test.go
+++ b/collector/tls_linux_test.go
@@ -1,0 +1,102 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !notls
+
+package collector
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+type testTLSCollector struct {
+	c Collector
+}
+
+func (c testTLSCollector) Collect(ch chan<- prometheus.Metric) {
+	c.c.Update(ch)
+}
+
+func (c testTLSCollector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(c, ch)
+}
+
+func NewTestTLSCollector(t *testing.T, logger *slog.Logger) prometheus.Collector {
+	t.Helper()
+
+	c, err := NewTLSCollector(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return testTLSCollector{c: c}
+}
+
+func TestTLS(t *testing.T) {
+	if _, err := kingpin.CommandLine.Parse([]string{}); err != nil {
+		t.Fatal(err)
+	}
+	*procPath = "fixtures/proc"
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	c := NewTestTLSCollector(t, logger)
+
+	expected := `
+# HELP node_tls_curr_rx_device Number of RX sessions currently installed where NIC handles cryptography.
+# TYPE node_tls_curr_rx_device gauge
+node_tls_curr_rx_device 4
+# HELP node_tls_curr_rx_sw Number of RX sessions currently installed where host handles cryptography.
+# TYPE node_tls_curr_rx_sw gauge
+node_tls_curr_rx_sw 2
+# HELP node_tls_curr_tx_device Number of TX sessions currently installed where NIC handles cryptography.
+# TYPE node_tls_curr_tx_device gauge
+node_tls_curr_tx_device 3
+# HELP node_tls_curr_tx_sw Number of TX sessions currently installed where host handles cryptography.
+# TYPE node_tls_curr_tx_sw gauge
+node_tls_curr_tx_sw 1
+# HELP node_tls_decrypt_error_total Number of record decryption failures, e.g. due to incorrect authentication tags.
+# TYPE node_tls_decrypt_error_total counter
+node_tls_decrypt_error_total 9
+# HELP node_tls_decrypt_retry_total Number of retried record decryption attempts.
+# TYPE node_tls_decrypt_retry_total counter
+node_tls_decrypt_retry_total 11
+# HELP node_tls_rx_device_resync_total Number of RX resyncs sent to NICs handling cryptography.
+# TYPE node_tls_rx_device_resync_total counter
+node_tls_rx_device_resync_total 10
+# HELP node_tls_rx_device_total Number of RX sessions opened with NIC cryptography.
+# TYPE node_tls_rx_device_total counter
+node_tls_rx_device_total 8
+# HELP node_tls_rx_nopad_violation_total Number of RX no-pad violations.
+# TYPE node_tls_rx_nopad_violation_total counter
+node_tls_rx_nopad_violation_total 12
+# HELP node_tls_rx_sw_total Number of RX sessions opened with host cryptography.
+# TYPE node_tls_rx_sw_total counter
+node_tls_rx_sw_total 6
+# HELP node_tls_tx_device_total Number of TX sessions opened with NIC cryptography.
+# TYPE node_tls_tx_device_total counter
+node_tls_tx_device_total 7
+# HELP node_tls_tx_sw_total Number of TX sessions opened with host cryptography.
+# TYPE node_tls_tx_sw_total counter
+node_tls_tx_sw_total 5
+`
+
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -82,6 +82,7 @@ enabled_collectors=$(cat << COLLECTORS
   sysctl
   textfile
   thermal_zone
+  tls
   udp_queues
   vmstat
   watchdog


### PR DESCRIPTION
Fixes #2290

## What this PR does

Adds a `tls` collector exposing kernel TLS (kTLS) statistics from `/proc/net/tls_stat`, closing the long-standing feature request in #2290.

The procfs side landed years ago (prometheus/procfs#579, released in v0.13.0) and node_exporter already depends on procfs v0.22.0, so this only adds the collector that consumes `procfs.TLSStat` — no dependency bump or procfs change is needed.

## Metrics

Twelve metrics under the `node_tls_` namespace:

| Metric | Type | Source counter |
|---|---|---|
| `node_tls_curr_tx_sw` | gauge | `TlsCurrTxSw` |
| `node_tls_curr_rx_sw` | gauge | `TlsCurrRxSw` |
| `node_tls_curr_tx_device` | gauge | `TlsCurrTxDevice` |
| `node_tls_curr_rx_device` | gauge | `TlsCurrRxDevice` |
| `node_tls_tx_sw_total` | counter | `TlsTxSw` |
| `node_tls_rx_sw_total` | counter | `TlsRxSw` |
| `node_tls_tx_device_total` | counter | `TlsTxDevice` |
| `node_tls_rx_device_total` | counter | `TlsRxDevice` |
| `node_tls_decrypt_error_total` | counter | `TlsDecryptError` |
| `node_tls_rx_device_resync_total` | counter | `TlsRxDeviceResync` |
| `node_tls_decrypt_retry_total` | counter | `TlsDecryptRetry` |
| `node_tls_rx_nopad_violation_total` | counter | `TlsRxNoPadViolation` |

The `Curr*` counters report currently-installed sessions, so they are gauges; the rest are cumulative and exposed as counters with the `_total` suffix.

## Design notes

- **Disabled by default** (`registerCollector("tls", defaultDisabled, ...)`), consistent with collectors that only apply when a specific kernel subsystem is active. `/proc/net/tls_stat` only exists while the `tls` kernel module is loaded; when absent, `Update` returns `ErrNoData` (logged at debug) rather than a hard error.
- **Descriptors allocated once.** The 12 `typedDesc`s are built in the constructor and reused; `Update` never calls `prometheus.NewDesc`, so there is no per-scrape allocation. I did not adopt the generator + drift-test approach used for netstat in #3796, because that machinery exists to track netstat's hundreds of dynamically-named, user-filterable fields. `tls_stat` is a fixed set of 12 counters with no filter flag, so a hand-written table is simpler and trivially stays in sync.
- Registered in the e2e fixture set (`collector/fixtures/proc/net/tls_stat`), the e2e golden output, the enabled-collectors list in `end-to-end-test.sh`, and the "Disabled by default" table in the README.

## Testing

- `go test ./collector -run TestTLS` (via `testutil.CollectAndCompare` against the fixture) passes.
- `GOOS=linux go build ./... && go vet ./collector && go test -c ./collector` are all clean.

Fixes #2290

Signed-off-by: neoLsH <43921685+neoLsH@users.noreply.github.com>

