### PR TITLE
Fix end-to-end CPU info expectations on non-x86 platforms

### DIFF
--- a/collector/cpu_linux_amd64_test.go
+++ b/collector/cpu_linux_amd64_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nocpu
+
+package collector
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// The cpuinfo fixture is x86-specific, and procfs selects its parser by GOARCH.
+func TestCPUInfoMetrics(t *testing.T) {
+	oldProcPath := *procPath
+	oldSysPath := *sysPath
+	oldEnableCPUInfo := *enableCPUInfo
+	oldFlagsInclude := *flagsInclude
+	oldBugsInclude := *bugsInclude
+	t.Cleanup(func() {
+		*procPath = oldProcPath
+		*sysPath = oldSysPath
+		*enableCPUInfo = oldEnableCPUInfo
+		*flagsInclude = oldFlagsInclude
+		*bugsInclude = oldBugsInclude
+	})
+
+	*procPath = "fixtures/proc"
+	*sysPath = "fixtures/sys"
+	*enableCPUInfo = false
+	*flagsInclude = "^(aes|avx.?|constant_tsc)$"
+	*bugsInclude = "^(cpu_meltdown|spectre_.*|mds)$"
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	collector, err := NewCPUCollector(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !*enableCPUInfo {
+		t.Fatal("CPU info was not enabled by its include flags")
+	}
+
+	const expected = `# HELP node_cpu_bug_info The ` + "`bugs`" + ` field of CPU information from /proc/cpuinfo taken from the first core.
+# TYPE node_cpu_bug_info gauge
+node_cpu_bug_info{bug="cpu_meltdown"} 1
+node_cpu_bug_info{bug="mds"} 1
+node_cpu_bug_info{bug="spectre_v1"} 1
+node_cpu_bug_info{bug="spectre_v2"} 1
+# HELP node_cpu_flag_info The ` + "`flags`" + ` field of CPU information from /proc/cpuinfo taken from the first core.
+# TYPE node_cpu_flag_info gauge
+node_cpu_flag_info{flag="aes"} 1
+node_cpu_flag_info{flag="avx"} 1
+node_cpu_flag_info{flag="avx2"} 1
+node_cpu_flag_info{flag="constant_tsc"} 1
+# HELP node_cpu_info CPU information from /proc/cpuinfo.
+# TYPE node_cpu_info gauge
+node_cpu_info{cachesize="8192 KB",core="0",cpu="0",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
+node_cpu_info{cachesize="8192 KB",core="0",cpu="4",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
+node_cpu_info{cachesize="8192 KB",core="1",cpu="1",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
+node_cpu_info{cachesize="8192 KB",core="1",cpu="5",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
+node_cpu_info{cachesize="8192 KB",core="2",cpu="2",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
+node_cpu_info{cachesize="8192 KB",core="2",cpu="6",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
+node_cpu_info{cachesize="8192 KB",core="3",cpu="3",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
+node_cpu_info{cachesize="8192 KB",core="3",cpu="7",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
+# HELP node_scrape_collector_success node_exporter: Whether a collector succeeded.
+# TYPE node_scrape_collector_success gauge
+node_scrape_collector_success{collector="cpu"} 1
+`
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(&NodeCollector{
+		Collectors: map[string]Collector{"cpu": collector},
+		logger:     logger,
+	})
+	if err := testutil.GatherAndCompare(
+		registry,
+		strings.NewReader(expected),
+		"node_cpu_bug_info",
+		"node_cpu_flag_info",
+		"node_cpu_info",
+		"node_scrape_collector_success",
+	); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/collector/fixtures/e2e-output.txt
+++ b/collector/fixtures/e2e-output.txt
@@ -884,24 +884,12 @@ node_cooling_device_cur_state{name="0",type="Processor"} 0
 # HELP node_cooling_device_max_state Maximum throttle state of the cooling device
 # TYPE node_cooling_device_max_state gauge
 node_cooling_device_max_state{name="0",type="Processor"} 3
-# HELP node_cpu_bug_info The `bugs` field of CPU information from /proc/cpuinfo taken from the first core.
-# TYPE node_cpu_bug_info gauge
-node_cpu_bug_info{bug="cpu_meltdown"} 1
-node_cpu_bug_info{bug="mds"} 1
-node_cpu_bug_info{bug="spectre_v1"} 1
-node_cpu_bug_info{bug="spectre_v2"} 1
 # HELP node_cpu_core_throttles_total Number of times this CPU core has been throttled.
 # TYPE node_cpu_core_throttles_total counter
 node_cpu_core_throttles_total{core="0",package="0"} 5
 node_cpu_core_throttles_total{core="0",package="1"} 0
 node_cpu_core_throttles_total{core="1",package="0"} 0
 node_cpu_core_throttles_total{core="1",package="1"} 9
-# HELP node_cpu_flag_info The `flags` field of CPU information from /proc/cpuinfo taken from the first core.
-# TYPE node_cpu_flag_info gauge
-node_cpu_flag_info{flag="aes"} 1
-node_cpu_flag_info{flag="avx"} 1
-node_cpu_flag_info{flag="avx2"} 1
-node_cpu_flag_info{flag="constant_tsc"} 1
 # HELP node_cpu_guest_seconds_total Seconds the CPUs spent in guests (VMs) for each mode.
 # TYPE node_cpu_guest_seconds_total counter
 node_cpu_guest_seconds_total{cpu="0",mode="nice"} 0.01
@@ -920,16 +908,6 @@ node_cpu_guest_seconds_total{cpu="6",mode="nice"} 0.07
 node_cpu_guest_seconds_total{cpu="6",mode="user"} 0.08
 node_cpu_guest_seconds_total{cpu="7",mode="nice"} 0.08
 node_cpu_guest_seconds_total{cpu="7",mode="user"} 0.09
-# HELP node_cpu_info CPU information from /proc/cpuinfo.
-# TYPE node_cpu_info gauge
-node_cpu_info{cachesize="8192 KB",core="0",cpu="0",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
-node_cpu_info{cachesize="8192 KB",core="0",cpu="4",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
-node_cpu_info{cachesize="8192 KB",core="1",cpu="1",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
-node_cpu_info{cachesize="8192 KB",core="1",cpu="5",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
-node_cpu_info{cachesize="8192 KB",core="2",cpu="2",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
-node_cpu_info{cachesize="8192 KB",core="2",cpu="6",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
-node_cpu_info{cachesize="8192 KB",core="3",cpu="3",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
-node_cpu_info{cachesize="8192 KB",core="3",cpu="7",family="6",microcode="0xb4",model="142",model_name="Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",package="0",stepping="10",vendor="GenuineIntel"} 1
 # HELP node_cpu_isolated Whether each core is isolated, information from /sys/devices/system/cpu/isolated.
 # TYPE node_cpu_isolated gauge
 node_cpu_isolated{cpu="1"} 1

--- a/end-to-end-test.sh
+++ b/end-to-end-test.sh
@@ -115,20 +115,6 @@ case "${arch}" in
   *) fixture_metrics='collector/fixtures/e2e-output.txt' ;;
 esac
 
-# Only test CPU info collection on x86_64.
-case "${arch}" in
-  x86_64)
-    cpu_info_collector='--collector.cpu.info'
-    cpu_info_bugs='^(cpu_meltdown|spectre_.*|mds)$'
-    cpu_info_flags='^(aes|avx.?|constant_tsc)$'
-    ;;
-  *)
-    cpu_info_collector='--no-collector.cpu.info'
-    cpu_info_bugs=''
-    cpu_info_flags=''
-    ;;
-esac
-
 extra_flags=""; keep=0; update=0; verbose=0
 while getopts 'e:hkuv' opt
 do
@@ -162,13 +148,11 @@ then
     exit 1
 fi
 
+# CPU info uses an architecture-specific fixture; see collector/cpu_linux_amd64_test.go.
 collector_flags=$(cat << FLAGS
   ${extra_flags}
-  ${cpu_info_collector}
   --collector.arp.device-exclude=nope
   --collector.bcache.priorityStats
-  --collector.cpu.info.bugs-include=${cpu_info_bugs}
-  --collector.cpu.info.flags-include=${cpu_info_flags}
   --collector.hwmon.chip-include=(applesmc|asus_nb_wmi|coretemp|hwmon4|ieee80211|nct6779)
   --collector.netclass.ignore-invalid-speed
   --collector.netclass.ignored-devices=(dmz|int)


### PR DESCRIPTION
The shared e2e fixture expects x86 CPU info metrics even though the test disables their collection on other architectures, causing failures on riscv64.

Move these expectations into a linux/amd64 collector test and remove the CPU info flags from the e2e test. Preserve coverage through the normal collection path, including include filters and scrape success.

Fixes #3180