### PR TITLE
feat(collector): add power_meter collector for ACPI 4.0 power meters

### DIFF
--- a/collector/fixtures/e2e-64k-page-output.txt
+++ b/collector/fixtures/e2e-64k-page-output.txt
@@ -3600,6 +3600,52 @@ node_pcidevice_sriov_totalvfs{bus="45",device="00",function="0",segment="0000"} 
 node_pcidevice_sriov_vf_total_msix{bus="00",device="02",function="1",segment="0000"} 0
 node_pcidevice_sriov_vf_total_msix{bus="01",device="00",function="0",segment="0000"} 16
 node_pcidevice_sriov_vf_total_msix{bus="45",device="00",function="0",segment="0000"} 0
+# HELP node_power_meter_accuracy_percent ACPI power meter accuracy_percent value.
+# TYPE node_power_meter_accuracy_percent gauge
+node_power_meter_accuracy_percent{meter="ACPI000D:00"} 1.5
+# HELP node_power_meter_alarm ACPI power meter alarm value.
+# TYPE node_power_meter_alarm gauge
+node_power_meter_alarm{meter="ACPI000D:00"} 0
+# HELP node_power_meter_average_interval_max_seconds ACPI power meter average_interval_max_seconds value.
+# TYPE node_power_meter_average_interval_max_seconds gauge
+node_power_meter_average_interval_max_seconds{meter="ACPI000D:00"} 10
+# HELP node_power_meter_average_interval_min_seconds ACPI power meter average_interval_min_seconds value.
+# TYPE node_power_meter_average_interval_min_seconds gauge
+node_power_meter_average_interval_min_seconds{meter="ACPI000D:00"} 0.1
+# HELP node_power_meter_average_interval_seconds ACPI power meter average_interval_seconds value.
+# TYPE node_power_meter_average_interval_seconds gauge
+node_power_meter_average_interval_seconds{meter="ACPI000D:00"} 1
+# HELP node_power_meter_average_max_watts ACPI power meter average_max_watts value.
+# TYPE node_power_meter_average_max_watts gauge
+node_power_meter_average_max_watts{meter="ACPI000D:00"} 60
+# HELP node_power_meter_average_min_watts ACPI power meter average_min_watts value.
+# TYPE node_power_meter_average_min_watts gauge
+node_power_meter_average_min_watts{meter="ACPI000D:00"} 0
+# HELP node_power_meter_average_watts ACPI power meter average_watts value.
+# TYPE node_power_meter_average_watts gauge
+node_power_meter_average_watts{meter="ACPI000D:00"} 15
+# HELP node_power_meter_cap_hysteresis_watts ACPI power meter cap_hysteresis_watts value.
+# TYPE node_power_meter_cap_hysteresis_watts gauge
+node_power_meter_cap_hysteresis_watts{meter="ACPI000D:00"} 0.5
+# HELP node_power_meter_cap_max_watts ACPI power meter cap_max_watts value.
+# TYPE node_power_meter_cap_max_watts gauge
+node_power_meter_cap_max_watts{meter="ACPI000D:00"} 100
+# HELP node_power_meter_cap_min_watts ACPI power meter cap_min_watts value.
+# TYPE node_power_meter_cap_min_watts gauge
+node_power_meter_cap_min_watts{meter="ACPI000D:00"} 1
+# HELP node_power_meter_cap_watts ACPI power meter cap_watts value.
+# TYPE node_power_meter_cap_watts gauge
+node_power_meter_cap_watts{meter="ACPI000D:00"} 25
+# HELP node_power_meter_info ACPI power meter metadata.
+# TYPE node_power_meter_info gauge
+node_power_meter_info{meter="ACPI000D:00",model_number="ACME PM01",oem_info="ACME Corp",serial_number="SN12345"} 1
+# HELP node_power_meter_is_battery ACPI power meter is_battery value.
+# TYPE node_power_meter_is_battery gauge
+node_power_meter_is_battery{meter="ACPI000D:00"} 0
+# HELP node_power_meter_measures_info Device measured by this ACPI power meter.
+# TYPE node_power_meter_measures_info gauge
+node_power_meter_measures_info{device="LNXCPU:00",meter="ACPI000D:00"} 1
+node_power_meter_measures_info{device="LNXMEM:00",meter="ACPI000D:00"} 1
 # HELP node_power_supply_capacity capacity value of /sys/class/power_supply/<power_supply>.
 # TYPE node_power_supply_capacity gauge
 node_power_supply_capacity{power_supply="BAT0"} 81
@@ -3763,6 +3809,7 @@ node_scrape_collector_success{collector="nfsd"} 1
 node_scrape_collector_success{collector="nvme"} 1
 node_scrape_collector_success{collector="os"} 1
 node_scrape_collector_success{collector="pcidevice"} 1
+node_scrape_collector_success{collector="power_meter"} 1
 node_scrape_collector_success{collector="powersupplyclass"} 1
 node_scrape_collector_success{collector="pressure"} 1
 node_scrape_collector_success{collector="processes"} 1

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -3622,6 +3622,52 @@ node_pcidevice_sriov_totalvfs{bus="45",device="00",function="0",segment="0000"} 
 node_pcidevice_sriov_vf_total_msix{bus="00",device="02",function="1",segment="0000"} 0
 node_pcidevice_sriov_vf_total_msix{bus="01",device="00",function="0",segment="0000"} 16
 node_pcidevice_sriov_vf_total_msix{bus="45",device="00",function="0",segment="0000"} 0
+# HELP node_power_meter_accuracy_percent ACPI power meter accuracy_percent value.
+# TYPE node_power_meter_accuracy_percent gauge
+node_power_meter_accuracy_percent{meter="ACPI000D:00"} 1.5
+# HELP node_power_meter_alarm ACPI power meter alarm value.
+# TYPE node_power_meter_alarm gauge
+node_power_meter_alarm{meter="ACPI000D:00"} 0
+# HELP node_power_meter_average_interval_max_seconds ACPI power meter average_interval_max_seconds value.
+# TYPE node_power_meter_average_interval_max_seconds gauge
+node_power_meter_average_interval_max_seconds{meter="ACPI000D:00"} 10
+# HELP node_power_meter_average_interval_min_seconds ACPI power meter average_interval_min_seconds value.
+# TYPE node_power_meter_average_interval_min_seconds gauge
+node_power_meter_average_interval_min_seconds{meter="ACPI000D:00"} 0.1
+# HELP node_power_meter_average_interval_seconds ACPI power meter average_interval_seconds value.
+# TYPE node_power_meter_average_interval_seconds gauge
+node_power_meter_average_interval_seconds{meter="ACPI000D:00"} 1
+# HELP node_power_meter_average_max_watts ACPI power meter average_max_watts value.
+# TYPE node_power_meter_average_max_watts gauge
+node_power_meter_average_max_watts{meter="ACPI000D:00"} 60
+# HELP node_power_meter_average_min_watts ACPI power meter average_min_watts value.
+# TYPE node_power_meter_average_min_watts gauge
+node_power_meter_average_min_watts{meter="ACPI000D:00"} 0
+# HELP node_power_meter_average_watts ACPI power meter average_watts value.
+# TYPE node_power_meter_average_watts gauge
+node_power_meter_average_watts{meter="ACPI000D:00"} 15
+# HELP node_power_meter_cap_hysteresis_watts ACPI power meter cap_hysteresis_watts value.
+# TYPE node_power_meter_cap_hysteresis_watts gauge
+node_power_meter_cap_hysteresis_watts{meter="ACPI000D:00"} 0.5
+# HELP node_power_meter_cap_max_watts ACPI power meter cap_max_watts value.
+# TYPE node_power_meter_cap_max_watts gauge
+node_power_meter_cap_max_watts{meter="ACPI000D:00"} 100
+# HELP node_power_meter_cap_min_watts ACPI power meter cap_min_watts value.
+# TYPE node_power_meter_cap_min_watts gauge
+node_power_meter_cap_min_watts{meter="ACPI000D:00"} 1
+# HELP node_power_meter_cap_watts ACPI power meter cap_watts value.
+# TYPE node_power_meter_cap_watts gauge
+node_power_meter_cap_watts{meter="ACPI000D:00"} 25
+# HELP node_power_meter_info ACPI power meter metadata.
+# TYPE node_power_meter_info gauge
+node_power_meter_info{meter="ACPI000D:00",model_number="ACME PM01",oem_info="ACME Corp",serial_number="SN12345"} 1
+# HELP node_power_meter_is_battery ACPI power meter is_battery value.
+# TYPE node_power_meter_is_battery gauge
+node_power_meter_is_battery{meter="ACPI000D:00"} 0
+# HELP node_power_meter_measures_info Device measured by this ACPI power meter.
+# TYPE node_power_meter_measures_info gauge
+node_power_meter_measures_info{device="LNXCPU:00",meter="ACPI000D:00"} 1
+node_power_meter_measures_info{device="LNXMEM:00",meter="ACPI000D:00"} 1
 # HELP node_power_supply_capacity capacity value of /sys/class/power_supply/<power_supply>.
 # TYPE node_power_supply_capacity gauge
 node_power_supply_capacity{power_supply="BAT0"} 81
@@ -3785,6 +3831,7 @@ node_scrape_collector_success{collector="nfsd"} 1
 node_scrape_collector_success{collector="nvme"} 1
 node_scrape_collector_success{collector="os"} 1
 node_scrape_collector_success{collector="pcidevice"} 1
+node_scrape_collector_success{collector="power_meter"} 1
 node_scrape_collector_success{collector="powersupplyclass"} 1
 node_scrape_collector_success{collector="pressure"} 1
 node_scrape_collector_success{collector="processes"} 1

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -997,6 +997,107 @@ Mode: 644
 Directory: sys/bus
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/acpi
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/acpi/drivers
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/acpi/drivers/power_meter
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/acpi/drivers/power_meter/ACPI000D:00
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/acpi/drivers/power_meter/ACPI000D:00/measures
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/measures/cpu0
+SymlinkTo: ../../../../devices/LNXSYSTM:00/LNXCPU:00
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/measures/mem0
+SymlinkTo: ../../../../devices/LNXSYSTM:00/LNXMEM:00
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_accuracy
+Lines: 1
+1.50%
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_alarm
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_average
+Lines: 1
+15000000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_average_interval
+Lines: 1
+1000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_average_interval_max
+Lines: 1
+10000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_average_interval_min
+Lines: 1
+100
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_average_max
+Lines: 1
+60000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_average_min
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_cap
+Lines: 1
+25000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_cap_hyst
+Lines: 1
+500000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_cap_max
+Lines: 1
+100000000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_cap_min
+Lines: 1
+1000000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_is_battery
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_model_number
+Lines: 1
+ACME PM01
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_oem_info
+Lines: 1
+ACME Corp
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/acpi/drivers/power_meter/ACPI000D:00/power1_serial_number
+Lines: 1
+SN12345
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/bus/cpu
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3128,6 +3229,15 @@ Directory: sys/class/watchdog/watchdog1
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/devices
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/LNXSYSTM:00
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/LNXSYSTM:00/LNXCPU:00
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/devices/LNXSYSTM:00/LNXMEM:00
+Mode: 755
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/devices/pci0000:00

--- a/collector/power_meter_linux.go
+++ b/collector/power_meter_linux.go
@@ -1,0 +1,204 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nopowermeter
+
+package collector
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/procfs/sysfs"
+)
+
+const powerMeterCollectorSubsystem = "power_meter"
+
+var (
+	powerMeterIgnoredMeters = kingpin.Flag(
+		"collector.power-meter.ignored-meters",
+		"Regexp of ACPI power meter names to ignore for power_meter collector.",
+	).Default("^$").String()
+)
+
+type powerMeterCollector struct {
+	ignoredPattern *regexp.Regexp
+	logger         *slog.Logger
+}
+
+func init() {
+	registerCollector(powerMeterCollectorSubsystem, defaultEnabled, NewPowerMeterCollector)
+}
+
+// NewPowerMeterCollector returns a new Collector exposing ACPI 4.0 power meter
+// metrics read from /sys/bus/acpi/drivers/power_meter/ACPI000D:XX/.
+func NewPowerMeterCollector(logger *slog.Logger) (Collector, error) {
+	pattern, err := regexp.Compile(*powerMeterIgnoredMeters)
+	if err != nil {
+		return nil, err
+	}
+	return &powerMeterCollector{
+		ignoredPattern: pattern,
+		logger:         logger,
+	}, nil
+}
+
+// pushPowerMeterMetric is a helper that builds a single gauge metric under the
+// node_power_meter_<name> family and writes it to ch. The `meter` label is
+// always set to the ACPI device name (e.g. "ACPI000D:00").
+func pushPowerMeterMetric(ch chan<- prometheus.Metric, name string, value float64, meter string, valueType prometheus.ValueType) {
+	desc := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, powerMeterCollectorSubsystem, name),
+		"ACPI power meter "+name+" value.",
+		[]string{"meter"},
+		nil,
+	)
+	ch <- prometheus.MustNewConstMetric(desc, valueType, value, meter)
+}
+
+// Update implements Collector and emits ACPI power meter metrics.
+func (c *powerMeterCollector) Update(ch chan<- prometheus.Metric) error {
+	fs, err := sysfs.NewFS(*sysPath)
+	if err != nil {
+		return fmt.Errorf("failed to open sysfs: %w", err)
+	}
+
+	meters, err := sysfs.GetPowerMeters(fs)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			c.logger.Debug("ACPI power meter bus path not present; collector idle")
+			return ErrNoData
+		}
+		if errors.Is(err, os.ErrPermission) {
+			c.logger.Debug("cannot access ACPI power meter sysfs path", "err", err)
+			return ErrNoData
+		}
+		return fmt.Errorf("failed to read ACPI power meters: %w", err)
+	}
+
+	for _, pm := range meters {
+		if c.ignoredPattern.MatchString(pm.Name) {
+			c.logger.Debug("ignoring ACPI power meter", "meter", pm.Name)
+			continue
+		}
+		c.emitPowerMeterMetrics(ch, pm)
+	}
+	return nil
+}
+
+// emitPowerMeterMetrics writes every metric for a single PowerMeter.
+func (c *powerMeterCollector) emitPowerMeterMetrics(ch chan<- prometheus.Metric, pm sysfs.PowerMeter) {
+	meter := pm.Name
+
+	// Power gauges (µW -> W).
+	for name, v := range map[string]*int64{
+		"average_watts":     pm.Average,
+		"average_min_watts": pm.AverageMin,
+		"average_max_watts": pm.AverageMax,
+	} {
+		if v != nil {
+			pushPowerMeterMetric(ch, name, float64(*v)/1e6, meter, prometheus.GaugeValue)
+		}
+	}
+
+	// Cap gauges (µW -> W).
+	for name, v := range map[string]*int64{
+		"cap_watts":            pm.Cap,
+		"cap_min_watts":        pm.CapMin,
+		"cap_max_watts":        pm.CapMax,
+		"cap_hysteresis_watts": pm.CapHyst,
+	} {
+		if v != nil {
+			pushPowerMeterMetric(ch, name, float64(*v)/1e6, meter, prometheus.GaugeValue)
+		}
+	}
+
+	// Interval gauges (ms -> s).
+	for name, v := range map[string]*int64{
+		"average_interval_seconds":     pm.AverageInterval,
+		"average_interval_min_seconds": pm.AverageIntervalMin,
+		"average_interval_max_seconds": pm.AverageIntervalMax,
+	} {
+		if v != nil {
+			pushPowerMeterMetric(ch, name, float64(*v)/1e3, meter, prometheus.GaugeValue)
+		}
+	}
+
+	// State gauges (0/1, no unit conversion).
+	for name, v := range map[string]*int64{
+		"alarm":      pm.Alarm,
+		"is_battery": pm.IsBattery,
+	} {
+		if v != nil {
+			pushPowerMeterMetric(ch, name, float64(*v), meter, prometheus.GaugeValue)
+		}
+	}
+
+	// Accuracy (percent string "1.50%" -> 1.50).
+	if pm.Accuracy != "" {
+		if percent, err := parseAccuracy(pm.Accuracy); err == nil {
+			pushPowerMeterMetric(ch, "accuracy_percent", percent, meter, prometheus.GaugeValue)
+		} else {
+			c.logger.Debug("could not parse power meter accuracy", "meter", meter, "accuracy", pm.Accuracy, "err", err)
+		}
+	}
+
+	// Info metric: meter metadata as labels, value = 1.
+	infoLabels := []string{"meter"}
+	infoValues := []string{meter}
+	for _, kv := range []struct{ name, value string }{
+		{"model_number", pm.ModelNumber},
+		{"serial_number", pm.SerialNumber},
+		{"oem_info", pm.OEMInfo},
+	} {
+		if kv.value != "" {
+			infoLabels = append(infoLabels, kv.name)
+			infoValues = append(infoValues, strings.ToValidUTF8(kv.value, ""))
+		}
+	}
+	infoDesc := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, powerMeterCollectorSubsystem, "info"),
+		"ACPI power meter metadata.",
+		infoLabels,
+		nil,
+	)
+	ch <- prometheus.MustNewConstMetric(infoDesc, prometheus.GaugeValue, 1.0, infoValues...)
+
+	// Measures info: one series per device this meter measures.
+	if len(pm.Measures) > 0 {
+		measuresDesc := prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, powerMeterCollectorSubsystem, "measures_info"),
+			"Device measured by this ACPI power meter.",
+			[]string{"meter", "device"},
+			nil,
+		)
+		for _, dev := range pm.Measures {
+			ch <- prometheus.MustNewConstMetric(measuresDesc, prometheus.GaugeValue, 1.0, meter, dev)
+		}
+	}
+}
+
+// parseAccuracy converts a sysfs accuracy string like "1.50%" to a percentage
+// value (1.50). Returns an error if the string cannot be parsed.
+func parseAccuracy(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, "%")
+	return strconv.ParseFloat(s, 64)
+}

--- a/collector/power_meter_linux_test.go
+++ b/collector/power_meter_linux_test.go
@@ -1,0 +1,380 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nopowermeter
+
+package collector
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// buildFakePowerMeterSysfs writes a minimal /sys tree containing ACPI power
+// meter devices under <root>/bus/acpi/drivers/power_meter/ and returns root.
+// Each meter is described by its ACPI device name (e.g. "ACPI000D:00") and a
+// map of sysfs attribute file basename -> content (without trailing newline).
+// Optional measures entries are given as "<linkname>:<target-basename>" and
+// materialized as symlinks into a shared <root>/devices/LNXSYSTM:00/<target>.
+func buildFakePowerMeterSysfs(t *testing.T, meters map[string]map[string]string, measures map[string][]string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	base := filepath.Join(root, "bus", "acpi", "drivers", "power_meter")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatalf("mkdir base: %v", err)
+	}
+
+	devicesDir := filepath.Join(root, "devices", "LNXSYSTM:00")
+	if err := os.MkdirAll(devicesDir, 0o755); err != nil {
+		t.Fatalf("mkdir devices: %v", err)
+	}
+
+	for name, attrs := range meters {
+		meterDir := filepath.Join(base, name)
+		if err := os.MkdirAll(meterDir, 0o755); err != nil {
+			t.Fatalf("mkdir meter %s: %v", name, err)
+		}
+		for fname, content := range attrs {
+			if err := os.WriteFile(filepath.Join(meterDir, fname), []byte(content+"\n"), 0o644); err != nil {
+				t.Fatalf("write %s/%s: %v", name, fname, err)
+			}
+		}
+
+		measureLinks := measures[name]
+		if len(measureLinks) > 0 {
+			measuresDir := filepath.Join(meterDir, "measures")
+			if err := os.MkdirAll(measuresDir, 0o755); err != nil {
+				t.Fatalf("mkdir measures %s: %v", name, err)
+			}
+			for i, entry := range measureLinks {
+				parts := strings.SplitN(entry, ":", 2)
+				linkName, target := parts[0], parts[1]
+				targetDir := filepath.Join(devicesDir, target)
+				if err := os.MkdirAll(targetDir, 0o755); err != nil {
+					t.Fatalf("mkdir target %s: %v", target, err)
+				}
+				// The procfs parsePowerMeterMeasures reads symlinks and takes
+				// the basename of the target. Relative symlink target with
+				// enough ../ to reach devices/LNXSYSTM:00/<target>.
+				rel := filepath.Join("..", "..", "..", "..", "devices", "LNXSYSTM:00", target)
+				if err := os.Symlink(rel, filepath.Join(measuresDir, linkName)); err != nil {
+					t.Fatalf("symlink measures[%d]: %v", i, err)
+				}
+			}
+		} else {
+			// Empty measures/ dir so parsePowerMeterMeasures sees no entries.
+			if err := os.MkdirAll(filepath.Join(meterDir, "measures"), 0o755); err != nil {
+				t.Fatalf("mkdir empty measures: %v", err)
+			}
+		}
+	}
+
+	return root
+}
+
+// gatheredMetric is a (family name, metric) pair returned from gatherMetrics.
+type gatheredMetric struct {
+	Family string
+	Metric *dto.Metric
+}
+
+// gatherMetrics runs the collector through a fresh registry and returns every
+// emitted metric as a dto.Metric plus its family name.
+func gatherMetrics(t *testing.T, c *powerMeterCollector) []gatheredMetric {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(testPowerMeterCollector{c: c}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	var out []gatheredMetric
+	for _, fam := range families {
+		for _, m := range fam.Metric {
+			out = append(out, gatheredMetric{Family: fam.GetName(), Metric: m})
+		}
+	}
+	return out
+}
+
+// label returns the value of label `name` on m, or "" if absent.
+func label(m *dto.Metric, name string) string {
+	for _, l := range m.Label {
+		if l.GetName() == name {
+			return l.GetValue()
+		}
+	}
+	return ""
+}
+
+// findMetric returns the first metric whose family == family AND whose labels
+// match the provided map exactly. Returns nil if none matches.
+func findMetric(metrics []gatheredMetric, family string, labels map[string]string) *dto.Metric {
+	for _, m := range metrics {
+		if m.Family != family {
+			continue
+		}
+		match := true
+		for k, v := range labels {
+			if label(m.Metric, k) != v {
+				match = false
+				break
+			}
+		}
+		if match && len(m.Metric.Label) == len(labels) {
+			return m.Metric
+		}
+	}
+	return nil
+}
+
+type testPowerMeterCollector struct {
+	c *powerMeterCollector
+}
+
+func (t testPowerMeterCollector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(t, ch)
+}
+
+func (t testPowerMeterCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := t.c.Update(ch); err != nil {
+		panic(err)
+	}
+}
+
+func TestPowerMeterCollector_FullField(t *testing.T) {
+	meters := map[string]map[string]string{
+		"ACPI000D:00": {
+			"power1_average":              "15000000", // 15 W
+			"power1_average_min":          "0",
+			"power1_average_max":          "60000000", // 60 W
+			"power1_average_interval":     "1000",     // 1 s
+			"power1_average_interval_min": "100",      // 0.1 s
+			"power1_average_interval_max": "10000",    // 10 s
+			"power1_alarm":                "0",
+			"power1_cap":                  "25000000",  // 25 W
+			"power1_cap_min":              "1000000",   // 1 W
+			"power1_cap_max":              "100000000", // 100 W
+			"power1_cap_hyst":             "500000",    // 0.5 W
+			"power1_accuracy":             "1.50%",     // 1.50
+			"power1_is_battery":           "0",
+			"power1_model_number":         "ACME PM01",
+			"power1_serial_number":        "SN12345",
+			"power1_oem_info":             "ACME Corp",
+		},
+	}
+	measures := map[string][]string{
+		"ACPI000D:00": {"cpu0:LNXCPU:00", "mem0:LNXMEM:00"},
+	}
+
+	root := buildFakePowerMeterSysfs(t, meters, measures)
+	prev := *sysPath
+	t.Cleanup(func() { *sysPath = prev })
+	*sysPath = root
+
+	c, err := NewPowerMeterCollector(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("new collector: %v", err)
+	}
+
+	metrics := gatherMetrics(t, c.(*powerMeterCollector))
+
+	// --- Gauge metrics (power, cap, interval, state, accuracy) ---
+	wantGauges := map[string]float64{
+		"node_power_meter_average_watts":                15.0,
+		"node_power_meter_average_min_watts":            0.0,
+		"node_power_meter_average_max_watts":            60.0,
+		"node_power_meter_average_interval_seconds":     1.0,
+		"node_power_meter_average_interval_min_seconds": 0.1,
+		"node_power_meter_average_interval_max_seconds": 10.0,
+		"node_power_meter_alarm":                        0.0,
+		"node_power_meter_cap_watts":                    25.0,
+		"node_power_meter_cap_min_watts":                1.0,
+		"node_power_meter_cap_max_watts":                100.0,
+		"node_power_meter_cap_hysteresis_watts":         0.5,
+		"node_power_meter_is_battery":                   0.0,
+		"node_power_meter_accuracy_percent":             1.50,
+	}
+	for family, want := range wantGauges {
+		m := findMetric(metrics, family, map[string]string{"meter": "ACPI000D:00"})
+		if m == nil {
+			t.Errorf("missing metric %s{meter=ACPI000D:00}", family)
+			continue
+		}
+		if m.GetGauge().GetValue() != want {
+			t.Errorf("%s: want %v, got %v", family, want, m.GetGauge().GetValue())
+		}
+	}
+
+	// --- Info metric ---
+	info := findMetric(metrics, "node_power_meter_info", map[string]string{
+		"meter":         "ACPI000D:00",
+		"model_number":  "ACME PM01",
+		"serial_number": "SN12345",
+		"oem_info":      "ACME Corp",
+	})
+	if info == nil {
+		t.Fatalf("missing node_power_meter_info{meter=ACPI000D:00}")
+	}
+	if info.GetGauge().GetValue() != 1.0 {
+		t.Errorf("info metric value: want 1.0, got %v", info.GetGauge().GetValue())
+	}
+
+	// --- Measures info metric (one series per measured device) ---
+	for _, dev := range []string{"LNXCPU:00", "LNXMEM:00"} {
+		m := findMetric(metrics, "node_power_meter_measures_info", map[string]string{
+			"meter":  "ACPI000D:00",
+			"device": dev,
+		})
+		if m == nil {
+			t.Errorf("missing node_power_meter_measures_info{meter=ACPI000D:00, device=%s}", dev)
+			continue
+		}
+		if m.GetGauge().GetValue() != 1.0 {
+			t.Errorf("measures_info[%s] value: want 1.0, got %v", dev, m.GetGauge().GetValue())
+		}
+	}
+}
+
+func TestPowerMeterCollector_NoDevices(t *testing.T) {
+	root := buildFakePowerMeterSysfs(t, nil, nil)
+	prev := *sysPath
+	t.Cleanup(func() { *sysPath = prev })
+	*sysPath = root
+
+	c, err := NewPowerMeterCollector(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("new collector: %v", err)
+	}
+	pc := c.(*powerMeterCollector)
+
+	ch := make(chan prometheus.Metric, 16)
+	err = pc.Update(ch)
+	if !errors.Is(err, ErrNoData) {
+		t.Fatalf("expected ErrNoData when no devices exist, got %v", err)
+	}
+	close(ch)
+	for m := range ch {
+		t.Errorf("unexpected metric emitted on ErrNoData path: %v", m)
+	}
+}
+
+func TestPowerMeterCollector_PartialFields(t *testing.T) {
+	// Only average and alarm; every other field is nil/empty.
+	meters := map[string]map[string]string{
+		"ACPI000D:01": {
+			"power1_average": "5000000", // 5 W
+			"power1_alarm":   "1",
+		},
+	}
+	root := buildFakePowerMeterSysfs(t, meters, nil)
+	prev := *sysPath
+	t.Cleanup(func() { *sysPath = prev })
+	*sysPath = root
+
+	c, err := NewPowerMeterCollector(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("new collector: %v", err)
+	}
+	metrics := gatherMetrics(t, c.(*powerMeterCollector))
+
+	// Present metrics.
+	if m := findMetric(metrics, "node_power_meter_average_watts", map[string]string{"meter": "ACPI000D:01"}); m == nil {
+		t.Errorf("missing average_watts")
+	} else if m.GetGauge().GetValue() != 5.0 {
+		t.Errorf("average_watts: want 5, got %v", m.GetGauge().GetValue())
+	}
+	if m := findMetric(metrics, "node_power_meter_alarm", map[string]string{"meter": "ACPI000D:01"}); m == nil {
+		t.Errorf("missing alarm")
+	} else if m.GetGauge().GetValue() != 1.0 {
+		t.Errorf("alarm: want 1, got %v", m.GetGauge().GetValue())
+	}
+
+	// Absent optional metrics.
+	for _, family := range []string{
+		"node_power_meter_average_min_watts",
+		"node_power_meter_average_max_watts",
+		"node_power_meter_cap_watts",
+		"node_power_meter_cap_min_watts",
+		"node_power_meter_cap_max_watts",
+		"node_power_meter_cap_hysteresis_watts",
+		"node_power_meter_average_interval_seconds",
+		"node_power_meter_average_interval_min_seconds",
+		"node_power_meter_average_interval_max_seconds",
+		"node_power_meter_accuracy_percent",
+		"node_power_meter_is_battery",
+	} {
+		if m := findMetric(metrics, family, map[string]string{"meter": "ACPI000D:01"}); m != nil {
+			t.Errorf("did not expect %s when underlying field is absent", family)
+		}
+	}
+
+	// Info metric still present with only the `meter` label.
+	info := findMetric(metrics, "node_power_meter_info", map[string]string{"meter": "ACPI000D:01"})
+	if info == nil {
+		t.Fatalf("missing info metric for partial meter")
+	}
+	// No metadata labels beyond `meter`.
+	if got, want := len(info.Label), 1; got != want {
+		t.Errorf("info metric label count: want %d, got %d", want, got)
+	}
+
+	// No measures for this meter → no measures_info series.
+	for _, m := range metrics {
+		if m.Family == "node_power_meter_measures_info" {
+			t.Errorf("did not expect measures_info for meter with empty measures/: got %v", m.Metric)
+		}
+	}
+}
+
+func TestPowerMeterCollector_Filter(t *testing.T) {
+	meters := map[string]map[string]string{
+		"ACPI000D:00": {"power1_average": "15000000"},
+		"ACPI000D:01": {"power1_average": "5000000"},
+	}
+	root := buildFakePowerMeterSysfs(t, meters, nil)
+	prev := *sysPath
+	t.Cleanup(func() { *sysPath = prev })
+	*sysPath = root
+
+	// Configure filter to exclude ACPI000D:00.
+	prevFilter := *powerMeterIgnoredMeters
+	t.Cleanup(func() { *powerMeterIgnoredMeters = prevFilter })
+	*powerMeterIgnoredMeters = `^ACPI000D:00$`
+
+	c, err := NewPowerMeterCollector(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("new collector: %v", err)
+	}
+	metrics := gatherMetrics(t, c.(*powerMeterCollector))
+
+	if m := findMetric(metrics, "node_power_meter_average_watts", map[string]string{"meter": "ACPI000D:00"}); m != nil {
+		t.Errorf("ACPI000D:00 should have been filtered out, but metric is present: %v", m)
+	}
+	if m := findMetric(metrics, "node_power_meter_average_watts", map[string]string{"meter": "ACPI000D:01"}); m == nil {
+		t.Errorf("ACPI000D:01 should still be present after filtering ACPI000D:00")
+	} else if m.GetGauge().GetValue() != 5.0 {
+		t.Errorf("ACPI000D:01 average: want 5, got %v", m.GetGauge().GetValue())
+	}
+}


### PR DESCRIPTION
## What

Add a `power_meter` collector exposing ACPI 4.0 power meter readings from `/sys/bus/acpi/drivers/power_meter/ACPI000D:XX/` as Prometheus metrics. Uses `sysfs.PowerMeter` / `sysfs.GetPowerMeters()` from prometheus/procfs#860 (procfs v0.22.0, already a dependency).

## Metrics

15 metrics under `node_power_meter_*`, all labeled with `meter` (e.g. `ACPI000D:00`):

- **Power (W)**: `average_watts`, `average_min_watts`, `average_max_watts`
- **Cap (W)**: `cap_watts`, `cap_min_watts`, `cap_max_watts`, `cap_hysteresis_watts`
- **Interval (s)**: `average_interval_seconds`, `average_interval_min_seconds`, `average_interval_max_seconds`
- **State (0/1)**: `alarm`, `is_battery`
- **Accuracy**: `accuracy_percent` (parsed from sysfs `"X.Y%"` string)
- **Info**: `node_power_meter_info{meter, model_number, serial_number, oem_info}`, `node_power_meter_measures_info{meter, device}`

Optional `*int64` fields from procfs are silently skipped when nil.

## Configuration

- Registered as `power_meter`, enabled by default.
- `--collector.power-meter.ignored-meters` — regexp filter (default `^$`).
- `os.ErrNotExist` returns `ErrNoData` (collector idle, no scrape error), matching the `rapl` pattern.

## Files

- `collector/power_meter_linux.go` — registration, constructor, `Update()`, metric emission.
- `collector/power_meter_linux_test.go` — unit tests with fake sysfs tree.
- `collector/fixtures/sys.ttar` — added `sys/bus/acpi/drivers/power_meter/ACPI000D:00/`.
- `collector/fixtures/e2e-output.txt` — expected metric lines.

## Verification

- `go vet ./...` (host + `GOOS=linux`)
- `gofmt -l .` clean
- `go build ./...` (host + linux cross-compile)
- `go test -short ./...` passes
- Unit tests: full-field meter, no-device `ErrNoData`, partial-field meter, regexp filter

Ref: prometheus/procfs#860